### PR TITLE
Remove references to the removed column-types vignettes

### DIFF
--- a/R/read_delim.R
+++ b/R/read_delim.R
@@ -27,7 +27,7 @@ NULL
 #'   in with dummy names `X1`, `X2` etc. Duplicate column names
 #'   will generate a warning and be made unique with a numeric prefix.
 #' @param col_types One of `NULL`, a [cols()] specification, or
-#'   a string. See `vignette("column-types")` for more details.
+#'   a string. See `vignette("readr")` for more details.
 #'
 #'   If `NULL`, all column types will be imputed from the first 1000 rows
 #'   on the input. This is convenient (and fast), but not robust. If the

--- a/R/type_convert.R
+++ b/R/type_convert.R
@@ -7,7 +7,7 @@
 #'
 #' @param df A data frame.
 #' @param col_types One of `NULL`, a [cols()] specification, or
-#'   a string. See `vignette("column-types")` for more details.
+#'   a string. See `vignette("readr")` for more details.
 #'
 #'   If `NULL`, all column types will be imputed from the first 1000 rows
 #'   on the input. This is convenient (and fast), but not robust. If the

--- a/README.Rmd
+++ b/README.Rmd
@@ -82,7 +82,7 @@ mtcars <- read_csv(readr_example("mtcars.csv"), col_types =
 )
 ```
 
-`vignette("column-types")` gives more detail on how readr guess the column types, how you can override the defaults, and provides some useful tools for debugging parsing problems.
+`vignette("readr")` gives more detail on how readr guess the column types, how you can override the defaults, and provides some useful tools for debugging parsing problems.
 
 ## Alternatives
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ mtcars <- read_csv(readr_example("mtcars.csv"), col_types =
 )
 ```
 
-`vignette("column-types")` gives more detail on how readr guess the column types, how you can override the defaults, and provides some useful tools for debugging parsing problems.
+`vignette("readr")` gives more detail on how readr guess the column types, how you can override the defaults, and provides some useful tools for debugging parsing problems.
 
 Alternatives
 ------------

--- a/man/read_delim.Rd
+++ b/man/read_delim.Rd
@@ -70,7 +70,7 @@ in with dummy names \code{X1}, \code{X2} etc. Duplicate column names
 will generate a warning and be made unique with a numeric prefix.}
 
 \item{col_types}{One of \code{NULL}, a \code{\link[=cols]{cols()}} specification, or
-a string. See \code{vignette("column-types")} for more details.
+a string. See \code{vignette("readr")} for more details.
 
 If \code{NULL}, all column types will be imputed from the first 1000 rows
 on the input. This is convenient (and fast), but not robust. If the

--- a/man/read_delim_chunked.Rd
+++ b/man/read_delim_chunked.Rd
@@ -74,7 +74,7 @@ in with dummy names \code{X1}, \code{X2} etc. Duplicate column names
 will generate a warning and be made unique with a numeric prefix.}
 
 \item{col_types}{One of \code{NULL}, a \code{\link[=cols]{cols()}} specification, or
-a string. See \code{vignette("column-types")} for more details.
+a string. See \code{vignette("readr")} for more details.
 
 If \code{NULL}, all column types will be imputed from the first 1000 rows
 on the input. This is convenient (and fast), but not robust. If the

--- a/man/read_fwf.Rd
+++ b/man/read_fwf.Rd
@@ -39,7 +39,7 @@ use \code{\link[=fwf_positions]{fwf_positions()}}. If the width of the last colu
 ragged fwf file), supply the last end position as NA.}
 
 \item{col_types}{One of \code{NULL}, a \code{\link[=cols]{cols()}} specification, or
-a string. See \code{vignette("column-types")} for more details.
+a string. See \code{vignette("readr")} for more details.
 
 If \code{NULL}, all column types will be imputed from the first 1000 rows
 on the input. This is convenient (and fast), but not robust. If the

--- a/man/read_log.Rd
+++ b/man/read_log.Rd
@@ -36,7 +36,7 @@ in with dummy names \code{X1}, \code{X2} etc. Duplicate column names
 will generate a warning and be made unique with a numeric prefix.}
 
 \item{col_types}{One of \code{NULL}, a \code{\link[=cols]{cols()}} specification, or
-a string. See \code{vignette("column-types")} for more details.
+a string. See \code{vignette("readr")} for more details.
 
 If \code{NULL}, all column types will be imputed from the first 1000 rows
 on the input. This is convenient (and fast), but not robust. If the

--- a/man/read_table.Rd
+++ b/man/read_table.Rd
@@ -42,7 +42,7 @@ in with dummy names \code{X1}, \code{X2} etc. Duplicate column names
 will generate a warning and be made unique with a numeric prefix.}
 
 \item{col_types}{One of \code{NULL}, a \code{\link[=cols]{cols()}} specification, or
-a string. See \code{vignette("column-types")} for more details.
+a string. See \code{vignette("readr")} for more details.
 
 If \code{NULL}, all column types will be imputed from the first 1000 rows
 on the input. This is convenient (and fast), but not robust. If the

--- a/man/spec_delim.Rd
+++ b/man/spec_delim.Rd
@@ -75,7 +75,7 @@ in with dummy names \code{X1}, \code{X2} etc. Duplicate column names
 will generate a warning and be made unique with a numeric prefix.}
 
 \item{col_types}{One of \code{NULL}, a \code{\link[=cols]{cols()}} specification, or
-a string. See \code{vignette("column-types")} for more details.
+a string. See \code{vignette("readr")} for more details.
 
 If \code{NULL}, all column types will be imputed from the first 1000 rows
 on the input. This is convenient (and fast), but not robust. If the

--- a/man/type_convert.Rd
+++ b/man/type_convert.Rd
@@ -11,7 +11,7 @@ type_convert(df, col_types = NULL, na = c("", "NA"), trim_ws = TRUE,
 \item{df}{A data frame.}
 
 \item{col_types}{One of \code{NULL}, a \code{\link[=cols]{cols()}} specification, or
-a string. See \code{vignette("column-types")} for more details.
+a string. See \code{vignette("readr")} for more details.
 
 If \code{NULL}, all column types will be imputed from the first 1000 rows
 on the input. This is convenient (and fast), but not robust. If the


### PR DESCRIPTION
I rebuilt the pkgdown site locally, but the diff was bigger than I was expecting, so I did not include that in this PR. 