### PR TITLE
`read_table()` can now handle files with many lines of leading comments

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # readr 1.0.0.9000
 
 * Long spec declarations now print properly (#597).
+* `read_table()` can now handle files with many lines of leading comments (#563).
 
 * parsing problems in `read_delim()` and `read_fwf()` when columns are skipped using col_types now report the correct column name (#573, @cb4ds)
 

--- a/R/read_table.R
+++ b/R/read_table.R
@@ -31,6 +31,8 @@ read_table <- function(file, col_names = TRUE, col_types = NULL,
                        n_max = Inf, guess_max = min(n_max, 1000),
                        progress = show_progress(), comment = "") {
   columns <- fwf_empty(file, skip = skip, n = guess_max, comment = comment)
+  skip <- skip + columns$skip
+
   tokenizer <- tokenizer_fwf(columns$begin, columns$end, na = na, comment = comment)
 
   spec <- col_spec_standardise(

--- a/tests/testthat/test-read-fwf.R
+++ b/tests/testthat/test-read-fwf.R
@@ -21,7 +21,7 @@ test_that("skipping column doesn't pad col_names", {
 })
 
 test_that("fwf_empty can skip comments", {
-  x <- "1 2 3\nCOMMENT\n4 5 6"
+  x <- "COMMENT\n1 2 3\n4 5 6"
 
   out1 <- read_fwf(x, fwf_empty(x, comment = "COMMENT"), comment = "COMMENT")
   expect_equal(dim(out1), c(2, 3))
@@ -132,4 +132,12 @@ test_that("error on empty spec (#511, #519)", {
 test_that("read_table silently reads ragged last column", {
   x <- read_table("foo bar\n1   2\n3   4\n5   6\n", progress = FALSE)
   expect_equal(x$foo, c(1, 3, 5))
+})
+
+test_that("read_table skips all comment lines", {
+  x <- read_table("foo bar\n1   2\n3   4\n5   6\n", progress = FALSE)
+
+  y <- read_table("#comment1\n#comment2\nfoo bar\n1   2\n3   4\n5   6\n", progress = FALSE, comment = "#")
+
+  expect_equal(x, y)
 })


### PR DESCRIPTION
Fixes #563