### PR TITLE
Simplify the modulus expression

### DIFF
--- a/src/TokenizerDelim.cpp
+++ b/src/TokenizerDelim.cpp
@@ -61,7 +61,7 @@ Token TokenizerDelim::nextToken() {
     if (*cur_ == '\0')
       hasNull = true;
 
-    if ((row_ + 1) % 100000 == 0 || (col_ + 1) % 100000 == 0)
+    if ((end_ - cur_) % 131072 == 0)
       Rcpp::checkUserInterrupt();
 
     switch(state_) {


### PR DESCRIPTION
Using a modulo power of 2 lets the compiler simplify the expression into
an and, which requires far fewer (and lest costly) instructions. This
also avoids the expression returning true for the entire row 10000. See
https://godbolt.org/g/N1TLPY for the generated assembly for each
alternative.

This gives us a fairly minor ~7%, but consistent execution increase over the
previous behavior.

    Unit: seconds
           expr      min       lq     mean   median       uq      max neval
        current 2.145237 2.159644 2.231668 2.225491 2.259040 2.469164    10
     simplified 1.967682 2.062774 2.075334 2.072157 2.097775 2.186902    10

![modulus](https://cloud.githubusercontent.com/assets/205275/23381789/ce16c670-fd0d-11e6-8151-13e8474c45ab.png)
