### PR TITLE
Make spec inclusion optional

### DIFF
--- a/R/read_delim.R
+++ b/R/read_delim.R
@@ -52,6 +52,9 @@ NULL
 #' @param progress Display a progress bar? By default it will only display
 #'   in an interactive session. The display is updated every 50,000 values
 #'   and will only display if estimated reading time is 5 seconds or more.
+#' @param include_spec Whether or not to include the specification (the assumptions
+#'   made about the type of each column) as an attribute of the object. TRUE by
+#'   default.
 #' @return A data frame. If there are parsing problems, a warning tells you
 #'   how many, and you can retrieve the details with \code{\link{problems}()}.
 #' @export
@@ -91,13 +94,15 @@ read_delim <- function(file, delim, quote = '"',
                        locale = default_locale(),
                        na = c("", "NA"), quoted_na = TRUE,
                        comment = "", trim_ws = FALSE,
-                       skip = 0, n_max = Inf, guess_max = min(1000, n_max), progress = interactive()) {
+                       skip = 0, n_max = Inf,
+                       guess_max = min(1000, n_max), progress = interactive(),
+                       include_spec = TRUE) {
   tokenizer <- tokenizer_delim(delim, quote = quote,
     escape_backslash = escape_backslash, escape_double = escape_double,
     na = na, quoted_na = quoted_na, comment = comment, trim_ws = trim_ws)
   read_delimited(file, tokenizer, col_names = col_names, col_types = col_types,
     locale = locale, skip = skip, comment = comment, n_max = n_max, guess_max =
-      guess_max, progress = progress)
+      guess_max, progress = progress, include_spec = include_spec)
 }
 
 #' @rdname read_delim
@@ -106,12 +111,12 @@ read_csv <- function(file, col_names = TRUE, col_types = NULL,
                      locale = default_locale(), na = c("", "NA"),
                      quoted_na = TRUE, comment = "", trim_ws = TRUE, skip = 0,
                      n_max = Inf, guess_max = min(1000, n_max),
-                     progress = interactive()) {
+                     progress = interactive(), include_spec = TRUE) {
 
   tokenizer <- tokenizer_csv(na = na, quoted_na = TRUE, comment = comment, trim_ws = trim_ws)
   read_delimited(file, tokenizer, col_names = col_names, col_types = col_types,
     locale = locale, skip = skip, comment = comment, n_max = n_max, guess_max =
-      guess_max, progress = progress)
+      guess_max, progress = progress, include_spec = include_spec)
 }
 
 #' @rdname read_delim
@@ -120,7 +125,8 @@ read_csv2 <- function(file, col_names = TRUE, col_types = NULL,
                       locale = default_locale(),
                       na = c("", "NA"), quoted_na = TRUE, comment = "",
                       trim_ws = TRUE, skip = 0, n_max = Inf,
-                      guess_max = min(1000, n_max), progress = interactive()) {
+                      guess_max = min(1000, n_max), progress = interactive(),
+                      include_spec = TRUE) {
 
   if (locale$decimal_mark == ".") {
     locale$decimal_mark <- ","
@@ -131,7 +137,7 @@ read_csv2 <- function(file, col_names = TRUE, col_types = NULL,
     comment = comment, trim_ws = trim_ws)
   read_delimited(file, tokenizer, col_names = col_names, col_types = col_types,
     locale = locale, skip = skip, comment = comment, n_max = n_max,
-    guess_max = guess_max, progress = progress)
+    guess_max = guess_max, progress = progress, include_spec = include_spec)
 }
 
 
@@ -141,12 +147,13 @@ read_tsv <- function(file, col_names = TRUE, col_types = NULL,
                      locale = default_locale(),
                      na = c("", "NA"), quoted_na = TRUE,
                      comment = "", trim_ws = TRUE, skip = 0, n_max = Inf,
-                     guess_max = min(1000, n_max), progress = interactive()) {
+                     guess_max = min(1000, n_max), progress = interactive(),
+                     include_spec = TRUE) {
 
   tokenizer <- tokenizer_tsv(na = na, quoted_na = quoted_na, comment = comment, trim_ws = trim_ws)
   read_delimited(file, tokenizer, col_names = col_names, col_types = col_types,
     locale = locale, skip = skip, comment = comment, n_max = n_max,
-    guess_max = guess_max, progress = progress)
+    guess_max = guess_max, progress = progress, include_spec = include_spec)
 }
 
 # Helper functions for reading from delimited files ----------------------------
