### PR TITLE
Whole number doubles are no longer written with a trailing `.0` decimal

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * Long spec declarations now print properly (#597).
 * `read_table()` can now handle files with many lines of leading comments (#563).
+* Whole number doubles are no longer written with a trailing `.0` decimal (#526).
 
 * parsing problems in `read_delim()` and `read_fwf()` when columns are skipped using col_types now report the correct column name (#573, @cb4ds)
 

--- a/src/grisu3.c
+++ b/src/grisu3.c
@@ -352,7 +352,7 @@ int dtoa_grisu3(double v, char *dst)
 	// Prehandle negative values.
 	if ((u64 & D64_SIGN) != 0) { *s2++ = '-'; v = -v; u64 ^= D64_SIGN; }
 	// Prehandle zero.
-	if (!u64) { *s2++ = '0'; *s2++ = '.'; *s2++ = '0'; *s2 = '\0'; return (int)(s2 - dst); }
+	if (!u64) { *s2++ = '0'; *s2 = '\0'; return (int)(s2 - dst); }
 	// Prehandle infinity.
 	if (u64 == D64_EXP_MASK) { *s2++ = 'i'; *s2++ = 'n'; *s2++ = 'f'; *s2 = '\0'; return (int)(s2 - dst); }
 
@@ -363,10 +363,8 @@ int dtoa_grisu3(double v, char *dst)
 	// handle whole numbers
 	if (d_exp >= 0 && d_exp <= 2) {
 		while(d_exp-- > 0) s2[len++] = '0';
-		 s2[len++] = '.';
-		 s2[len++] = '0';
-		 s2[len] = '\0';
-		 return (int)(s2+len-dst);
+		s2[len] = '\0';
+		return (int)(s2+len-dst);
 	}
 	// We now have an integer string of form "151324135" and a base-10 exponent for that number.
 	// Next, decide the best presentation for that string by whether to use a decimal point, or the scientific exponent notation 'e'.

--- a/tests/testthat/test-write-delim.R
+++ b/tests/testthat/test-write-delim.R
@@ -77,18 +77,18 @@ test_that("write_excel_csv includes a byte order mark", {
 })
 
 
-test_that("writes a tailing .0 for whole number doubles", {
-  expect_equal(format_tsv(tibble::data_frame(x = 1)), "x\n1.0\n")
+test_that("does not writes a tailing .0 for whole number doubles", {
+  expect_equal(format_tsv(tibble::data_frame(x = 1)), "x\n1\n")
 
-  expect_equal(format_tsv(tibble::data_frame(x = 0)), "x\n0.0\n")
+  expect_equal(format_tsv(tibble::data_frame(x = 0)), "x\n0\n")
 
-  expect_equal(format_tsv(tibble::data_frame(x = -1)), "x\n-1.0\n")
+  expect_equal(format_tsv(tibble::data_frame(x = -1)), "x\n-1\n")
 
-  expect_equal(format_tsv(tibble::data_frame(x = 999)), "x\n999.0\n")
+  expect_equal(format_tsv(tibble::data_frame(x = 999)), "x\n999\n")
 
-  expect_equal(format_tsv(tibble::data_frame(x = -999)), "x\n-999.0\n")
+  expect_equal(format_tsv(tibble::data_frame(x = -999)), "x\n-999\n")
 
-  expect_equal(format_tsv(tibble::data_frame(x = 123456789)), "x\n123456789.0\n")
+  expect_equal(format_tsv(tibble::data_frame(x = 123456789)), "x\n123456789\n")
 
-  expect_equal(format_tsv(tibble::data_frame(x = -123456789)), "x\n-123456789.0\n")
+  expect_equal(format_tsv(tibble::data_frame(x = -123456789)), "x\n-123456789\n")
 })


### PR DESCRIPTION
Fixes #526