### PR TITLE
Raise error on zero-length specifications for FWF tokenizer

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,14 +1,11 @@
 # readr 1.0.0.9000
 
+* `read_fwf()` stops with an error (instead of a segmentation fault) if no columns are specified, or if skipping past the end of the file (#511, #519, #574, @krlmlr).
+
 * `col_euro_double()`, `parse_euro_double()`, `col_numeric()`, and 
   `parse_numeric()` have been removed.
-# readr 0.2.2.9000
+
 * Skip Unicode byte order markers if they exist (#263, @jimhester).
-
-* Supports reading into long vectors (#309, @jimhester).
-
-* `default_locale()` now sets the default locale in `readr.default_locale`
-  rather than regenerating it for each call. (#416, @jimhester).
 
 * `guess_encoding()` returns a tibble, and works better with lists of 
   raw vectors (as returned by `read_lines_raw()`).

--- a/src/TokenizerFwf.cpp
+++ b/src/TokenizerFwf.cpp
@@ -96,6 +96,9 @@ TokenizerFwf::TokenizerFwf(const std::vector<int>& beginOffset, const std::vecto
     Rcpp::stop("Begin (%i) and end (%i) specifications must have equal length",
                beginOffset_.size(), endOffset_.size());
 
+  if (beginOffset_.size() == 0)
+    Rcpp::stop("Zero-length begin and end specifications not supported");
+
   // File is assumed to be ragged (last column can have variable width)
   // when the last element of endOffset_ is NA
   isRagged_ = endOffset_[endOffset_.size() - 1L] == NA_INTEGER;

--- a/tests/testthat/test-read-fwf.R
+++ b/tests/testthat/test-read-fwf.R
@@ -121,6 +121,12 @@ test_that("ignore commented lines anywhere in file", {
   expect_equal(n_problems(x1), 0)
 })
 
+test_that("error on empty spec (#511, #519)", {
+  txt = "foo\n"
+  pos = fwf_positions(start = numeric(0), end = numeric(0))
+  expect_error(read_fwf(txt, pos), "Zero-length.*specifications not supported")
+})
+
 # read_table -------------------------------------------------------------------
 
 test_that("read_table silently reads ragged last column", {


### PR DESCRIPTION
Fixes #511. Fixes #519.