### PR TITLE
Properly allow stopping of chunked reading

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # readr 1.0.0.9000
 
+* Bugfix for chunked reading to properly allow stopping of a stream by returning FALSE from the callback.
+
 # readr 1.0.0
 
 ## Column guessing

--- a/src/read.cpp
+++ b/src/read.cpp
@@ -47,7 +47,10 @@ Function R6method(Environment env, const std::string& method) {
   return as<Function>(env[method]);
 }
 bool isTrue(SEXP x) {
-  return TYPEOF(x) == LGLSXP && Rf_length(x) == 1 && LOGICAL(x)[0] == TRUE;
+  if (!(TYPEOF(x) == LGLSXP && Rf_length(x) == 1)) {
+    stop("`continue()` must return a length 1 logical vector");
+  }
+  return LOGICAL(x)[0] == TRUE;
 }
 
 // [[Rcpp::export]]

--- a/src/read.cpp
+++ b/src/read.cpp
@@ -46,6 +46,9 @@ CharacterVector read_lines_(List sourceSpec, List locale_,
 Function R6method(Environment env, const std::string& method) {
   return as<Function>(env[method]);
 }
+bool isTrue(SEXP x) {
+  return TYPEOF(x) == LGLSXP && Rf_length(x) == 1 && LOGICAL(x)[0] == TRUE;
+}
 
 // [[Rcpp::export]]
 void read_lines_chunked_(List sourceSpec, List locale_,
@@ -62,7 +65,7 @@ void read_lines_chunked_(List sourceSpec, List locale_,
   CharacterVector out;
 
   int pos = 1;
-  while (R6method(callback, "continue")() &&
+  while (isTrue(R6method(callback, "continue")()) &&
       (out = r.readToVector<CharacterVector>(chunkSize)).size()) {
     R6method(callback, "receive")(out, pos);
     pos += out.size();
@@ -117,7 +120,7 @@ void read_tokens_chunked_(List sourceSpec, Environment callback, int chunkSize,
   DataFrame out;
 
   int pos = 1;
-  while (R6method(callback, "continue")() &&
+  while (isTrue(R6method(callback, "continue")()) &&
       (out = r.readToDataFrame(chunkSize)).nrows()) {
     R6method(callback, "receive")(out, pos);
     pos += out.nrows();

--- a/tests/testthat/test-read-chunked.R
+++ b/tests/testthat/test-read-chunked.R
@@ -22,6 +22,18 @@ test_that("read_lines_chunked", {
   read_lines_chunked(file, get_sizes, chunk_size = 5)
   expect_true(all(sizes[1:6] == 5))
   expect_true(all(sizes[[7]] == 3))
+
+  # Halting early
+  get_sizes_stop <- function(data, pos) {
+    sizes[[length(sizes) + 1]] <<- length(data)
+    if (pos >= 5) {
+      return(FALSE)
+    }
+  }
+  sizes <- list()
+  read_lines_chunked(file, get_sizes_stop, chunk_size = 5)
+  expect_true(length(sizes) == 2)
+  expect_true(all(sizes[1:2] == 5))
 })
 
 test_that("read_delim_chunked", {
@@ -46,6 +58,18 @@ test_that("read_delim_chunked", {
   read_csv_chunked(file, get_dims, chunk_size = 5)
   expect_true(all(vapply(dims[1:6], identical, logical(1), c(5L, 11L))))
   expect_true(identical(dims[[7]], c(2L, 11L)))
+
+  # Halting early
+  get_dims_stop <- function(data, pos) {
+    dims[[length(dims) + 1]] <<- dim(data)
+    if (pos >= 5) {
+      return(FALSE)
+    }
+  }
+  dims <- list()
+  read_csv_chunked(file, get_dims_stop, chunk_size = 5)
+  expect_true(length(dims) == 2)
+  expect_true(all(vapply(dims[1:2], identical, logical(1), c(5L, 11L))))
 })
 
 test_that("DataFrameCallback works as intended", {


### PR DESCRIPTION
Previously we were 'checking' the SEXP address, which would always be
non-zero. This meant that there was no value returned by callback that
would halt the reading.

Instead we need to explicitly test the value of the first element of the logical vector.

I unfortunately realized this this morning instead of yesterday, unfortunate timing considering we released yesterday 😞 .
