### PR TITLE
Writing to compressed files / connections

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,11 +20,11 @@ LinkingTo: Rcpp,
     BH
 Imports:
     Rcpp (>= 0.12.0.5),
-    curl,
     tibble,
     hms,
     R6
 Suggests:
+    curl,
     testthat,
     knitr,
     rmarkdown,

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,9 @@
 * `read_table2()` which allows any number of whitespace characters as
   delimiters, a more exact replacement for `utils::read.table()` (#608).
 
+* The `write_*` functions now support writing to binary connections. In
+  addition output filenames with `.gz`, `.bz2` or `.xz` will automatically open
+  the appropriate connection and to write the compressed file. (#348)
 * Long spec declarations now print properly (#597).
 * `read_table()` can now handle files with many lines of leading comments (#563).
 * Whole number doubles are no longer written with a trailing `.0` decimal (#526).

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -73,43 +73,23 @@ type_convert_col <- function(x, spec, locale_, col, na, trim_ws) {
     .Call('readr_type_convert_col', PACKAGE = 'readr', x, spec, locale_, col, na, trim_ws)
 }
 
-stream_delim_file <- function(df, path, delim, na, col_names = TRUE, append = FALSE, bom = FALSE) {
-    .Call('readr_stream_delim_file', PACKAGE = 'readr', df, path, delim, na, col_names, append, bom)
+stream_delim_ <- function(df, connection, delim, na, col_names = TRUE, bom = FALSE) {
+    .Call('readr_stream_delim_', PACKAGE = 'readr', df, connection, delim, na, col_names, bom)
 }
 
-stream_delim_connection <- function(df, connection, delim, na, col_names = TRUE, append = FALSE, bom = FALSE) {
-    invisible(.Call('readr_stream_delim_connection', PACKAGE = 'readr', df, connection, delim, na, col_names, append, bom))
+write_lines_ <- function(lines, connection, na) {
+    invisible(.Call('readr_write_lines_', PACKAGE = 'readr', lines, connection, na))
 }
 
-write_lines_ <- function(lines, path, na, append = FALSE) {
-    invisible(.Call('readr_write_lines_', PACKAGE = 'readr', lines, path, na, append))
+write_lines_raw_ <- function(x, connection) {
+    invisible(.Call('readr_write_lines_raw_', PACKAGE = 'readr', x, connection))
 }
 
-write_lines_connection_ <- function(lines, connection, na) {
-    invisible(.Call('readr_write_lines_connection_', PACKAGE = 'readr', lines, connection, na))
+write_file_ <- function(x, connection) {
+    invisible(.Call('readr_write_file_', PACKAGE = 'readr', x, connection))
 }
 
-write_lines_raw_ <- function(x, path, append = FALSE) {
-    invisible(.Call('readr_write_lines_raw_', PACKAGE = 'readr', x, path, append))
-}
-
-write_lines_raw_connection_ <- function(x, connection) {
-    invisible(.Call('readr_write_lines_raw_connection_', PACKAGE = 'readr', x, connection))
-}
-
-write_file_raw_ <- function(x, path, append = FALSE) {
-    invisible(.Call('readr_write_file_raw_', PACKAGE = 'readr', x, path, append))
-}
-
-write_file_raw_connection_ <- function(x, connection) {
-    invisible(.Call('readr_write_file_raw_connection_', PACKAGE = 'readr', x, connection))
-}
-
-write_file_ <- function(x, path, append = FALSE) {
-    invisible(.Call('readr_write_file_', PACKAGE = 'readr', x, path, append))
-}
-
-write_file_connection_ <- function(x, connection) {
-    invisible(.Call('readr_write_file_connection_', PACKAGE = 'readr', x, connection))
+write_file_raw_ <- function(x, connection) {
+    invisible(.Call('readr_write_file_raw_', PACKAGE = 'readr', x, connection))
 }
 

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -73,23 +73,43 @@ type_convert_col <- function(x, spec, locale_, col, na, trim_ws) {
     .Call('readr_type_convert_col', PACKAGE = 'readr', x, spec, locale_, col, na, trim_ws)
 }
 
-stream_delim <- function(df, path, delim, na, col_names = TRUE, append = FALSE, bom = FALSE) {
-    .Call('readr_stream_delim', PACKAGE = 'readr', df, path, delim, na, col_names, append, bom)
+stream_delim_file <- function(df, path, delim, na, col_names = TRUE, append = FALSE, bom = FALSE) {
+    .Call('readr_stream_delim_file', PACKAGE = 'readr', df, path, delim, na, col_names, append, bom)
+}
+
+stream_delim_connection <- function(df, connection, delim, na, col_names = TRUE, append = FALSE, bom = FALSE) {
+    invisible(.Call('readr_stream_delim_connection', PACKAGE = 'readr', df, connection, delim, na, col_names, append, bom))
 }
 
 write_lines_ <- function(lines, path, na, append = FALSE) {
     invisible(.Call('readr_write_lines_', PACKAGE = 'readr', lines, path, na, append))
 }
 
+write_lines_connection_ <- function(lines, connection, na) {
+    invisible(.Call('readr_write_lines_connection_', PACKAGE = 'readr', lines, connection, na))
+}
+
 write_lines_raw_ <- function(x, path, append = FALSE) {
     invisible(.Call('readr_write_lines_raw_', PACKAGE = 'readr', x, path, append))
+}
+
+write_lines_raw_connection_ <- function(x, connection) {
+    invisible(.Call('readr_write_lines_raw_connection_', PACKAGE = 'readr', x, connection))
 }
 
 write_file_raw_ <- function(x, path, append = FALSE) {
     invisible(.Call('readr_write_file_raw_', PACKAGE = 'readr', x, path, append))
 }
 
+write_file_raw_connection_ <- function(x, connection) {
+    invisible(.Call('readr_write_file_raw_connection_', PACKAGE = 'readr', x, connection))
+}
+
 write_file_ <- function(x, path, append = FALSE) {
     invisible(.Call('readr_write_file_', PACKAGE = 'readr', x, path, append))
+}
+
+write_file_connection_ <- function(x, connection) {
+    invisible(.Call('readr_write_file_connection_', PACKAGE = 'readr', x, connection))
 }
 

--- a/R/file.R
+++ b/R/file.R
@@ -47,28 +47,19 @@ read_file_raw <- function(file) {
 #' @rdname read_file
 #' @export
 write_file <- function(x, path, append = FALSE) {
-  path <- standardise_path(path, check = FALSE)
-
-  if (!(is.raw(x) || is.character(x))) {
-    stop("`x` must be a raw or character vector", call. = FALSE)
-  }
-
-  if (inherits(path, "connection")) {
-    if (!isOpen(path)) {
+  path <- standardise_path(path, input = FALSE)
+  if (!isOpen(path)) {
+    on.exit(close(path), add = TRUE)
+    if (isTRUE(append)) {
+      open(path, "ab")
+    } else {
       open(path, "wb")
-      on.exit(close(path))
     }
-    if (is.raw(x)) {
-      write_file_raw_connection_(x, path)
-    } else {
-      write_file_connection_(x, path)
-    }
+  }
+  if (is.raw(x)) {
+    write_file_raw_(x, path)
   } else {
-    if (is.raw(x)) {
-      write_file_raw_(x, path, append = append)
-    } else {
-      write_file_(x, path, append = append)
-    }
+    write_file_(x, path)
   }
 
   invisible(x)

--- a/R/file.R
+++ b/R/file.R
@@ -47,14 +47,28 @@ read_file_raw <- function(file) {
 #' @rdname read_file
 #' @export
 write_file <- function(x, path, append = FALSE) {
-  path <- normalizePath(path, mustWork = FALSE)
+  path <- standardise_path(path, check = FALSE)
 
-  if (is.raw(x)) {
-    write_file_raw_(x, path, append = append)
-  } else if (is.character(x)) {
-    write_file_(x, path, append = append)
-  } else {
+  if (!(is.raw(x) || is.character(x))) {
     stop("`x` must be a raw or character vector", call. = FALSE)
+  }
+
+  if (inherits(path, "connection")) {
+    if (!isOpen(path)) {
+      open(path, "wb")
+      on.exit(close(path))
+    }
+    if (is.raw(x)) {
+      write_file_raw_connection_(x, path)
+    } else {
+      write_file_connection_(x, path)
+    }
+  } else {
+    if (is.raw(x)) {
+      write_file_raw_(x, path, append = append)
+    } else {
+      write_file_(x, path, append = append)
+    }
   }
 
   invisible(x)

--- a/R/lines.R
+++ b/R/lines.R
@@ -53,7 +53,7 @@ read_lines_raw <- function(file, skip = 0, n_max = -1L, progress = show_progress
 write_lines <- function(x, path, na = "NA", append = FALSE) {
   path <- standardise_path(path, check = FALSE)
 
-  is_raw <- is.list(x) && all(vapply(x, inherits, logical(1), "raw"))
+  is_raw <- is.list(x) && inherits(x[[1]], "raw")
   if (!is_raw) {
     x <- as.character(x)
   }

--- a/R/lines.R
+++ b/R/lines.R
@@ -51,31 +51,25 @@ read_lines_raw <- function(file, skip = 0, n_max = -1L, progress = show_progress
 #' @export
 #' @rdname read_lines
 write_lines <- function(x, path, na = "NA", append = FALSE) {
-  path <- standardise_path(path, check = FALSE)
-
   is_raw <- is.list(x) && inherits(x[[1]], "raw")
   if (!is_raw) {
     x <- as.character(x)
   }
 
-  if (inherits(path, "connection")) {
-    if (!isOpen(path)) {
+  path <- standardise_path(path, input = FALSE)
+  if (!isOpen(path)) {
+    on.exit(close(path), add = TRUE)
+    if (isTRUE(append)) {
+      open(path, "ab")
+    } else {
       open(path, "wb")
-      on.exit(close(path))
     }
-    if (is_raw) {
-      write_lines_raw_connection_(x, path)
-    } else {
-      write_lines_connection_(x, path, na)
-    }
+  }
+  if (is_raw) {
+    write_lines_raw_(x, path)
   } else {
-    if (is_raw) {
-      write_lines_raw_(x, path, append)
-    } else {
-      write_lines_(x, path, na, append)
-    }
+    write_lines_(x, path, na)
   }
 
   invisible(x)
 }
-

--- a/R/lines.R
+++ b/R/lines.R
@@ -59,11 +59,7 @@ write_lines <- function(x, path, na = "NA", append = FALSE) {
   path <- standardise_path(path, input = FALSE)
   if (!isOpen(path)) {
     on.exit(close(path), add = TRUE)
-    if (isTRUE(append)) {
-      open(path, "ab")
-    } else {
-      open(path, "wb")
-    }
+    open(path, if (isTRUE(append)) "ab" else "wb")
   }
   if (is_raw) {
     write_lines_raw_(x, path)

--- a/R/source.R
+++ b/R/source.R
@@ -102,7 +102,7 @@ read_connection <- function(con) {
   read_connection_(con)
 }
 
-standardise_path <- function(path, check = TRUE) {
+standardise_path <- function(path, input = TRUE) {
   if (!is.character(path))
     return(path)
 
@@ -122,7 +122,7 @@ standardise_path <- function(path, check = TRUE) {
     }
   }
 
-  if (isTRUE(check)) {
+  if (isTRUE(input)) {
     path <- check_path(path)
   }
   switch(tools::file_ext(path),
@@ -130,8 +130,13 @@ standardise_path <- function(path, check = TRUE) {
     bz2 = bzfile(path, ""),
     xz = xzfile(path, ""),
     zip = zipfile(path, ""),
-    path
-  )
+
+    # Use a file connection for output
+    if (!isTRUE(input)) {
+      file(path, "")
+    } else {
+      path
+    })
 }
 
 source_name <- function(x) {

--- a/R/source.R
+++ b/R/source.R
@@ -113,6 +113,7 @@ standardise_path <- function(path, input = TRUE) {
     if (requireNamespace("curl", quietly = TRUE)) {
       con <- curl::curl(path)
     } else {
+      message("`curl` package not installed, falling back to using `url()`")
       con <- url(path)
     }
     if (identical(tools::file_ext(path), "gz")) {

--- a/R/source.R
+++ b/R/source.R
@@ -110,10 +110,15 @@ standardise_path <- function(path) {
     return(path)
 
   if (is_url(path)) {
-    if (identical(tools::file_ext(path), "gz")) {
-      return(gzcon(curl::curl(path)))
+    if (requireNamespace("curl", quietly = TRUE)) {
+      con <- curl::curl(path)
     } else {
-      return(curl::curl(path))
+      con <- url(path)
+    }
+    if (identical(tools::file_ext(path), "gz")) {
+      return(gzcon(con))
+    } else {
+      return(con)
     }
   }
 

--- a/R/source.R
+++ b/R/source.R
@@ -102,7 +102,7 @@ read_connection <- function(con) {
   read_connection_(con)
 }
 
-standardise_path <- function(path) {
+standardise_path <- function(path, check = TRUE) {
   if (!is.character(path))
     return(path)
 
@@ -122,7 +122,9 @@ standardise_path <- function(path) {
     }
   }
 
-  path <- check_path(path)
+  if (isTRUE(check)) {
+    path <- check_path(path)
+  }
   switch(tools::file_ext(path),
     gz = gzfile(path, ""),
     bz2 = bzfile(path, ""),

--- a/R/write.R
+++ b/R/write.R
@@ -49,7 +49,6 @@
 write_delim <- function(x, path, delim = " ", na = "NA", append = FALSE,
                         col_names = !append) {
   stopifnot(is.data.frame(x))
-  path <- normalizePath(path, mustWork = FALSE)
 
   x_out <- lapply(x, output_column)
   stream_delim(x_out, path, delim, col_names = col_names, append = append,
@@ -68,7 +67,6 @@ write_csv <- function(x, path, na = "NA", append = FALSE, col_names = !append) {
 #' @export
 write_excel_csv <- function(x, path, na = "NA", append = FALSE, col_names = !append) {
   stopifnot(is.data.frame(x))
-  path <- normalizePath(path, mustWork = FALSE)
 
   x_out <- lapply(x, output_column)
   stream_delim(x_out, path, ",", col_names = col_names, append = append,
@@ -141,4 +139,19 @@ output_column.double <- function(x) {
 #' @export
 output_column.POSIXt <- function(x) {
   format(x, "%Y-%m-%dT%H:%M:%OSZ", tz = "UTC")
+}
+
+stream_delim <- function(df, path, ...) {
+  path <- standardise_path(path, check = FALSE)
+
+  if (inherits(path, "connection")) {
+    if (!isOpen(path)) {
+      open(path, "wb")
+      on.exit(close(path))
+    }
+    stream_delim_connection(df, path, ...)
+  } else {
+    path <- normalizePath(path, mustWork = FALSE)
+    stream_delim_file(df, path, ...)
+  }
 }

--- a/R/write.R
+++ b/R/write.R
@@ -15,7 +15,7 @@
 #' Values are only quoted if needed: if they contain a comma, quote or newline.
 #'
 #' @param x A data frame to write to disk
-#' @param path Path to write to.
+#' @param path Path or connection to write to.
 #' @param append If `FALSE`, will overwrite existing file. If `TRUE`,
 #'   will append to existing file. In both cases, if file does not exist a new
 #'   file is created.
@@ -46,6 +46,13 @@
 #' # Quotes are automatically as needed
 #' df <- data.frame(x = c("a", '"', ",", "\n"))
 #' cat(format_csv(df))
+#'
+#' # A output connection will be automatically created for output filenames
+#' # with appropriate extensions.
+#' dir <- tempdir()
+#' write_tsv(mtcars, file.path(dir, "mtcars.tsv.gz"))
+#' write_tsv(mtcars, file.path(dir, "mtcars.tsv.bz2"))
+#' write_tsv(mtcars, file.path(dir, "mtcars.tsv.xz"))
 write_delim <- function(x, path, delim = " ", na = "NA", append = FALSE,
                         col_names = !append) {
   stopifnot(is.data.frame(x))

--- a/man/read_file.Rd
+++ b/man/read_file.Rd
@@ -33,7 +33,7 @@ names.}
 
 \item{x}{A data frame to write to disk}
 
-\item{path}{Path to write to.}
+\item{path}{Path or connection to write to.}
 
 \item{append}{If \code{FALSE}, will overwrite existing file. If \code{TRUE},
 will append to existing file. In both cases, if file does not exist a new

--- a/man/read_lines.Rd
+++ b/man/read_lines.Rd
@@ -48,7 +48,7 @@ setting option \code{readr.show_progress} to \code{FALSE}.}
 
 \item{x}{A data frame to write to disk}
 
-\item{path}{Path to write to.}
+\item{path}{Path or connection to write to.}
 
 \item{append}{If \code{FALSE}, will overwrite existing file. If \code{TRUE},
 will append to existing file. In both cases, if file does not exist a new

--- a/man/write_delim.Rd
+++ b/man/write_delim.Rd
@@ -19,7 +19,7 @@ write_tsv(x, path, na = "NA", append = FALSE, col_names = !append)
 \arguments{
 \item{x}{A data frame to write to disk}
 
-\item{path}{Path to write to.}
+\item{path}{Path or connection to write to.}
 
 \item{delim}{Delimiter used to seperate values. Defaults to \code{" "}. Must be
 a single character.}
@@ -70,6 +70,13 @@ format_csv(df, na = ".")
 # Quotes are automatically as needed
 df <- data.frame(x = c("a", '"', ",", "\\n"))
 cat(format_csv(df))
+
+# A output connection will be automatically created for output filenames
+# with appropriate extensions.
+dir <- tempdir()
+write_tsv(mtcars, file.path(dir, "mtcars.tsv.gz"))
+write_tsv(mtcars, file.path(dir, "mtcars.tsv.bz2"))
+write_tsv(mtcars, file.path(dir, "mtcars.tsv.xz"))
 }
 \references{
 Florian Loitsch, Printing Floating-Point Numbers Quickly and

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -254,130 +254,64 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// stream_delim_file
-std::string stream_delim_file(const List& df, const std::string& path, char delim, const std::string& na, bool col_names, bool append, bool bom);
-RcppExport SEXP readr_stream_delim_file(SEXP dfSEXP, SEXP pathSEXP, SEXP delimSEXP, SEXP naSEXP, SEXP col_namesSEXP, SEXP appendSEXP, SEXP bomSEXP) {
+// stream_delim_
+std::string stream_delim_(const List& df, RObject connection, char delim, const std::string& na, bool col_names, bool bom);
+RcppExport SEXP readr_stream_delim_(SEXP dfSEXP, SEXP connectionSEXP, SEXP delimSEXP, SEXP naSEXP, SEXP col_namesSEXP, SEXP bomSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const List& >::type df(dfSEXP);
-    Rcpp::traits::input_parameter< const std::string& >::type path(pathSEXP);
+    Rcpp::traits::input_parameter< RObject >::type connection(connectionSEXP);
     Rcpp::traits::input_parameter< char >::type delim(delimSEXP);
     Rcpp::traits::input_parameter< const std::string& >::type na(naSEXP);
     Rcpp::traits::input_parameter< bool >::type col_names(col_namesSEXP);
-    Rcpp::traits::input_parameter< bool >::type append(appendSEXP);
     Rcpp::traits::input_parameter< bool >::type bom(bomSEXP);
-    rcpp_result_gen = Rcpp::wrap(stream_delim_file(df, path, delim, na, col_names, append, bom));
+    rcpp_result_gen = Rcpp::wrap(stream_delim_(df, connection, delim, na, col_names, bom));
     return rcpp_result_gen;
 END_RCPP
 }
-// stream_delim_connection
-void stream_delim_connection(const List& df, RObject connection, char delim, const std::string& na, bool col_names, bool append, bool bom);
-RcppExport SEXP readr_stream_delim_connection(SEXP dfSEXP, SEXP connectionSEXP, SEXP delimSEXP, SEXP naSEXP, SEXP col_namesSEXP, SEXP appendSEXP, SEXP bomSEXP) {
-BEGIN_RCPP
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const List& >::type df(dfSEXP);
-    Rcpp::traits::input_parameter< RObject >::type connection(connectionSEXP);
-    Rcpp::traits::input_parameter< char >::type delim(delimSEXP);
-    Rcpp::traits::input_parameter< const std::string& >::type na(naSEXP);
-    Rcpp::traits::input_parameter< bool >::type col_names(col_namesSEXP);
-    Rcpp::traits::input_parameter< bool >::type append(appendSEXP);
-    Rcpp::traits::input_parameter< bool >::type bom(bomSEXP);
-    stream_delim_connection(df, connection, delim, na, col_names, append, bom);
-    return R_NilValue;
-END_RCPP
-}
 // write_lines_
-void write_lines_(const CharacterVector& lines, const std::string& path, const std::string& na, bool append);
-RcppExport SEXP readr_write_lines_(SEXP linesSEXP, SEXP pathSEXP, SEXP naSEXP, SEXP appendSEXP) {
-BEGIN_RCPP
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const CharacterVector& >::type lines(linesSEXP);
-    Rcpp::traits::input_parameter< const std::string& >::type path(pathSEXP);
-    Rcpp::traits::input_parameter< const std::string& >::type na(naSEXP);
-    Rcpp::traits::input_parameter< bool >::type append(appendSEXP);
-    write_lines_(lines, path, na, append);
-    return R_NilValue;
-END_RCPP
-}
-// write_lines_connection_
-void write_lines_connection_(const CharacterVector& lines, RObject connection, const std::string& na);
-RcppExport SEXP readr_write_lines_connection_(SEXP linesSEXP, SEXP connectionSEXP, SEXP naSEXP) {
+void write_lines_(const CharacterVector& lines, RObject connection, const std::string& na);
+RcppExport SEXP readr_write_lines_(SEXP linesSEXP, SEXP connectionSEXP, SEXP naSEXP) {
 BEGIN_RCPP
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const CharacterVector& >::type lines(linesSEXP);
     Rcpp::traits::input_parameter< RObject >::type connection(connectionSEXP);
     Rcpp::traits::input_parameter< const std::string& >::type na(naSEXP);
-    write_lines_connection_(lines, connection, na);
+    write_lines_(lines, connection, na);
     return R_NilValue;
 END_RCPP
 }
 // write_lines_raw_
-void write_lines_raw_(List x, const std::string& path, bool append);
-RcppExport SEXP readr_write_lines_raw_(SEXP xSEXP, SEXP pathSEXP, SEXP appendSEXP) {
-BEGIN_RCPP
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< List >::type x(xSEXP);
-    Rcpp::traits::input_parameter< const std::string& >::type path(pathSEXP);
-    Rcpp::traits::input_parameter< bool >::type append(appendSEXP);
-    write_lines_raw_(x, path, append);
-    return R_NilValue;
-END_RCPP
-}
-// write_lines_raw_connection_
-void write_lines_raw_connection_(List x, RObject connection);
-RcppExport SEXP readr_write_lines_raw_connection_(SEXP xSEXP, SEXP connectionSEXP) {
+void write_lines_raw_(List x, RObject connection);
+RcppExport SEXP readr_write_lines_raw_(SEXP xSEXP, SEXP connectionSEXP) {
 BEGIN_RCPP
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< List >::type x(xSEXP);
     Rcpp::traits::input_parameter< RObject >::type connection(connectionSEXP);
-    write_lines_raw_connection_(x, connection);
-    return R_NilValue;
-END_RCPP
-}
-// write_file_raw_
-void write_file_raw_(RawVector x, const std::string& path, bool append);
-RcppExport SEXP readr_write_file_raw_(SEXP xSEXP, SEXP pathSEXP, SEXP appendSEXP) {
-BEGIN_RCPP
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< RawVector >::type x(xSEXP);
-    Rcpp::traits::input_parameter< const std::string& >::type path(pathSEXP);
-    Rcpp::traits::input_parameter< bool >::type append(appendSEXP);
-    write_file_raw_(x, path, append);
-    return R_NilValue;
-END_RCPP
-}
-// write_file_raw_connection_
-void write_file_raw_connection_(RawVector x, RObject connection);
-RcppExport SEXP readr_write_file_raw_connection_(SEXP xSEXP, SEXP connectionSEXP) {
-BEGIN_RCPP
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< RawVector >::type x(xSEXP);
-    Rcpp::traits::input_parameter< RObject >::type connection(connectionSEXP);
-    write_file_raw_connection_(x, connection);
+    write_lines_raw_(x, connection);
     return R_NilValue;
 END_RCPP
 }
 // write_file_
-void write_file_(std::string x, const std::string& path, bool append);
-RcppExport SEXP readr_write_file_(SEXP xSEXP, SEXP pathSEXP, SEXP appendSEXP) {
-BEGIN_RCPP
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< std::string >::type x(xSEXP);
-    Rcpp::traits::input_parameter< const std::string& >::type path(pathSEXP);
-    Rcpp::traits::input_parameter< bool >::type append(appendSEXP);
-    write_file_(x, path, append);
-    return R_NilValue;
-END_RCPP
-}
-// write_file_connection_
-void write_file_connection_(std::string x, RObject connection);
-RcppExport SEXP readr_write_file_connection_(SEXP xSEXP, SEXP connectionSEXP) {
+void write_file_(std::string x, RObject connection);
+RcppExport SEXP readr_write_file_(SEXP xSEXP, SEXP connectionSEXP) {
 BEGIN_RCPP
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< std::string >::type x(xSEXP);
     Rcpp::traits::input_parameter< RObject >::type connection(connectionSEXP);
-    write_file_connection_(x, connection);
+    write_file_(x, connection);
+    return R_NilValue;
+END_RCPP
+}
+// write_file_raw_
+void write_file_raw_(RawVector x, RObject connection);
+RcppExport SEXP readr_write_file_raw_(SEXP xSEXP, SEXP connectionSEXP) {
+BEGIN_RCPP
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< RawVector >::type x(xSEXP);
+    Rcpp::traits::input_parameter< RObject >::type connection(connectionSEXP);
+    write_file_raw_(x, connection);
     return R_NilValue;
 END_RCPP
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -254,9 +254,9 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// stream_delim
-std::string stream_delim(const List& df, const std::string& path, char delim, const std::string& na, bool col_names, bool append, bool bom);
-RcppExport SEXP readr_stream_delim(SEXP dfSEXP, SEXP pathSEXP, SEXP delimSEXP, SEXP naSEXP, SEXP col_namesSEXP, SEXP appendSEXP, SEXP bomSEXP) {
+// stream_delim_file
+std::string stream_delim_file(const List& df, const std::string& path, char delim, const std::string& na, bool col_names, bool append, bool bom);
+RcppExport SEXP readr_stream_delim_file(SEXP dfSEXP, SEXP pathSEXP, SEXP delimSEXP, SEXP naSEXP, SEXP col_namesSEXP, SEXP appendSEXP, SEXP bomSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -267,8 +267,24 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< bool >::type col_names(col_namesSEXP);
     Rcpp::traits::input_parameter< bool >::type append(appendSEXP);
     Rcpp::traits::input_parameter< bool >::type bom(bomSEXP);
-    rcpp_result_gen = Rcpp::wrap(stream_delim(df, path, delim, na, col_names, append, bom));
+    rcpp_result_gen = Rcpp::wrap(stream_delim_file(df, path, delim, na, col_names, append, bom));
     return rcpp_result_gen;
+END_RCPP
+}
+// stream_delim_connection
+void stream_delim_connection(const List& df, RObject connection, char delim, const std::string& na, bool col_names, bool append, bool bom);
+RcppExport SEXP readr_stream_delim_connection(SEXP dfSEXP, SEXP connectionSEXP, SEXP delimSEXP, SEXP naSEXP, SEXP col_namesSEXP, SEXP appendSEXP, SEXP bomSEXP) {
+BEGIN_RCPP
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const List& >::type df(dfSEXP);
+    Rcpp::traits::input_parameter< RObject >::type connection(connectionSEXP);
+    Rcpp::traits::input_parameter< char >::type delim(delimSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type na(naSEXP);
+    Rcpp::traits::input_parameter< bool >::type col_names(col_namesSEXP);
+    Rcpp::traits::input_parameter< bool >::type append(appendSEXP);
+    Rcpp::traits::input_parameter< bool >::type bom(bomSEXP);
+    stream_delim_connection(df, connection, delim, na, col_names, append, bom);
+    return R_NilValue;
 END_RCPP
 }
 // write_lines_
@@ -284,6 +300,18 @@ BEGIN_RCPP
     return R_NilValue;
 END_RCPP
 }
+// write_lines_connection_
+void write_lines_connection_(const CharacterVector& lines, RObject connection, const std::string& na);
+RcppExport SEXP readr_write_lines_connection_(SEXP linesSEXP, SEXP connectionSEXP, SEXP naSEXP) {
+BEGIN_RCPP
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const CharacterVector& >::type lines(linesSEXP);
+    Rcpp::traits::input_parameter< RObject >::type connection(connectionSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type na(naSEXP);
+    write_lines_connection_(lines, connection, na);
+    return R_NilValue;
+END_RCPP
+}
 // write_lines_raw_
 void write_lines_raw_(List x, const std::string& path, bool append);
 RcppExport SEXP readr_write_lines_raw_(SEXP xSEXP, SEXP pathSEXP, SEXP appendSEXP) {
@@ -293,6 +321,17 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const std::string& >::type path(pathSEXP);
     Rcpp::traits::input_parameter< bool >::type append(appendSEXP);
     write_lines_raw_(x, path, append);
+    return R_NilValue;
+END_RCPP
+}
+// write_lines_raw_connection_
+void write_lines_raw_connection_(List x, RObject connection);
+RcppExport SEXP readr_write_lines_raw_connection_(SEXP xSEXP, SEXP connectionSEXP) {
+BEGIN_RCPP
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< List >::type x(xSEXP);
+    Rcpp::traits::input_parameter< RObject >::type connection(connectionSEXP);
+    write_lines_raw_connection_(x, connection);
     return R_NilValue;
 END_RCPP
 }
@@ -308,6 +347,17 @@ BEGIN_RCPP
     return R_NilValue;
 END_RCPP
 }
+// write_file_raw_connection_
+void write_file_raw_connection_(RawVector x, RObject connection);
+RcppExport SEXP readr_write_file_raw_connection_(SEXP xSEXP, SEXP connectionSEXP) {
+BEGIN_RCPP
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< RawVector >::type x(xSEXP);
+    Rcpp::traits::input_parameter< RObject >::type connection(connectionSEXP);
+    write_file_raw_connection_(x, connection);
+    return R_NilValue;
+END_RCPP
+}
 // write_file_
 void write_file_(std::string x, const std::string& path, bool append);
 RcppExport SEXP readr_write_file_(SEXP xSEXP, SEXP pathSEXP, SEXP appendSEXP) {
@@ -317,6 +367,17 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const std::string& >::type path(pathSEXP);
     Rcpp::traits::input_parameter< bool >::type append(appendSEXP);
     write_file_(x, path, append);
+    return R_NilValue;
+END_RCPP
+}
+// write_file_connection_
+void write_file_connection_(std::string x, RObject connection);
+RcppExport SEXP readr_write_file_connection_(SEXP xSEXP, SEXP connectionSEXP) {
+BEGIN_RCPP
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< std::string >::type x(xSEXP);
+    Rcpp::traits::input_parameter< RObject >::type connection(connectionSEXP);
+    write_file_connection_(x, connection);
     return R_NilValue;
 END_RCPP
 }

--- a/src/write.cpp
+++ b/src/write.cpp
@@ -2,6 +2,8 @@
 using namespace Rcpp;
 #include <ostream>
 #include <fstream>
+#include "write_connection.h"
+#include <boost/iostreams/stream.hpp> // stream
 
 // [[Rcpp::export]]
 void write_lines_(const CharacterVector &lines, const std::string &path, const std::string& na, bool append = false) {
@@ -10,6 +12,21 @@ void write_lines_(const CharacterVector &lines, const std::string &path, const s
   if (output.fail()) {
     stop("Failed to open '%s'.", path);
   }
+  for (CharacterVector::const_iterator i = lines.begin(); i != lines.end(); ++i) {
+
+    if (CharacterVector::is_na(*i)) {
+      output << na << '\n';
+    } else {
+      output << Rf_translateCharUTF8(*i) << '\n';
+    }
+  }
+
+  return;
+}
+
+// [[Rcpp::export]]
+void write_lines_connection_(const CharacterVector &lines, RObject connection, const std::string& na) {
+  boost::iostreams::stream<connection_sink> output(connection);
   for (CharacterVector::const_iterator i = lines.begin(); i != lines.end(); ++i) {
 
     if (CharacterVector::is_na(*i)) {
@@ -41,6 +58,21 @@ void write_lines_raw_(List x, const std::string &path, bool append = false) {
 }
 
 // [[Rcpp::export]]
+void write_lines_raw_connection_(List x, RObject connection) {
+
+  boost::iostreams::stream<connection_sink> output(connection);
+
+  std::ostream_iterator<char> out = std::ostream_iterator<char>(output);
+  for (int i = 0;i < x.length();++i) {
+    RawVector y = x.at(i);
+    std::copy(y.begin(), y.end(), out);
+    *out++ = '\n';
+  }
+
+  return;
+}
+
+// [[Rcpp::export]]
 void write_file_raw_(RawVector x, const std::string &path, bool append = false) {
   std::ofstream output(path.c_str(), std::ofstream::binary | (append ? std::ofstream::app : std::ofstream::trunc));
 
@@ -48,6 +80,15 @@ void write_file_raw_(RawVector x, const std::string &path, bool append = false) 
     stop("Failed to open '%s'.", path);
   }
 
+  std::copy(x.begin(), x.end(), std::ostream_iterator<char>(output));
+
+  return;
+}
+
+// [[Rcpp::export]]
+void write_file_raw_connection_(RawVector x, RObject connection) {
+
+  boost::iostreams::stream<connection_sink> output(connection);
   std::copy(x.begin(), x.end(), std::ostream_iterator<char>(output));
 
   return;
@@ -63,5 +104,12 @@ void write_file_(std::string x, const std::string &path, bool append = false) {
 
   std::copy(x.begin(), x.end(), std::ostream_iterator<char>(output));
 
+  return;
+}
+
+// [[Rcpp::export]]
+void write_file_connection_(std::string x, RObject connection) {
+  boost::iostreams::stream<connection_sink> out(connection);
+  out << x;
   return;
 }

--- a/src/write.cpp
+++ b/src/write.cpp
@@ -6,26 +6,7 @@ using namespace Rcpp;
 #include <boost/iostreams/stream.hpp> // stream
 
 // [[Rcpp::export]]
-void write_lines_(const CharacterVector &lines, const std::string &path, const std::string& na, bool append = false) {
-
-  std::ofstream output(path.c_str(), std::ofstream::binary | (append ? std::ofstream::app : std::ofstream::trunc));
-  if (output.fail()) {
-    stop("Failed to open '%s'.", path);
-  }
-  for (CharacterVector::const_iterator i = lines.begin(); i != lines.end(); ++i) {
-
-    if (CharacterVector::is_na(*i)) {
-      output << na << '\n';
-    } else {
-      output << Rf_translateCharUTF8(*i) << '\n';
-    }
-  }
-
-  return;
-}
-
-// [[Rcpp::export]]
-void write_lines_connection_(const CharacterVector &lines, RObject connection, const std::string& na) {
+void write_lines_(const CharacterVector &lines, RObject connection, const std::string& na) {
   boost::iostreams::stream<connection_sink> output(connection);
   for (CharacterVector::const_iterator i = lines.begin(); i != lines.end(); ++i) {
 
@@ -40,76 +21,32 @@ void write_lines_connection_(const CharacterVector &lines, RObject connection, c
 }
 
 // [[Rcpp::export]]
-void write_lines_raw_(List x, const std::string &path, bool append = false) {
-  std::ofstream output(path.c_str(), std::ofstream::binary | (append ? std::ofstream::app : std::ofstream::trunc));
-
-  if (output.fail()) {
-    stop("Failed to open '%s'.", path);
-  }
-
-  std::ostream_iterator<char> out = std::ostream_iterator<char>(output);
-  for (int i = 0;i < x.length();++i) {
-    RawVector y = x.at(i);
-    std::copy(y.begin(), y.end(), out);
-    *out++ = '\n';
-  }
-
-  return;
-}
-
-// [[Rcpp::export]]
-void write_lines_raw_connection_(List x, RObject connection) {
+void write_lines_raw_(List x, RObject connection) {
 
   boost::iostreams::stream<connection_sink> output(connection);
 
-  std::ostream_iterator<char> out = std::ostream_iterator<char>(output);
   for (int i = 0;i < x.length();++i) {
     RawVector y = x.at(i);
-    std::copy(y.begin(), y.end(), out);
-    *out++ = '\n';
+    output.write(reinterpret_cast<const char*>(&y[0]), y.size() * sizeof(y[0]));
+    output << '\n';
   }
 
   return;
 }
 
 // [[Rcpp::export]]
-void write_file_raw_(RawVector x, const std::string &path, bool append = false) {
-  std::ofstream output(path.c_str(), std::ofstream::binary | (append ? std::ofstream::app : std::ofstream::trunc));
-
-  if (output.fail()) {
-    stop("Failed to open '%s'.", path);
-  }
-
-  std::copy(x.begin(), x.end(), std::ostream_iterator<char>(output));
-
-  return;
-}
-
-// [[Rcpp::export]]
-void write_file_raw_connection_(RawVector x, RObject connection) {
-
-  boost::iostreams::stream<connection_sink> output(connection);
-  std::copy(x.begin(), x.end(), std::ostream_iterator<char>(output));
-
-  return;
-}
-
-// [[Rcpp::export]]
-void write_file_(std::string x, const std::string &path, bool append = false) {
-  std::ofstream output(path.c_str(), std::ofstream::binary | (append ? std::ofstream::app : std::ofstream::trunc));
-
-  if (output.fail()) {
-    stop("Failed to open '%s'.", path);
-  }
-
-  std::copy(x.begin(), x.end(), std::ostream_iterator<char>(output));
-
-  return;
-}
-
-// [[Rcpp::export]]
-void write_file_connection_(std::string x, RObject connection) {
+void write_file_(std::string x, RObject connection) {
   boost::iostreams::stream<connection_sink> out(connection);
+
   out << x;
+  return;
+}
+
+// [[Rcpp::export]]
+void write_file_raw_(RawVector x, RObject connection) {
+
+  boost::iostreams::stream<connection_sink> output(connection);
+
+  output.write(reinterpret_cast<const char*>(&x[0]), x.size() * sizeof(x[0]));
   return;
 }

--- a/src/write_connection.cpp
+++ b/src/write_connection.cpp
@@ -1,0 +1,41 @@
+#include "write_connection.h"
+
+#define class class_name
+#define private private_ptr
+#include <R_ext/Connections.h>
+#undef class
+#undef private
+
+#if R_CONNECTIONS_VERSION != 1
+#error "Missing or unsupported connection API in R"
+#endif
+
+#if defined(R_VERSION) && R_VERSION >= R_Version(3, 3, 0)
+Rconnection get_connection(SEXP con) {
+  return R_GetConnection(con);
+}
+# else
+extern "C" {
+    extern Rconnection getConnection(int) ;
+}
+Rconnection get_connection(SEXP con) {
+  if (!Rf_inherits(con, "connection")) Rcpp::stop("invalid connection");
+  return getConnection(Rf_asInteger(con));
+}
+#endif
+
+// http://www.boost.org/doc/libs/1_63_0/libs/iostreams/doc/tutorial/container_sink.html
+//
+namespace io = boost::iostreams;
+
+connection_sink::connection_sink(SEXP con) {
+  con_ = get_connection(con);
+}
+std::streamsize connection_sink::write(const char* s, std::streamsize n) {
+  size_t write_size;
+
+  if ((write_size = R_WriteConnection(con_, (void *) s, n)) != n) {
+    Rcpp::stop("write failed, expected %l, got %l", n, write_size);
+  }
+  return write_size;
+}

--- a/src/write_connection.h
+++ b/src/write_connection.h
@@ -1,0 +1,26 @@
+#ifndef READR_WRITE_CONNECTION_H_
+#define READR_WRITE_CONNECTION_H_
+
+#include <ios>                          // streamsize
+#include <boost/iostreams/categories.hpp>  // sink_tag
+#include <Rcpp.h>
+
+typedef struct Rconn * Rconnection;
+Rconnection get_connection(SEXP con);
+
+// http://www.boost.org/doc/libs/1_63_0/libs/iostreams/doc/tutorial/container_sink.html
+namespace io = boost::iostreams;
+
+class connection_sink {
+private:
+  Rconnection con_;
+
+public:
+    typedef char      char_type;
+    typedef io::sink_tag  category;
+
+    connection_sink(SEXP con);
+    std::streamsize write(const char* s, std::streamsize n);
+};
+
+#endif

--- a/src/write_delim.cpp
+++ b/src/write_delim.cpp
@@ -57,7 +57,7 @@ void stream_delim(Stream& output, const char* string, char delim, const std::str
 
 template <class Stream>
 void stream_delim(Stream& output, const List& df, char delim, const std::string& na,
-                  bool col_names = true, bool append = false, bool bom = false) {
+                  bool col_names = true, bool bom = false) {
   int p = Rf_length(df);
   if (p == 0)
     return;
@@ -85,30 +85,18 @@ void stream_delim(Stream& output, const List& df, char delim, const std::string&
 }
 
 // [[Rcpp::export]]
-std::string stream_delim_file(const List& df, const std::string& path, char delim, const std::string& na,
-                         bool col_names = true, bool append = false, bool bom = false) {
-
-  if (path == "") {
+std::string stream_delim_(const List& df, RObject connection, char delim, const std::string& na,
+                         bool col_names = true, bool bom = false) {
+  if (connection == R_NilValue) {
     std::ostringstream output;
-
-    stream_delim(output, df, delim, na, col_names, append, bom);
+    stream_delim(output, df, delim, na, col_names, bom);
     return output.str();
   } else {
-    std::ofstream output(path.c_str(), append ? std::ofstream::app : std::ofstream::trunc);
-    if (output.fail()) {
-      stop("Failed to open '%s'.", path);
-    }
-    stream_delim(output, df, delim, na, col_names, append, bom);
-    return "";
+    boost::iostreams::stream<connection_sink> output(connection);
+    stream_delim(output, df, delim, na, col_names, bom);
   }
-}
 
-// [[Rcpp::export]]
-void stream_delim_connection(const List& df, RObject connection, char delim, const std::string& na,
-                         bool col_names = true, bool append = false, bool bom = false) {
-  boost::iostreams::stream<connection_sink> output(connection);
-  stream_delim(output, df, delim, na, col_names, append, bom);
-  return;
+  return "";
 }
 
 // =============================================================================

--- a/src/write_delim.cpp
+++ b/src/write_delim.cpp
@@ -2,6 +2,8 @@
 using namespace Rcpp;
 #include <fstream>
 #include "grisu3.h"
+#include "write_connection.h"
+#include <boost/iostreams/stream.hpp> // stream
 
 // Defined later to make copyright clearer
 template <class Stream>
@@ -83,7 +85,7 @@ void stream_delim(Stream& output, const List& df, char delim, const std::string&
 }
 
 // [[Rcpp::export]]
-std::string stream_delim(const List& df, const std::string& path, char delim, const std::string& na,
+std::string stream_delim_file(const List& df, const std::string& path, char delim, const std::string& na,
                          bool col_names = true, bool append = false, bool bom = false) {
 
   if (path == "") {
@@ -99,6 +101,14 @@ std::string stream_delim(const List& df, const std::string& path, char delim, co
     stream_delim(output, df, delim, na, col_names, append, bom);
     return "";
   }
+}
+
+// [[Rcpp::export]]
+void stream_delim_connection(const List& df, RObject connection, char delim, const std::string& na,
+                         bool col_names = true, bool append = false, bool bom = false) {
+  boost::iostreams::stream<connection_sink> output(connection);
+  stream_delim(output, df, delim, na, col_names, append, bom);
+  return;
 }
 
 // =============================================================================

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -4,3 +4,10 @@
 all.equal.tbl_df <- function(target, current, ..., check.attributes = FALSE) {
   all.equal.list(target, current, ..., check.attributes = check.attributes)
 }
+
+is_bz2_file <- function(x) {
+
+  # Magic number for bz2 is "BZh" in ASCII
+  # https://en.wikipedia.org/wiki/Bzip2#File_format
+  identical(charToRaw("BZh"), readBin(x, n = 3, what = "raw"))
+}

--- a/tests/testthat/test-read-fwf.R
+++ b/tests/testthat/test-read-fwf.R
@@ -126,3 +126,23 @@ test_that("error on empty spec (#511, #519)", {
   pos = fwf_positions(start = numeric(0), end = numeric(0))
   expect_error(read_fwf(txt, pos), "Zero-length.*specifications not supported")
 })
+
+# read_table -------------------------------------------------------------------
+
+test_that("read_table silently reads ragged last column", {
+  x <- read_table("foo bar\n1   2\n3   4\n5   6\n", progress = FALSE)
+  expect_equal(x$foo, c(1, 3, 5))
+})
+
+test_that("read_table skips all comment lines", {
+  x <- read_table("foo bar\n1   2\n3   4\n5   6\n", progress = FALSE)
+
+  y <- read_table("#comment1\n#comment2\nfoo bar\n1   2\n3   4\n5   6\n", progress = FALSE, comment = "#")
+
+  expect_equal(x, y)
+})
+
+test_that("read_table can read from a pipe (552)", {
+  x <- read_table(pipe("echo a b c && echo 1 2 3 && echo 4 5 6"), progress = FALSE)
+  expect_equal(x$a, c(1, 4))
+})

--- a/tests/testthat/test-write-delim.R
+++ b/tests/testthat/test-write-delim.R
@@ -58,7 +58,7 @@ test_that("roundtrip preserves dates and datetimes", {
 })
 
 test_that("fails to create file in non-existent directory", {
-  expect_error(write_csv(mtcars, file.path(tempdir(), "/x/y")), "Failed to open")
+  expect_warning(expect_error(write_csv(mtcars, file.path(tempdir(), "/x/y")), "cannot open the connection"), "No such file or directory")
 })
 
 test_that("write_excel_csv includes a byte order mark", {

--- a/tests/testthat/test-write-delim.R
+++ b/tests/testthat/test-write-delim.R
@@ -99,5 +99,7 @@ test_that("write_csv can write to compressed files", {
   filename <- file.path(tempdir(), "mtcars.csv.bz2")
   on.exit(unlink(filename))
   write_csv(mt, filename)
+
+  expect_true(is_bz2_file(filename))
   expect_equal(mt, read_csv(filename))
 })

--- a/tests/testthat/test-write-delim.R
+++ b/tests/testthat/test-write-delim.R
@@ -92,3 +92,12 @@ test_that("does not writes a tailing .0 for whole number doubles", {
 
   expect_equal(format_tsv(tibble::data_frame(x = -123456789)), "x\n-123456789\n")
 })
+
+test_that("write_csv can write to compressed files", {
+  mt <- read_csv(readr_example("mtcars.csv.bz2"))
+
+  filename <- file.path(tempdir(), "mtcars.csv.bz2")
+  on.exit(unlink(filename))
+  write_csv(mt, filename)
+  expect_equal(mt, read_csv(filename))
+})

--- a/tests/testthat/test-write-lines.R
+++ b/tests/testthat/test-write-lines.R
@@ -101,6 +101,8 @@ test_that("write_lines can write to compressed files", {
   filename <- file.path(tempdir(), "mtcars.csv.bz2")
   on.exit(unlink(filename))
   write_lines(mt, filename)
+
+  expect_true(is_bz2_file(filename))
   expect_equal(mt, read_lines(filename))
 })
 
@@ -111,5 +113,7 @@ test_that("write_file can write to compressed files", {
   filename <- file.path(tempdir(), "mtcars.csv.bz2")
   on.exit(unlink(filename))
   write_file(mt, filename)
+
+  expect_true(is_bz2_file(filename))
   expect_equal(mt, read_file(filename))
 })

--- a/tests/testthat/test-write-lines.R
+++ b/tests/testthat/test-write-lines.R
@@ -93,3 +93,23 @@ test_that("write_file with raw round trips with an empty vector", {
 
   expect_equal(read_file_raw(tmp), x)
 })
+
+test_that("write_lines can write to compressed files", {
+
+  mt <- read_lines(readr_example("mtcars.csv.bz2"))
+
+  filename <- file.path(tempdir(), "mtcars.csv.bz2")
+  on.exit(unlink(filename))
+  write_lines(mt, filename)
+  expect_equal(mt, read_lines(filename))
+})
+
+test_that("write_file can write to compressed files", {
+
+  mt <- read_file(readr_example("mtcars.csv.bz2"))
+
+  filename <- file.path(tempdir(), "mtcars.csv.bz2")
+  on.exit(unlink(filename))
+  write_file(mt, filename)
+  expect_equal(mt, read_file(filename))
+})


### PR DESCRIPTION
Fixes #348 

This still needs documentation, more tests and examples, but works pretty well.

The connection writing uses [boost::iostreams](http://www.boost.org/doc/libs/1_63_0/libs/iostreams/doc/), so is nicely buffered and should be pretty performant.