### PR TITLE
Document %I format, recommend for use with AM/PM

### DIFF
--- a/R/collectors.R
+++ b/R/collectors.R
@@ -251,7 +251,7 @@ col_factor <- function(levels, ordered = FALSE) {
 #'   \item Month: "\%m" (2 digits), "\%b" (abbreviated name in current
 #'     locale), "\%B" (full name in current locale).
 #'   \item Day: "\%d" (2 digits), "\%e" (optional leading space)
-#'   \item Hour: "\%H"
+#'   \item Hour: "\%H" or "\%I", use I (and not H) with AM/PM.
 #'   \item Minutes: "\%M"
 #'   \item Seconds: "\%S" (integer seconds), "\%OS" (partial seconds)
 #'   \item Time zone: "\%Z" (as name, e.g. "America/Chicago"), "\%z" (as


### PR DESCRIPTION
Support for `%I` in `parse_datetime` was added in https://github.com/tidyverse/readr/pull/426, but this was not documented. This PR documents this format, recommending using it with AM/PM.