### PR TITLE
`parse_factor()` gains a `include_na` argument

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # readr 1.0.0.9000
 
+* `parse_factor()` gains a `include_na` argument, to include `NA` in the factor levels (#541).
+
 * parsing problems in `read_delim()` and `read_fwf()` when columns are skipped using col_types now report the correct column name (#573, @cb4ds)
 
 * `parse_time()` now correctly handles 12 AM/PM (#579).

--- a/R/collectors.R
+++ b/R/collectors.R
@@ -200,6 +200,7 @@ guess_parser <- function(x, locale = default_locale()) {
 #'
 #' @param levels Character vector providing set of allowed levels.
 #' @param ordered Is it an ordered factor?
+#' @param include_na Should `NA` be included as a factor level?
 #' @inheritParams parse_atomic
 #' @inheritParams tokenizer_delim
 #' @inheritParams read_delim
@@ -217,14 +218,14 @@ guess_parser <- function(x, locale = default_locale()) {
 #' # parse_factor generates a warning & problems
 #' x2 <- parse_factor(x, levels)
 parse_factor <- function(x, levels, ordered = FALSE, na = c("", "NA"),
-                         locale = default_locale()) {
-  parse_vector(x, col_factor(levels, ordered), na = na, locale = locale)
+                         locale = default_locale(), include_na = FALSE) {
+  parse_vector(x, col_factor(levels, ordered, include_na), na = na, locale = locale)
 }
 
 #' @rdname parse_factor
 #' @export
-col_factor <- function(levels, ordered = FALSE) {
-  collector("factor", levels = levels, ordered = ordered)
+col_factor <- function(levels, ordered = FALSE, include_na = FALSE) {
+  collector("factor", levels = levels, ordered = ordered, include_na = include_na)
 }
 
 # More complex ------------------------------------------------------------

--- a/man/parse_factor.Rd
+++ b/man/parse_factor.Rd
@@ -6,9 +6,9 @@
 \title{Parse factors}
 \usage{
 parse_factor(x, levels, ordered = FALSE, na = c("", "NA"),
-  locale = default_locale())
+  locale = default_locale(), include_na = FALSE)
 
-col_factor(levels, ordered = FALSE)
+col_factor(levels, ordered = FALSE, include_na = FALSE)
 }
 \arguments{
 \item{x}{Character vector of values to parse.}
@@ -25,6 +25,8 @@ The default locale is US-centric (like R), but you can use
 \code{\link[=locale]{locale()}} to create your own locale that controls things like
 the default time zone, encoding, decimal mark, big mark, and day/month
 names.}
+
+\item{include_na}{Should \code{NA} be included as a factor level?}
 }
 \description{
 \code{parse_factor} is similar to \code{\link[=factor]{factor()}}, but will generate

--- a/src/Collector.cpp
+++ b/src/Collector.cpp
@@ -37,7 +37,8 @@ CollectorPtr Collector::create(List spec, LocaleInfo* pLocale) {
   if (subclass == "collector_factor") {
     CharacterVector levels = as<CharacterVector>(spec["levels"]);
     bool ordered = as<bool>(spec["ordered"]);
-    return CollectorPtr(new CollectorFactor(levels, ordered));
+    bool includeNa = as<bool>(spec["include_na"]);
+    return CollectorPtr(new CollectorFactor(levels, ordered, includeNa));
   }
 
   Rcpp::stop("Unsupported column type");

--- a/src/Collector.h
+++ b/src/Collector.h
@@ -151,11 +151,12 @@ class CollectorFactor : public Collector {
   Rcpp::CharacterVector levels_;
   std::map<std::string,int> levelset_;
   bool ordered_;
+  bool includeNa_;
   boost::container::string buffer_;
 
 public:
-  CollectorFactor(Rcpp::CharacterVector levels, bool ordered):
-      Collector(Rcpp::IntegerVector()), levels_(levels), ordered_(ordered)
+  CollectorFactor(Rcpp::CharacterVector levels, bool ordered, bool includeNa):
+      Collector(Rcpp::IntegerVector()), levels_(levels), ordered_(ordered), includeNa_(includeNa)
   {
     int n = levels.size();
 
@@ -172,6 +173,9 @@ public:
       column_.attr("class") = Rcpp::CharacterVector::create("ordered", "factor");
     } else {
       column_.attr("class") = "factor";
+    }
+    if (includeNa_) {
+      levels_.push_back(NA_STRING);
     }
 
     column_.attr("levels") = levels_;

--- a/tests/testthat/test-parsing-factors.R
+++ b/tests/testthat/test-parsing-factors.R
@@ -22,3 +22,7 @@ test_that("NAs silently passed along", {
   expect_equal(x, factor(c("a", "b", NA)))
 })
 
+test_that("NAs included in levels if desired", {
+  x <- parse_factor(c("a", "b", "NA"), levels = c("a", "b"), include_na = TRUE)
+  expect_equal(x, factor(c("a", "b", NA), exclude = NULL))
+})


### PR DESCRIPTION
Which includes `NA` in the factor levels.

Fixes #541