### PR TITLE
Add error for overlapping fwf specification (#534).

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,8 @@
 
 * Pass `guess_max` to  fwf_empty, to control how many lines are read for whitespace before determining column structure.
 
+* `read_fwf()` gives error message if specifications have overlapping columns (#534, @gergness)
+
 # readr 0.2.2.9000
 * Skip Unicode byte order markers if they exist (#263, @jimhester).
 

--- a/src/TokenizerFwf.cpp
+++ b/src/TokenizerFwf.cpp
@@ -109,6 +109,10 @@ TokenizerFwf::TokenizerFwf(const std::vector<int>& beginOffset, const std::vecto
       Rcpp::stop("Begin offset (%i) must be smaller than end offset (%i)",
         beginOffset_[j], endOffset_[j]);
 
+    if (beginOffset_[j] < max_)
+      Rcpp::stop("Overlapping specification not supported. Begin offset (%i) must be greater than previous end offsets (%i)",
+                 beginOffset_[j], max_);
+
     if (endOffset_[j] > max_)
       max_ = endOffset_[j];
   }

--- a/src/TokenizerFwf.cpp
+++ b/src/TokenizerFwf.cpp
@@ -109,7 +109,7 @@ TokenizerFwf::TokenizerFwf(const std::vector<int>& beginOffset, const std::vecto
       Rcpp::stop("Begin offset (%i) must be smaller than end offset (%i)",
         beginOffset_[j], endOffset_[j]);
 
-    if (beginOffset_[j] < max_)
+    if (beginOffset_[j] <= max_)
       Rcpp::stop("Overlapping specification not supported. Begin offset (%i) must be greater than previous end offsets (%i)",
                  beginOffset_[j], max_);
 

--- a/tests/testthat/test-read-fwf.R
+++ b/tests/testthat/test-read-fwf.R
@@ -127,6 +127,13 @@ test_that("error on empty spec (#511, #519)", {
   expect_error(read_fwf(txt, pos), "Zero-length.*specifications not supported")
 })
 
+test_that("error on overlapping spec (#534)", {
+  expect_error(
+    read_fwf("2015a\n2016b", fwf_positions(c(1, 3, 5), c(4, 4, 5))),
+    "Overlap.*"
+    )
+})
+
 # read_table -------------------------------------------------------------------
 
 test_that("read_table silently reads ragged last column", {


### PR DESCRIPTION
I'm worried that the error message part of #534 got lost in the discussion of the full implementation for overlapping columns. The previous behavior can be very difficult to track down, and I think this error message helps tremendously.
Thanks for all the great work!