### PR TITLE
issue #537. extend parse_number to allow scientific notation

### DIFF
--- a/src/QiParsers.h
+++ b/src/QiParsers.h
@@ -32,6 +32,8 @@ enum NumberState {
   STATE_INIT,
   STATE_LHS,
   STATE_RHS,
+  STATE_SCIENTIFIC_NOTATION_INIT,   // e/E +/-
+  STATE_SCIENTIFIC_NOTATION_DIGITS, // the digits
   STATE_FIN
 };
 
@@ -55,6 +57,8 @@ inline bool parseNumber(char decimalMark, char groupingMark, Iterator& first,
   NumberState state = STATE_INIT;
   bool seenNumber = false;
   double sign = 1.0;
+  int scientific_notation_exponent = 0;
+  int scientific_notation_exponent_sign = 0;
 
   Iterator cur = first;
   for(; cur != last; ++cur) {
@@ -81,6 +85,9 @@ inline bool parseNumber(char decimalMark, char groupingMark, Iterator& first,
         // do nothing
       } else if (*cur == decimalMark) {
         state = STATE_RHS;
+      } else if (*cur == 'e' || *cur == 'E') {
+        seenNumber = false; // to 'force' it to expect more digits
+        state = STATE_SCIENTIFIC_NOTATION_INIT;
       } else if (*cur >= '0' && *cur <= '9') {
         seenNumber = true;
         sum *= 10;
@@ -92,10 +99,40 @@ inline bool parseNumber(char decimalMark, char groupingMark, Iterator& first,
     case STATE_RHS:
       if (*cur == groupingMark) {
         // do nothing
+      } else if (*cur == 'e' || *cur == 'E') {
+        seenNumber = false; // to 'force' it to expect more digits
+        state = STATE_SCIENTIFIC_NOTATION_INIT;
       } else if (*cur >= '0' && *cur <= '9') {
         seenNumber = true;
         denom *= 10;
         sum += (*cur - '0') / denom;
+      } else {
+        goto end;
+      }
+      break;
+    case STATE_SCIENTIFIC_NOTATION_INIT: // optional initial + or - allowed here. Then one of more digits
+      if (*cur == '+') {
+          scientific_notation_exponent_sign = 1;
+          state = STATE_SCIENTIFIC_NOTATION_DIGITS;
+      } else if (*cur == '-') {
+          scientific_notation_exponent_sign = -1;
+          state = STATE_SCIENTIFIC_NOTATION_DIGITS;
+      } else if (*cur >= '0' && *cur <= '9') { // Default to positive
+          scientific_notation_exponent_sign = 1;
+          state = STATE_SCIENTIFIC_NOTATION_DIGITS;
+          goto STATE_SCIENTIFIC_NOTATION_DIGITS_; // goto immediately, so that we may pick up this initial digit
+      } else {
+          goto end;
+      }
+      break;
+STATE_SCIENTIFIC_NOTATION_DIGITS_:
+    case STATE_SCIENTIFIC_NOTATION_DIGITS:
+      if (*cur == groupingMark) {
+        // do nothing
+      } else if (*cur >= '0' && *cur <= '9') {
+        seenNumber = true;
+        scientific_notation_exponent *= 10;
+        scientific_notation_exponent += (*cur)-'0';
       } else {
         goto end;
       }
@@ -106,6 +143,8 @@ inline bool parseNumber(char decimalMark, char groupingMark, Iterator& first,
   }
 
 end:
+
+  sum *= pow(10, scientific_notation_exponent_sign * scientific_notation_exponent);
 
   // Set last to point to final character used
   last = cur;


### PR DESCRIPTION
[ Relevant issue I reported  https://github.com/tidyverse/readr/issues/537 ]

Originally, `readr::parse_number('3e-5')` returned `3` where I expected `0.00003`. It appears that `parse_number` is designed to ignore any content that is not obviously a number. This is relevant for `col_type='n'` when reading files.

This pull request extends `parse_number` to also apply any scientific notation that is found after the (non-scientific) number. An `e` or `E`, followed (optionally) by `+` or `-`, followed (non-optionally) by one or more digits, is treated as scientific notation.

`3.14e+` and `3.14e` will fail, by design, as it expects one or more digits after the `e`/`e+`/`e-`. If you prefer more relaxed behaviour (accepting, and ignoring, the `e`/`e+`/`e-` here), then you can delete the following line in my pull request

        seenNumber = false; // to 'force' it to expect more digits