### PR TITLE
change progress defaults

### DIFF
--- a/R/lines.R
+++ b/R/lines.R
@@ -28,7 +28,8 @@
 read_lines <- function(file, skip = 0, n_max = -1L,
                        locale = default_locale(),
                        na = character(),
-                       progress = interactive()) {
+                       progress = NULL) {
+  progress <- progress %||% progress_defaults()
   if (empty_file(file)) {
     return(character())
   }
@@ -38,10 +39,11 @@ read_lines <- function(file, skip = 0, n_max = -1L,
 
 #' @export
 #' @rdname read_lines
-read_lines_raw <- function(file, skip = 0, n_max = -1L, progress = interactive()) {
+read_lines_raw <- function(file, skip = 0, n_max = -1L, progress = NULL) {
   if (empty_file(file)) {
     return(list())
   }
+progress <- progress %||% progress_defaults()
   ds <- datasource(file, skip = skip)
   read_lines_raw_(ds, n_max = n_max, progress = progress)
 }

--- a/R/read_delim.R
+++ b/R/read_delim.R
@@ -50,8 +50,10 @@ NULL
 #' @param n_max Maximum number of records to read.
 #' @param guess_max Maximum number of records to use for guessing column types.
 #' @param progress Display a progress bar? By default it will only display
-#'   in an interactive session. The display is updated every 50,000 values
+#'   in an interactive session and not in knitr.  The display is updated every 50,000 values
 #'   and will only display if estimated reading time is 5 seconds or more.
+#'   The automatic progress bar can be disabled by setting option
+#'   \code{readr.show_progress} to \code{FALSE}.
 #' @return A data frame. If there are parsing problems, a warning tells you
 #'   how many, and you can retrieve the details with \code{\link{problems}()}.
 #' @export
@@ -91,7 +93,8 @@ read_delim <- function(file, delim, quote = '"',
                        locale = default_locale(),
                        na = c("", "NA"), quoted_na = TRUE,
                        comment = "", trim_ws = FALSE,
-                       skip = 0, n_max = Inf, guess_max = min(1000, n_max), progress = interactive()) {
+                       skip = 0, n_max = Inf, guess_max = min(1000, n_max), progress = NULL) {
+  progress <- progress %||% progress_defaults()
   tokenizer <- tokenizer_delim(delim, quote = quote,
     escape_backslash = escape_backslash, escape_double = escape_double,
     na = na, quoted_na = quoted_na, comment = comment, trim_ws = trim_ws)
@@ -106,8 +109,8 @@ read_csv <- function(file, col_names = TRUE, col_types = NULL,
                      locale = default_locale(), na = c("", "NA"),
                      quoted_na = TRUE, comment = "", trim_ws = TRUE, skip = 0,
                      n_max = Inf, guess_max = min(1000, n_max),
-                     progress = interactive()) {
-
+                     progress = NULL) {
+  progress <- progress %||% progress_defaults()
   tokenizer <- tokenizer_csv(na = na, quoted_na = TRUE, comment = comment, trim_ws = trim_ws)
   read_delimited(file, tokenizer, col_names = col_names, col_types = col_types,
     locale = locale, skip = skip, comment = comment, n_max = n_max, guess_max =
@@ -120,13 +123,13 @@ read_csv2 <- function(file, col_names = TRUE, col_types = NULL,
                       locale = default_locale(),
                       na = c("", "NA"), quoted_na = TRUE, comment = "",
                       trim_ws = TRUE, skip = 0, n_max = Inf,
-                      guess_max = min(1000, n_max), progress = interactive()) {
+                      guess_max = min(1000, n_max), progress = NULL) {
 
   if (locale$decimal_mark == ".") {
     locale$decimal_mark <- ","
     locale$grouping_mark <- "."
   }
-
+  progress <- progress %||% progress_defaults()
   tokenizer <- tokenizer_delim(delim = ";", na = na, quoted_na = quoted_na,
     comment = comment, trim_ws = trim_ws)
   read_delimited(file, tokenizer, col_names = col_names, col_types = col_types,
@@ -141,8 +144,8 @@ read_tsv <- function(file, col_names = TRUE, col_types = NULL,
                      locale = default_locale(),
                      na = c("", "NA"), quoted_na = TRUE,
                      comment = "", trim_ws = TRUE, skip = 0, n_max = Inf,
-                     guess_max = min(1000, n_max), progress = interactive()) {
-
+                     guess_max = min(1000, n_max), progress = NULL) {
+  progress <- progress %||% progress_defaults()
   tokenizer <- tokenizer_tsv(na = na, quoted_na = quoted_na, comment = comment, trim_ws = trim_ws)
   read_delimited(file, tokenizer, col_names = col_names, col_types = col_types,
     locale = locale, skip = skip, comment = comment, n_max = n_max,
@@ -154,12 +157,14 @@ read_tokens <- function(data, tokenizer, col_specs, col_names, locale_, n_max, p
   if (n_max == Inf) {
     n_max <- -1
   }
+  progress <- progress %||% progress_defaults()
   read_tokens_(data, tokenizer, col_specs, col_names, locale_, n_max, progress)
 }
 
 read_delimited <- function(file, tokenizer, col_names = TRUE, col_types = NULL,
                            locale = default_locale(), skip = 0, comment = "",
-                           n_max = Inf, guess_max = min(1000, n_max), progress = interactive()) {
+                           n_max = Inf, guess_max = min(1000, n_max), progress = NULL) {
+  progress <- progress %||% progress_defaults()
   name <- source_name(file)
   # If connection needed, read once.
   file <- standardise_path(file)

--- a/R/read_fwf.R
+++ b/R/read_fwf.R
@@ -30,9 +30,9 @@
 read_fwf <- function(file, col_positions, col_types = NULL,
                      locale = default_locale(), na = c("", "NA"),
                      comment = "", skip = 0, n_max = Inf,
-                     guess_max = min(n_max, 1000), progress = interactive()) {
+                     guess_max = min(n_max, 1000), progress = NULL) {
   ds <- datasource(file, skip = skip)
-
+  progress <- progress %||% progress_defaults()
   if (inherits(ds, "source_file") && empty_file(file)) {
     return(tibble::data_frame())
   }

--- a/R/read_lines_chunked.R
+++ b/R/read_lines_chunked.R
@@ -6,12 +6,12 @@
 #' @family chunked
 #' @export
 read_lines_chunked <- function(file, callback, chunk_size = 10000, skip = 0,
-  locale = default_locale(), na = character(), progress = interactive()) {
+  locale = default_locale(), na = character(), progress = NULL) {
   if (empty_file(file)) {
     return(character())
   }
   ds <- datasource(file, skip = skip)
-
+  progress <- progress %||% progress_defaults()
   callback <- as_chunk_callback(callback)
   on.exit(callback$finally(), add = TRUE)
 

--- a/R/read_log.R
+++ b/R/read_log.R
@@ -9,8 +9,8 @@
 #' @examples
 #' read_log(readr_example("example.log"))
 read_log <- function(file, col_names = FALSE, col_types = NULL,
-                      skip = 0, n_max = -1, progress = interactive()) {
-
+                      skip = 0, n_max = -1, progress = NULL) {
+  progress <- progress %||% progress_defaults()
   tokenizer <- tokenizer_log()
   read_delimited(file, tokenizer, col_names = col_names, col_types = col_types,
     skip = skip, n_max = n_max, progress = progress)

--- a/R/read_table.R
+++ b/R/read_table.R
@@ -31,10 +31,11 @@
 read_table <- function(file, col_names = TRUE, col_types = NULL,
                        locale = default_locale(), na = "NA", skip = 0,
                        n_max = Inf, guess_max = min(n_max, 1000),
-                       progress = interactive(),
+                       progress = NULL,
                        n = 100L) {
   columns <- fwf_empty(file, skip = skip, n = n)
   tokenizer <- tokenizer_fwf(columns$begin, columns$end, na = na)
+  progress <- progress %||% progress_defaults()
 
   spec <- col_spec_standardise(
     file = file, skip = skip, n = guess_max,

--- a/R/utils.R
+++ b/R/utils.R
@@ -9,3 +9,9 @@ is.connection <- function(x) inherits(x, "connection")
 `%||%` <- function(a, b) if (is.null(a)) b else a
 
 is_syntactic <- function(x) make.names(x) == x
+
+progress_defaults <- function() {
+  !isTRUE(getOption("readr.show_progress")) || # user sepecifies no progress
+  !interactive() || # not an interactive session
+  !is.null(getOption("knitr.in.progress"))
+}

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,3 +1,13 @@
+.onLoad <- function(libname, pkgname) {
+  op <- options()
+  op.readr <- list(
+    readr.show_progress = TRUE
+  )
+  toset <- !(names(op.readr) %in% names(op))
+  if(any(toset)) options(op.readr[toset])
+  invisible()
+}
+
 release_questions <- function() {
   c(
     "Have checked with the IDE team?"


### PR DESCRIPTION
Change defaults for displaying the progress bar to be similar to those for dplyr. Currently, the progress bar defaults to display when not interactive. However, it will still display in knitr documents if they are compiled in an interactive session.

This patch defines an unexported function `progress_defaults` which sets checks for an option `readr.show_progress`, whether it is interactive, and whether it is in a knitr document (`knitr.in.progress`). This is equivalent to how `dplyr` defaults for showing a progress bar.