@@ -159,7 +166,8 @@ read_tokens <- function(data, tokenizer, col_specs, col_names, locale_, n_max, p
 
 read_delimited <- function(file, tokenizer, col_names = TRUE, col_types = NULL,
                            locale = default_locale(), skip = 0, comment = "",
-                           n_max = Inf, guess_max = min(1000, n_max), progress = interactive()) {
+                           n_max = Inf, guess_max = min(1000, n_max), progress = interactive(),
+                           include_spec = TRUE) {
   name <- source_name(file)
   # If connection needed, read once.
   file <- standardise_path(file)
@@ -187,7 +195,9 @@ read_delimited <- function(file, tokenizer, col_names = TRUE, col_types = NULL,
     n_max = n_max, progress = progress)
 
   out <- name_problems(out)
-  attr(out, "spec") <- spec
+  if(include_spec){
+    attr(out, "spec") <- spec
+  }
   warn_problems(out, name)
 }
 

--- a/R/read_fwf.R
+++ b/R/read_fwf.R
@@ -30,7 +30,8 @@
 read_fwf <- function(file, col_positions, col_types = NULL,
                      locale = default_locale(), na = c("", "NA"),
                      comment = "", skip = 0, n_max = Inf,
-                     guess_max = min(n_max, 1000), progress = interactive()) {
+                     guess_max = min(n_max, 1000), progress = interactive(),
+                     include_spec = TRUE) {
   ds <- datasource(file, skip = skip)
 
   if (inherits(ds, "source_file") && empty_file(file)) {
@@ -58,7 +59,9 @@ read_fwf <- function(file, col_positions, col_types = NULL,
     locale_ = locale, n_max = if (n_max == Inf) -1 else n_max, progress = progress)
 
   out <- name_problems(out)
-  attr(out, "spec") <- spec
+  if(include_spec){
+    attr(out, "spec") <- spec
+  }
   warn_problems(out, source_name(file))
 }
 

--- a/man/read_delim.Rd
+++ b/man/read_delim.Rd
@@ -11,22 +11,26 @@ read_delim(file, delim, quote = "\\"", escape_backslash = FALSE,
   escape_double = TRUE, col_names = TRUE, col_types = NULL,
   locale = default_locale(), na = c("", "NA"), quoted_na = TRUE,
   comment = "", trim_ws = FALSE, skip = 0, n_max = Inf,
-  guess_max = min(1000, n_max), progress = interactive())
+  guess_max = min(1000, n_max), progress = interactive(),
+  include_spec = TRUE)
 
 read_csv(file, col_names = TRUE, col_types = NULL,
   locale = default_locale(), na = c("", "NA"), quoted_na = TRUE,
   comment = "", trim_ws = TRUE, skip = 0, n_max = Inf,
-  guess_max = min(1000, n_max), progress = interactive())
+  guess_max = min(1000, n_max), progress = interactive(),
+  include_spec = TRUE)
 
 read_csv2(file, col_names = TRUE, col_types = NULL,
   locale = default_locale(), na = c("", "NA"), quoted_na = TRUE,
   comment = "", trim_ws = TRUE, skip = 0, n_max = Inf,
-  guess_max = min(1000, n_max), progress = interactive())
+  guess_max = min(1000, n_max), progress = interactive(),
+  include_spec = TRUE)
 
 read_tsv(file, col_names = TRUE, col_types = NULL,
   locale = default_locale(), na = c("", "NA"), quoted_na = TRUE,
   comment = "", trim_ws = TRUE, skip = 0, n_max = Inf,
-  guess_max = min(1000, n_max), progress = interactive())
+  guess_max = min(1000, n_max), progress = interactive(),
+  include_spec = TRUE)
 }
 \arguments{
 \item{file}{Either a path to a file, a connection, or literal data
@@ -113,6 +117,10 @@ each field before parsing it?}
 \item{progress}{Display a progress bar? By default it will only display
 in an interactive session. The display is updated every 50,000 values
 and will only display if estimated reading time is 5 seconds or more.}
+
+\item{include_spec}{Whether or not to include the specification (the assumptions
+made about the type of each column) as an attribute of the object. TRUE by
+default.}
 }
 \value{
 A data frame. If there are parsing problems, a warning tells you

--- a/man/read_delim_chunked.Rd
+++ b/man/read_delim_chunked.Rd
@@ -11,22 +11,26 @@ read_delim_chunked(file, callback, chunk_size = 10000, delim, quote = "\\"",
   escape_backslash = FALSE, escape_double = TRUE, col_names = TRUE,
   col_types = NULL, locale = default_locale(), na = c("", "NA"),
   quoted_na = TRUE, comment = "", trim_ws = FALSE, skip = 0,
-  guess_max = min(1000, chunk_size), progress = interactive())
+  guess_max = min(1000, chunk_size), progress = interactive(),
+  include_spec = TRUE)
 
 read_csv_chunked(file, callback, chunk_size = 10000, col_names = TRUE,
   col_types = NULL, locale = default_locale(), na = c("", "NA"),
   quoted_na = TRUE, comment = "", trim_ws = TRUE, skip = 0,
-  guess_max = min(1000, chunk_size), progress = interactive())
+  guess_max = min(1000, chunk_size), progress = interactive(),
+  include_spec = TRUE)
 
 read_csv2_chunked(file, callback, chunk_size = 10000, col_names = TRUE,
   col_types = NULL, locale = default_locale(), na = c("", "NA"),
   quoted_na = TRUE, comment = "", trim_ws = TRUE, skip = 0,
-  guess_max = min(1000, chunk_size), progress = interactive())
+  guess_max = min(1000, chunk_size), progress = interactive(),
+  include_spec = TRUE)
 
 read_tsv_chunked(file, callback, chunk_size = 10000, col_names = TRUE,
   col_types = NULL, locale = default_locale(), na = c("", "NA"),
   quoted_na = TRUE, comment = "", trim_ws = TRUE, skip = 0,
-  guess_max = min(1000, chunk_size), progress = interactive())
+  guess_max = min(1000, chunk_size), progress = interactive(),
+  include_spec = TRUE)
 }
 \arguments{
 \item{file}{Either a path to a file, a connection, or literal data
@@ -115,6 +119,10 @@ each field before parsing it?}
 \item{progress}{Display a progress bar? By default it will only display
 in an interactive session. The display is updated every 50,000 values
 and will only display if estimated reading time is 5 seconds or more.}
+
+\item{include_spec}{Whether or not to include the specification (the assumptions
+made about the type of each column) as an attribute of the object. TRUE by
+default.}
 }
 \description{
 Read a delimited file by chunks

--- a/man/read_fwf.Rd
+++ b/man/read_fwf.Rd
@@ -9,7 +9,8 @@
 \usage{
 read_fwf(file, col_positions, col_types = NULL, locale = default_locale(),
   na = c("", "NA"), comment = "", skip = 0, n_max = Inf,
-  guess_max = min(n_max, 1000), progress = interactive())
+  guess_max = min(n_max, 1000), progress = interactive(),
+  include_spec = TRUE)
 
 fwf_empty(file, skip = 0, col_names = NULL, comment = "")
 
@@ -73,6 +74,10 @@ comment characters will be silently ignored.}
 \item{progress}{Display a progress bar? By default it will only display
 in an interactive session. The display is updated every 50,000 values
 and will only display if estimated reading time is 5 seconds or more.}
