### PR TITLE
Use a datasource for all file arguments in read_table

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 * ListCallback S6 Class to provide a more flexible return type for callback functions (#568, @mmuurr)
 * parsing problems now include the filename (#581).
 * Numeric parser now returns the full string if it contains no numbers (#548).
+* `read_table()` can now handle `pipe()` connections (#552).
 
 * parsing problems in `read_delim()` and `read_fwf()` when columns are skipped using col_types now report the correct column name (#573, @cb4ds)
 

--- a/R/read_table.R
+++ b/R/read_table.R
@@ -30,13 +30,14 @@ read_table <- function(file, col_names = TRUE, col_types = NULL,
                        locale = default_locale(), na = "NA", skip = 0,
                        n_max = Inf, guess_max = min(n_max, 1000),
                        progress = show_progress(), comment = "") {
-  columns <- fwf_empty(file, skip = skip, n = guess_max, comment = comment)
+  ds <- datasource(file, skip = skip)
+  columns <- fwf_empty(ds, skip = skip, n = guess_max, comment = comment)
   skip <- skip + columns$skip
 
   tokenizer <- tokenizer_fwf(columns$begin, columns$end, na = na, comment = comment)
 
   spec <- col_spec_standardise(
-    file = file, skip = skip, n = guess_max,
+    file = ds, skip = skip, n = guess_max,
     col_names = col_names, col_types = col_types,
     locale = locale, tokenizer = tokenizer
   )
@@ -45,7 +46,7 @@ read_table <- function(file, col_names = TRUE, col_types = NULL,
      print(spec, n = getOption("readr.num_columns", 20))
   }
 
-  ds <- datasource(file, skip = skip + isTRUE(col_names))
+  ds <- datasource(file = ds, skip = skip + isTRUE(col_names))
   res <- read_tokens(ds, tokenizer, spec$cols, names(spec$cols), locale_ = locale,
     n_max = n_max, progress = progress)
   attr(res, "spec") <- spec

--- a/R/source.R
+++ b/R/source.R
@@ -33,6 +33,8 @@
 #' close(con)
 datasource <- function(file, skip = 0, comment = "") {
   if (inherits(file, "source")) {
+    if (!missing(skip)) { file$skip <- skip }
+    if (!missing(comment)) { file$comment <- comment }
     file
   } else if (is.connection(file)) {
     datasource_connection(file, skip, comment)

--- a/R/source.R
+++ b/R/source.R
@@ -33,8 +33,17 @@
 #' close(con)
 datasource <- function(file, skip = 0, comment = "") {
   if (inherits(file, "source")) {
-    if (!missing(skip)) { file$skip <- skip }
-    if (!missing(comment)) { file$comment <- comment }
+
+    # If `skip` and `comment` arguments are expliictly passed, we want to use
+    # those even if `file` is already a source
+    if (!missing(skip)) {
+      file$skip <- skip
+    }
+
+    if (!missing(comment)) {
+      file$comment <- comment
+    }
+
     file
   } else if (is.connection(file)) {
     datasource_connection(file, skip, comment)

--- a/tests/testthat/test-read-fwf.R
+++ b/tests/testthat/test-read-fwf.R
@@ -141,3 +141,8 @@ test_that("read_table skips all comment lines", {
 
   expect_equal(x, y)
 })
+
+test_that("read_table can read from a pipe (552)", {
+  x <- read_table(pipe("echo a b c && echo 1 2 3 && echo 4 5 6"))
+  expect_equal(x$a, c(1, 4))
+})


### PR DESCRIPTION
Fixes #552 

The `missing()` calls in https://github.com/tidyverse/readr/compare/552?expand=1#diff-7f0d4a03d8bda22664cf51f3fcf4a243R36 are a little gross, but we only want to override the current values if the first value is a data source _and_ non-default values are passed to the `datasource()` constructor.