### PR TITLE
`write_file()` gains a `sep` argument, to specify the line separator

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * Add `write_excel_csv2()` function to allow writing csv files with comma as a decimal separator and semicolon    as a column separator (#753, @olgamie).
 * `read_*()` files now support reading from the clipboard by using `clipboard()` (#656).
+* `write_file()` gains a `sep` argument, to specify the line separator (#665).
 
 * Column guessing will now never guess an integer type. This avoids issues
   where double columns are incorrectly guessed as integers if they have only

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -77,12 +77,12 @@ stream_delim_ <- function(df, connection, delim, na, col_names = TRUE, bom = FAL
     .Call(`_readr_stream_delim_`, df, connection, delim, na, col_names, bom)
 }
 
-write_lines_ <- function(lines, connection, na) {
-    invisible(.Call(`_readr_write_lines_`, lines, connection, na))
+write_lines_ <- function(lines, connection, na, sep = "\n") {
+    invisible(.Call(`_readr_write_lines_`, lines, connection, na, sep))
 }
 
-write_lines_raw_ <- function(x, connection) {
-    invisible(.Call(`_readr_write_lines_raw_`, x, connection))
+write_lines_raw_ <- function(x, connection, sep = "\n") {
+    invisible(.Call(`_readr_write_lines_raw_`, x, connection, sep))
 }
 
 write_file_ <- function(x, connection) {

--- a/R/lines.R
+++ b/R/lines.R
@@ -12,6 +12,9 @@
 #'   file will be read.
 #' @return `read_lines()`: A character vector with one element for each line.
 #'   `read_lines_raw()`: A list containing a raw vector for each line.
+#' @param sep The line separator. Defaults to `\\n`, commonly used on POSIX
+#' systems like macOS and linux. For native windows (CRLF) separators use
+#' `\\r\\n`.
 #' @export
 #' @examples
 #' read_lines(file.path(R.home("doc"), "AUTHORS"), n_max = 10)
@@ -50,7 +53,7 @@ read_lines_raw <- function(file, skip = 0, n_max = -1L, progress = show_progress
 #' @return `write_lines()` returns `x`, invisibly.
 #' @export
 #' @rdname read_lines
-write_lines <- function(x, path, na = "NA", append = FALSE) {
+write_lines <- function(x, path, sep = "\n", na = "NA", append = FALSE) {
   is_raw <- is.list(x) && inherits(x[[1]], "raw")
   if (!is_raw) {
     x <- as.character(x)
@@ -62,9 +65,9 @@ write_lines <- function(x, path, na = "NA", append = FALSE) {
     open(path, if (isTRUE(append)) "ab" else "wb")
   }
   if (is_raw) {
-    write_lines_raw_(x, path)
+    write_lines_raw_(x, path, sep)
   } else {
-    write_lines_(x, path, na)
+    write_lines_(x, path, na, sep)
   }
 
   invisible(x)

--- a/man/read_lines.Rd
+++ b/man/read_lines.Rd
@@ -11,7 +11,7 @@ read_lines(file, skip = 0, n_max = -1L, locale = default_locale(),
 
 read_lines_raw(file, skip = 0, n_max = -1L, progress = show_progress())
 
-write_lines(x, path, na = "NA", append = FALSE)
+write_lines(x, path, sep = "\\n", na = "NA", append = FALSE)
 }
 \arguments{
 \item{file}{Either a path to a file, a connection, or literal data
@@ -52,6 +52,10 @@ setting option \code{readr.show_progress} to \code{FALSE}.}
 \item{x}{A data frame to write to disk}
 
 \item{path}{Path or connection to write to.}
+
+\item{sep}{The line separator. Defaults to \code{\\n}, commonly used on POSIX
+systems like macOS and linux. For native windows (CRLF) separators use
+\code{\\r\\n}.}
 
 \item{append}{If \code{FALSE}, will overwrite existing file. If \code{TRUE},
 will append to existing file. In both cases, if file does not exist a new

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -271,25 +271,27 @@ BEGIN_RCPP
 END_RCPP
 }
 // write_lines_
-void write_lines_(const CharacterVector& lines, RObject connection, const std::string& na);
-RcppExport SEXP _readr_write_lines_(SEXP linesSEXP, SEXP connectionSEXP, SEXP naSEXP) {
+void write_lines_(const CharacterVector& lines, RObject connection, const std::string& na, const std::string& sep);
+RcppExport SEXP _readr_write_lines_(SEXP linesSEXP, SEXP connectionSEXP, SEXP naSEXP, SEXP sepSEXP) {
 BEGIN_RCPP
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const CharacterVector& >::type lines(linesSEXP);
     Rcpp::traits::input_parameter< RObject >::type connection(connectionSEXP);
     Rcpp::traits::input_parameter< const std::string& >::type na(naSEXP);
-    write_lines_(lines, connection, na);
+    Rcpp::traits::input_parameter< const std::string& >::type sep(sepSEXP);
+    write_lines_(lines, connection, na, sep);
     return R_NilValue;
 END_RCPP
 }
 // write_lines_raw_
-void write_lines_raw_(List x, RObject connection);
-RcppExport SEXP _readr_write_lines_raw_(SEXP xSEXP, SEXP connectionSEXP) {
+void write_lines_raw_(List x, RObject connection, const std::string& sep);
+RcppExport SEXP _readr_write_lines_raw_(SEXP xSEXP, SEXP connectionSEXP, SEXP sepSEXP) {
 BEGIN_RCPP
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< List >::type x(xSEXP);
     Rcpp::traits::input_parameter< RObject >::type connection(connectionSEXP);
-    write_lines_raw_(x, connection);
+    Rcpp::traits::input_parameter< const std::string& >::type sep(sepSEXP);
+    write_lines_raw_(x, connection, sep);
     return R_NilValue;
 END_RCPP
 }
@@ -336,8 +338,8 @@ static const R_CallMethodDef CallEntries[] = {
     {"_readr_whitespaceColumns", (DL_FUNC) &_readr_whitespaceColumns, 3},
     {"_readr_type_convert_col", (DL_FUNC) &_readr_type_convert_col, 6},
     {"_readr_stream_delim_", (DL_FUNC) &_readr_stream_delim_, 6},
-    {"_readr_write_lines_", (DL_FUNC) &_readr_write_lines_, 3},
-    {"_readr_write_lines_raw_", (DL_FUNC) &_readr_write_lines_raw_, 2},
+    {"_readr_write_lines_", (DL_FUNC) &_readr_write_lines_, 4},
+    {"_readr_write_lines_raw_", (DL_FUNC) &_readr_write_lines_raw_, 3},
     {"_readr_write_file_", (DL_FUNC) &_readr_write_file_, 2},
     {"_readr_write_file_raw_", (DL_FUNC) &_readr_write_file_raw_, 2},
     {NULL, NULL, 0}

--- a/src/write.cpp
+++ b/src/write.cpp
@@ -7,15 +7,18 @@ using namespace Rcpp;
 
 // [[Rcpp::export]]
 void write_lines_(
-    const CharacterVector& lines, RObject connection, const std::string& na) {
+    const CharacterVector& lines,
+    RObject connection,
+    const std::string& na,
+    const std::string& sep = "\n") {
   boost::iostreams::stream<connection_sink> output(connection);
   for (CharacterVector::const_iterator i = lines.begin(); i != lines.end();
        ++i) {
 
     if (CharacterVector::is_na(*i)) {
-      output << na << '\n';
+      output << na << sep;
     } else {
-      output << Rf_translateCharUTF8(*i) << '\n';
+      output << Rf_translateCharUTF8(*i) << sep;
     }
   }
 
@@ -23,14 +26,15 @@ void write_lines_(
 }
 
 // [[Rcpp::export]]
-void write_lines_raw_(List x, RObject connection) {
+void write_lines_raw_(
+    List x, RObject connection, const std::string& sep = "\n") {
 
   boost::iostreams::stream<connection_sink> output(connection);
 
   for (int i = 0; i < x.length(); ++i) {
     RawVector y = x.at(i);
     output.write(reinterpret_cast<const char*>(&y[0]), y.size() * sizeof(y[0]));
-    output << '\n';
+    output << sep;
   }
 
   return;

--- a/tests/testthat/test-write-lines.R
+++ b/tests/testthat/test-write-lines.R
@@ -106,6 +106,13 @@ test_that("write_lines can write to compressed files", {
   expect_equal(mt, read_lines(filename))
 })
 
+test_that("write_lines can write CRLF files", {
+  filename <- tempfile()
+  on.exit(unlink(filename))
+  write_lines(c("a", "b", "c"), filename, sep = "\r\n")
+  expect_identical(charToRaw("a\r\nb\r\nc\r\n"), readBin(filename, n = 9, what = "raw"))
+})
+
 test_that("write_file can write to compressed files", {
 
   mt <- read_file(readr_example("mtcars.csv.bz2"))


### PR DESCRIPTION
Fixes #665