+
+\item{include_spec}{Whether or not to include the specification (the assumptions
+made about the type of each column) as an attribute of the object. TRUE by
+default.}
 
 \item{col_names}{Either NULL, or a character vector column names.}
 

--- a/man/spec_delim.Rd
+++ b/man/spec_delim.Rd
@@ -11,22 +11,22 @@ spec_delim(file, delim, quote = "\\"", escape_backslash = FALSE,
   escape_double = TRUE, col_names = TRUE, col_types = NULL,
   locale = default_locale(), na = c("", "NA"), quoted_na = TRUE,
   comment = "", trim_ws = FALSE, skip = 0, n_max = 0,
-  guess_max = 1000, progress = interactive())
+  guess_max = 1000, progress = interactive(), include_spec = TRUE)
 
 spec_csv(file, col_names = TRUE, col_types = NULL,
   locale = default_locale(), na = c("", "NA"), quoted_na = TRUE,
   comment = "", trim_ws = TRUE, skip = 0, n_max = 0, guess_max = 1000,
-  progress = interactive())
+  progress = interactive(), include_spec = TRUE)
 
 spec_csv2(file, col_names = TRUE, col_types = NULL,
   locale = default_locale(), na = c("", "NA"), quoted_na = TRUE,
   comment = "", trim_ws = TRUE, skip = 0, n_max = 0, guess_max = 1000,
-  progress = interactive())
+  progress = interactive(), include_spec = TRUE)
 
 spec_tsv(file, col_names = TRUE, col_types = NULL,
   locale = default_locale(), na = c("", "NA"), quoted_na = TRUE,
   comment = "", trim_ws = TRUE, skip = 0, n_max = 0, guess_max = 1000,
-  progress = interactive())
+  progress = interactive(), include_spec = TRUE)
 }
 \arguments{
 \item{file}{Either a path to a file, a connection, or literal data
@@ -113,6 +113,10 @@ each field before parsing it?}
 \item{progress}{Display a progress bar? By default it will only display
 in an interactive session. The display is updated every 50,000 values
 and will only display if estimated reading time is 5 seconds or more.}
+
+\item{include_spec}{Whether or not to include the specification (the assumptions
+made about the type of each column) as an attribute of the object. TRUE by
+default.}
 }
 \value{
 The \code{col_spec} generated for the file.

--- a/tests/testthat/test-read-csv.R
+++ b/tests/testthat/test-read-csv.R
@@ -222,5 +222,13 @@ test_that("skip respects comments", {
 })
 
 test_that("read_csv returns an empty data.frame on an empty file", {
-   expect_equal(read_csv("empty-file", progress = FALSE), tibble::data_frame())
+  expect_equal(read_csv("empty-file", progress = FALSE), tibble::data_frame())
+})
+
+test_that("read_csv respects the include_spec parameter", {
+  expect_true(is.list(attr(x = read_csv("#a\n#b\nx\n1", comment = "#", progress = FALSE),
+                           which = "spec")))
+  expect_null(attr(x = read_csv("#a\n#b\nx\n1", comment = "#",
+                                progress = FALSE, include_spec = FALSE),
+                   which = "spec"))
 })

--- a/tests/testthat/test-read-fwf.R
+++ b/tests/testthat/test-read-fwf.R
@@ -121,9 +121,18 @@ test_that("ignore commented lines anywhere in file", {
   expect_equal(n_problems(x1), 0)
 })
 
+test_that("read_fwf respects the include_spec parameter", {
+  x <- "1 2 3\n4 5 6"
+  expect_true(is.list(attr(x = read_fwf(x, fwf_empty(x)), which = "spec")))
+  expect_null(attr(x = read_fwf(x, fwf_empty(x), include_spec = FALSE),
+                   which = "spec"))
+})
+
+
 # read_table -------------------------------------------------------------------
 
 test_that("read_table silently reads ragged last column", {
   x <- read_table("foo bar\n1   2\n3   4\n5   6\n", progress = FALSE)
   expect_equal(x$foo, c(1, 3, 5))
 })
+


### PR DESCRIPTION
Including the spec is useful 9/10ths of the time and the 10th - when you want to str() a data frame with a particularly large number of columns - it fills up the console with the spec and leaves the actual data far away in scrollback.

At the same time: useful 9/10ths of the time! So this pull request just adds `include_spec` as a parameter, set to TRUE by default, and leaves it up to the user. Comes with unit tests and everything.
