### PR TITLE
List files with readr_example() and remove internal keyword

### DIFF
--- a/R/example.R
+++ b/R/example.R
@@ -3,11 +3,15 @@
 #' readr comes bundled with a number of sample files in its `inst/extdata`
 #' directory. This function make them easy to access
 #'
-#' @param path Name of file
+#' @param path Name of file. If `NULL`, the example files will be listed.
 #' @export
-#' @keywords internal
 #' @examples
+#' readr_example()
 #' readr_example("challenge.csv")
-readr_example <- function(path) {
-  system.file("extdata", path, package = "readr", mustWork = TRUE)
+readr_example <- function(path = NULL) {
+  if (is.null(path)) {
+    dir(system.file("extdata", package = "readr"))
+  } else {
+    system.file("extdata", path, package = "readr", mustWork = TRUE)
+  }
 }

--- a/man/readr_example.Rd
+++ b/man/readr_example.Rd
@@ -4,16 +4,16 @@
 \alias{readr_example}
 \title{Get path to readr example}
 \usage{
-readr_example(path)
+readr_example(path = NULL)
 }
 \arguments{
-\item{path}{Name of file}
+\item{path}{Name of file. If \code{NULL}, the example files will be listed.}
 }
 \description{
 readr comes bundled with a number of sample files in its \code{inst/extdata}
 directory. This function make them easy to access
 }
 \examples{
+readr_example()
 readr_example("challenge.csv")
 }
-\keyword{internal}


### PR DESCRIPTION
I think it's nice to list the possible examples when `path` is unspecified. I also expected to see `readr_example()` in the help index. I think it's fine to remove the internal keyword, yes?