### PR TITLE
`write_lines()` now accepts a list of raw vectors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * Long spec declarations now print properly (#597).
 * `read_table()` can now handle files with many lines of leading comments (#563).
 * Whole number doubles are no longer written with a trailing `.0` decimal (#526).
+* `write_lines()` now accepts a list of raw vectors (#542).
 
 * parsing problems in `read_delim()` and `read_fwf()` when columns are skipped using col_types now report the correct column name (#573, @cb4ds)
 

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -81,6 +81,10 @@ write_lines_ <- function(lines, path, na, append = FALSE) {
     invisible(.Call('readr_write_lines_', PACKAGE = 'readr', lines, path, na, append))
 }
 
+write_lines_raw_ <- function(x, path, append = FALSE) {
+    invisible(.Call('readr_write_lines_raw_', PACKAGE = 'readr', x, path, append))
+}
+
 write_file_raw_ <- function(x, path, append = FALSE) {
     invisible(.Call('readr_write_file_raw_', PACKAGE = 'readr', x, path, append))
 }

--- a/R/lines.R
+++ b/R/lines.R
@@ -3,8 +3,8 @@
 #' `read_lines()` reads up to `n_max` lines from a file. New lines are
 #' not included in the output. `read_lines_raw()` produces a list of raw
 #' vectors, and is useful for handling data with unknown encoding.
-#' `write_lines()` takes a character vector, appending a new line
-#' after each entry.
+#' `write_lines()` takes a character vector or list of raw vectors, appending a
+#' new line after each entry.
 #'
 #' @inheritParams datasource
 #' @inheritParams read_delim
@@ -51,11 +51,13 @@ read_lines_raw <- function(file, skip = 0, n_max = -1L, progress = show_progress
 #' @export
 #' @rdname read_lines
 write_lines <- function(x, path, na = "NA", append = FALSE) {
-  x <- as.character(x)
-
   path <- normalizePath(path, mustWork = FALSE)
-
-  write_lines_(x, path, na, append)
+  if (is.list(x) && all(vapply(x, inherits, logical(1), "raw"))) {
+    write_lines_raw_(x, path, append)
+  } else {
+    x <- as.character(x)
+    write_lines_(x, path, na, append)
+  }
 
   invisible(x)
 }

--- a/man/read_lines.Rd
+++ b/man/read_lines.Rd
@@ -64,8 +64,8 @@ file is created.}
 \code{read_lines()} reads up to \code{n_max} lines from a file. New lines are
 not included in the output. \code{read_lines_raw()} produces a list of raw
 vectors, and is useful for handling data with unknown encoding.
-\code{write_lines()} takes a character vector, appending a new line
-after each entry.
+\code{write_lines()} takes a character vector or list of raw vectors, appending a
+new line after each entry.
 }
 \examples{
 read_lines(file.path(R.home("doc"), "AUTHORS"), n_max = 10)

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -284,6 +284,18 @@ BEGIN_RCPP
     return R_NilValue;
 END_RCPP
 }
+// write_lines_raw_
+void write_lines_raw_(List x, const std::string& path, bool append);
+RcppExport SEXP readr_write_lines_raw_(SEXP xSEXP, SEXP pathSEXP, SEXP appendSEXP) {
+BEGIN_RCPP
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< List >::type x(xSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type path(pathSEXP);
+    Rcpp::traits::input_parameter< bool >::type append(appendSEXP);
+    write_lines_raw_(x, path, append);
+    return R_NilValue;
+END_RCPP
+}
 // write_file_raw_
 void write_file_raw_(RawVector x, const std::string& path, bool append);
 RcppExport SEXP readr_write_file_raw_(SEXP xSEXP, SEXP pathSEXP, SEXP appendSEXP) {

--- a/src/write.cpp
+++ b/src/write.cpp
@@ -23,6 +23,24 @@ void write_lines_(const CharacterVector &lines, const std::string &path, const s
 }
 
 // [[Rcpp::export]]
+void write_lines_raw_(List x, const std::string &path, bool append = false) {
+  std::ofstream output(path.c_str(), std::ofstream::binary | (append ? std::ofstream::app : std::ofstream::trunc));
+
+  if (output.fail()) {
+    stop("Failed to open '%s'.", path);
+  }
+
+  std::ostream_iterator<char> out = std::ostream_iterator<char>(output);
+  for (int i = 0;i < x.length();++i) {
+    RawVector y = x.at(i);
+    std::copy(y.begin(), y.end(), out);
+    *out++ = '\n';
+  }
+
+  return;
+}
+
+// [[Rcpp::export]]
 void write_file_raw_(RawVector x, const std::string &path, bool append = false) {
   std::ofstream output(path.c_str(), std::ofstream::binary | (append ? std::ofstream::app : std::ofstream::trunc));
 

--- a/tests/testthat/test-write-lines.R
+++ b/tests/testthat/test-write-lines.R
@@ -36,6 +36,16 @@ test_that("write_lines can append to a file", {
   expect_equal(read_lines(tmp), c("first", "last", "first", "last"))
 })
 
+test_that("write_lines accepts a list of raws", {
+  x <- lapply(seq_along(1:10), function(x) charToRaw(paste0(collapse = "", sample(letters, size = sample(0:22, 1)))))
+  tmp <- tempfile()
+  on.exit(unlink(tmp))
+
+  write_lines(x, tmp)
+
+  expect_equal(read_lines(tmp), vapply(x, rawToChar, character(1)))
+})
+
 # write_file ------------------------------------------------------------------
 test_that("write_file round trips", {
   tmp <- tempfile()


### PR DESCRIPTION
Fixes #542