### PR TITLE
Vignette Readr.Rmd had no Title

### DIFF
--- a/vignettes/readr.Rmd
+++ b/vignettes/readr.Rmd
@@ -1,9 +1,9 @@
 ---
-title: "Vignette Title"
+title: "Output"
 date: "`r Sys.Date()`"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{Vignette Title}
+  %\VignetteIndexEntry{Output}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---


### PR DESCRIPTION
This vignette had *Vignette Title* as Title. It is better to have an explicit name, especially for the pkgdown website.
As it present output, I call it *Output* not *readr* as the Rmd file.