### PR TITLE
Fix “‘tzname’ undeclared (first use in this function)” in src/localti…

### DIFF
--- a/src/localtime.c
+++ b/src/localtime.c
@@ -1209,6 +1209,7 @@ localsub(const time_t *const timep, const int_fast32_t offset, stm *const tmp)
     int i;
     stm * result;
     const time_t t = *timep;
+    char *tzname[2];
 
     sp = lclptr;
     if ((sp->goback && t < sp->ats[0]) ||


### PR DESCRIPTION
[src/DateTime.h](https://github.com/tidyverse/readr/blob/master/src/DateTime.h#L8-L10) states: 

> Much of this code is adapted from R's src/main/datetime.c

 and from the latter source file is defined the `tzname` variable :
```Bash
awk 'NR >= 100 && NR <= 102' R/src/main/datetime.c 
typedef struct tm stm;
#define R_tzname tzname
extern char *tzname[2];
```

That variable isn't found in `readr` sources which causes building failures as in #507. The workaround proposed there (#507) isn't of so much help as it passes the compilation but fails at link time:
```Bash
$ g++ <FLAGS> -o readr.so Collector.o CollectorGuess.o DateTime.o Iconv.o LocaleInfo.o RcppExports.o Reader.o Source.o Tokenizer.o TokenizerDelim.o TokenizerFwf.o connection.o grisu3.o localtime.o parse.o read.o type_convert.o write.o write_delim.o

CollectorGuess.o:(.bss+0x0): multiple definition of `tzname'
Collector.o:(.bss+0x0): first defined here
CollectorGuess.o: In function `__gnu_cxx::new_allocator<char>::deallocate(char*, unsigned long)':
<PATH>/readr/src/CollectorGuess.cpp:50: multiple definition of `R_tzname'
Collector.o:<LIBPATH>/BH/include/boost/container/new_allocator.hpp:151: first defined here
DateTime.o:(.bss+0x0): multiple definition of `tzname'
Collector.o:<LIBPATH>/BH/include/boost/container/string.hpp:296: first defined here
DateTime.o: In function `std::basic_streambuf<char, std::char_traits<char> >::~basic_streambuf()':
<PATH>/readr/src/DateTime.cpp:9: multiple definition of `R_tzname'
Collector.o:<LIBPATH>/BH/include/boost/container/new_allocator.hpp:151: first defined here
Reader.o:(.bss+0x0): multiple definition of `tzname'
Collector.o:<LIBPATH>/BH/include/boost/container/string.hpp:296: first defined here
Reader.o: In function `__gnu_cxx::new_allocator<char>::deallocate(char*, unsigned long)':
/usr/include/c++/6.2.1/bits/basic_string.h:456: multiple definition of `R_tzname'
Collector.o:<LIBPATH>/BH/include/boost/container/new_allocator.hpp:151: first defined here
parse.o:(.bss+0x0): multiple definition of `tzname'
Collector.o:<LIBPATH>/BH/include/boost/container/string.hpp:296: first defined here
parse.o: In function `std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_dispose()':
<PATH>/readr/src/parse.cpp:12: multiple definition of `R_tzname'
Collector.o:<LIBPATH>/BH/include/boost/container/new_allocator.hpp:151: first defined here
read.o:(.bss+0x0): multiple definition of `tzname'
Collector.o:<LIBPATH>/BH/include/boost/container/string.hpp:296: first defined here
read.o: In function `std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_dispose()':
<LIBPATH>/BH/include/boost/smart_ptr/detail/sp_counted_base_gcc_x86.hpp:142: multiple definition of `R_tzname'
Collector.o:<LIBPATH>/BH/include/boost/container/new_allocator.hpp:151: first defined here
type_convert.o:(.bss+0x0): multiple definition of `tzname'
Collector.o:<LIBPATH>/BH/include/boost/container/string.hpp:296: first defined here
type_convert.o: In function `std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_dispose()':
<PATH>/readr/src/type_convert.cpp:10: multiple definition of `R_tzname'
Collector.o:<LIBPATH>/BH/include/boost/container/new_allocator.hpp:151: first defined here
collect2: error: ld returned 1 exit status
```

Whereas building “as is”, i.e. the original failing build outputs this:
```Bash
$ R --verbose -e 'devtools::compile_dll("readr")'
…
localtime.c: In function ‘localsub’:
localtime.c:1271:5: error: ‘tzname’ undeclared (first use in this function)
     tzname[tmp->tm_isdst] = &sp->chars[ttisp->tt_abbrind];
     ^~~~~~
localtime.c:1271:5: note: each undeclared identifier is reported only once for each function it appears in
…
```

The proposed change gets rid of the issue.
```Bash
$ R --verbose -e 'devtools::compile_dll("readr")'
…
g++ -m64 -shared -fuse-linker-plugin -fuse-linker-plugin -o readr.so Collector.o CollectorGuess.o DateTime.o Iconv.o LocaleInfo.o RcppExports.o Reader.o Source.o Tokenizer.o TokenizerDelim.o TokenizerFwf.o connection.o grisu3.o localtime.o parse.o read.o type_convert.o write.o write_delim.o
installing to <TMPDIR>/devtools_install_7cbe495f9197/readr/libs
* DONE (readr)
```

System info:

```Bash
$ readelf -d /usr/lib64/libstdc++* | grep SONAME | uniq
 0x000000000000000e (SONAME)             Library soname: [libstdc++.so.6]

$ gcc --version
gcc (GCC) 6.2.1 20160916 (Red Hat 6.2.1-2)
Copyright (C) 2016 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

$ cat /usr/lib/os-release
NAME=Fedora
VERSION="24 (Workstation Edition)"
ID=fedora
VERSION_ID=24
PRETTY_NAME="Fedora 24 (Workstation Edition)"
ANSI_COLOR="0;34"
CPE_NAME="cpe:/o:fedoraproject:fedora:24"
HOME_URL="https://fedoraproject.org/"
BUG_REPORT_URL="https://bugzilla.redhat.com/"
REDHAT_BUGZILLA_PRODUCT="Fedora"
REDHAT_BUGZILLA_PRODUCT_VERSION=24
REDHAT_SUPPORT_PRODUCT="Fedora"
REDHAT_SUPPORT_PRODUCT_VERSION=24
PRIVACY_POLICY_URL=https://fedoraproject.org/wiki/Legal:PrivacyPolicy
VARIANT="Workstation Edition"
VARIANT_ID=workstation
```
