### PR TITLE
Provide encoding information to the Source class

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,9 @@
   where double columns are incorrectly guessed as integers if they have only
   integer values in the first 1000 (#645, #652).
 
+* `datasource()` accepts an encoding. This is just ground work needed to parse
+  multibyte encodings (like UTF-16) properly in the future. (#306, #397, @zeehio).
+
 # readr 1.1.0
 
 ## New features

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -65,16 +65,12 @@ guess_types_ <- function(sourceSpec, tokenizerSpec, locale_, n = 100L) {
     .Call('readr_guess_types_', PACKAGE = 'readr', sourceSpec, tokenizerSpec, locale_, n)
 }
 
-whitespaceColumns <- function(sourceSpec, n = 100L, comment = "") {
-    .Call('readr_whitespaceColumns', PACKAGE = 'readr', sourceSpec, n, comment)
+whitespaceColumns <- function(sourceSpec, n = 100L) {
+    .Call('readr_whitespaceColumns', PACKAGE = 'readr', sourceSpec, n)
 }
 
 type_convert_col <- function(x, spec, locale_, col, na, trim_ws) {
     .Call('readr_type_convert_col', PACKAGE = 'readr', x, spec, locale_, col, na, trim_ws)
-}
-
-stream_delim_ <- function(df, connection, delim, na, col_names = TRUE, bom = FALSE) {
-    .Call('readr_stream_delim_', PACKAGE = 'readr', df, connection, delim, na, col_names, bom)
 }
 
 write_lines_ <- function(lines, connection, na) {
@@ -91,5 +87,9 @@ write_file_ <- function(x, connection) {
 
 write_file_raw_ <- function(x, connection) {
     invisible(.Call('readr_write_file_raw_', PACKAGE = 'readr', x, connection))
+}
+
+stream_delim_ <- function(df, connection, delim, na, col_names = TRUE, bom = FALSE) {
+    .Call('readr_stream_delim_', PACKAGE = 'readr', df, connection, delim, na, col_names, bom)
 }
 

--- a/R/col_types.R
+++ b/R/col_types.R
@@ -222,10 +222,15 @@ col_spec_standardise <- function(file, col_names = TRUE, col_types = NULL,
                                  tokenizer = tokenizer_csv(),
                                  locale = default_locale(),
                                  drop_skipped_names = FALSE) {
+  if (missing(locale)) {
+    encoding <- NULL
+  } else {
+    encoding <- locale$encoding
+  }
 
   # Figure out the column names -----------------------------------------------
   if (is.logical(col_names) && length(col_names) == 1) {
-    ds_header <- datasource(file, skip = skip, comment = comment, encoding = locale$encoding)
+    ds_header <- datasource(file, skip = skip, comment = comment, encoding = encoding)
 
     if (col_names) {
       col_names <- guess_header(ds_header, tokenizer, locale)
@@ -353,7 +358,7 @@ col_spec_standardise <- function(file, col_names = TRUE, col_types = NULL,
   is_guess <- vapply(spec$cols, function(x) inherits(x, "collector_guess"), logical(1))
   if (any(is_guess)) {
     if (is.null(guessed_types)) {
-      ds <- datasource(file, skip = skip, comment = comment, encoding = locale$encoding)
+      ds <- datasource(file, skip = skip, comment = comment, encoding = encoding)
       guessed_types <- guess_types(ds, tokenizer, locale, guess_max = guess_max)
     }
 

--- a/R/col_types.R
+++ b/R/col_types.R
@@ -225,7 +225,8 @@ col_spec_standardise <- function(file, col_names = TRUE, col_types = NULL,
 
   # Figure out the column names -----------------------------------------------
   if (is.logical(col_names) && length(col_names) == 1) {
-    ds_header <- datasource(file, skip = skip, comment = comment)
+    ds_header <- datasource(file, skip = skip, comment = comment, encoding = locale$encoding)
+
     if (col_names) {
       col_names <- guess_header(ds_header, tokenizer, locale)
       skip <- skip + 1
@@ -352,7 +353,7 @@ col_spec_standardise <- function(file, col_names = TRUE, col_types = NULL,
   is_guess <- vapply(spec$cols, function(x) inherits(x, "collector_guess"), logical(1))
   if (any(is_guess)) {
     if (is.null(guessed_types)) {
-      ds <- datasource(file, skip = skip, comment = comment)
+      ds <- datasource(file, skip = skip, comment = comment, encoding = locale$encoding)
       guessed_types <- guess_types(ds, tokenizer, locale, guess_max = guess_max)
     }
 

--- a/R/count_fields.R
+++ b/R/count_fields.R
@@ -11,7 +11,7 @@
 #' @export
 #' @examples
 #' count_fields(readr_example("mtcars.csv"), tokenizer_csv())
-count_fields <- function(file, tokenizer, skip = 0, n_max = -1L) {
-  ds <- datasource(file, skip = skip)
+count_fields <- function(file, tokenizer, skip = 0, n_max = -1L, encoding = NULL) {
+  ds <- datasource(file, skip = skip, encoding = encoding)
   count_fields_(ds, tokenizer, n_max)
 }

--- a/R/file.R
+++ b/R/file.R
@@ -27,8 +27,12 @@ read_file <- function(file, locale = default_locale()) {
   if (empty_file(file)) {
     return("")
   }
-
-  ds <- datasource(file, encoding = locale$encoding)
+  if (missing(locale)) {
+    encoding <- NULL
+  } else {
+    encoding <- locale$encoding
+  }
+  ds <- datasource(file, encoding = encoding)
   read_file_(ds, locale)
 }
 
@@ -39,7 +43,7 @@ read_file_raw <- function(file) {
     return(raw())
   }
 
-  ds <- datasource(file)
+  ds <- datasource(file, encoding = "bytes")
   read_file_raw_(ds)
 }
 

--- a/R/file.R
+++ b/R/file.R
@@ -28,7 +28,7 @@ read_file <- function(file, locale = default_locale()) {
     return("")
   }
 
-  ds <- datasource(file)
+  ds <- datasource(file, encoding = locale$encoding)
   read_file_(ds, locale)
 }
 

--- a/R/lines.R
+++ b/R/lines.R
@@ -32,7 +32,7 @@ read_lines <- function(file, skip = 0, n_max = -1L,
   if (empty_file(file)) {
     return(character())
   }
-  ds <- datasource(file, skip = skip)
+  ds <- datasource(file, skip = skip, encoding = locale$encoding)
   read_lines_(ds, locale_ = locale, na = na, n_max = n_max, progress = progress)
 }
 
@@ -42,7 +42,7 @@ read_lines_raw <- function(file, skip = 0, n_max = -1L, progress = show_progress
   if (empty_file(file)) {
     return(list())
   }
-  ds <- datasource(file, skip = skip)
+  ds <- datasource(file, skip = skip, encoding = "bytes")
   read_lines_raw_(ds, n_max = n_max, progress = progress)
 }
 

--- a/R/read_delim.R
+++ b/R/read_delim.R
@@ -185,7 +185,12 @@ read_delimited <- function(file, tokenizer, col_names = TRUE, col_types = NULL,
     col_names = col_names, col_types = col_types, tokenizer = tokenizer,
     locale = locale)
 
-  ds <- datasource(data, skip = skip + isTRUE(col_names), comment = comment, encoding = locale$encoding)
+  if (missing(locale)) {
+    encoding <- NULL
+  } else {
+    encoding <- locale$encoding
+  }
+  ds <- datasource(data, skip = skip + isTRUE(col_names), comment = comment, encoding = encoding)
 
   if (is.null(col_types) && !inherits(ds, "source_string")) {
     show_cols_spec(spec)

--- a/R/read_delim.R
+++ b/R/read_delim.R
@@ -185,7 +185,7 @@ read_delimited <- function(file, tokenizer, col_names = TRUE, col_types = NULL,
     col_names = col_names, col_types = col_types, tokenizer = tokenizer,
     locale = locale)
 
-  ds <- datasource(data, skip = skip + isTRUE(col_names), comment = comment)
+  ds <- datasource(data, skip = skip + isTRUE(col_names), comment = comment, encoding = locale$encoding)
 
   if (is.null(col_types) && !inherits(ds, "source_string")) {
     show_cols_spec(spec)

--- a/R/read_fwf.R
+++ b/R/read_fwf.R
@@ -74,7 +74,7 @@ read_fwf <- function(file, col_positions, col_types = NULL,
 #' @param n Number of lines the tokenizer will read to determine file structure. By default
 #'      it is set to 100.
 fwf_empty <- function(file, skip = 0, col_names = NULL, comment = "", n = 100L,
-                      encoding = default_locale()$encoding) {
+                      encoding = NULL) {
   ds <- datasource(file, skip = skip, comment = comment, encoding = encoding)
 
   out <- whitespaceColumns(ds, n = n)

--- a/R/read_fwf.R
+++ b/R/read_fwf.R
@@ -73,8 +73,9 @@ read_fwf <- function(file, col_positions, col_types = NULL,
 #' @export
 #' @param n Number of lines the tokenizer will read to determine file structure. By default
 #'      it is set to 100.
-fwf_empty <- function(file, skip = 0, col_names = NULL, comment = "", n = 100L) {
-  ds <- datasource(file, skip = skip, comment = comment)
+fwf_empty <- function(file, skip = 0, col_names = NULL, comment = "", n = 100L,
+                      encoding = default_locale()$encoding) {
+  ds <- datasource(file, skip = skip, comment = comment, encoding = encoding)
 
   out <- whitespaceColumns(ds, n = n)
   out$end[length(out$end)] <- NA

--- a/R/read_fwf.R
+++ b/R/read_fwf.R
@@ -37,7 +37,8 @@ read_fwf <- function(file, col_positions, col_types = NULL,
                      locale = default_locale(), na = c("", "NA"),
                      comment = "", skip = 0, n_max = Inf,
                      guess_max = min(n_max, 1000), progress = show_progress()) {
-  ds <- datasource(file, skip = skip)
+  ds <- datasource(file, skip = skip, comment = comment, encoding = locale$encoding)
+
   if (inherits(ds, "source_file") && empty_file(file)) {
     return(tibble::tibble())
   }
@@ -73,9 +74,9 @@ read_fwf <- function(file, col_positions, col_types = NULL,
 #' @param n Number of lines the tokenizer will read to determine file structure. By default
 #'      it is set to 100.
 fwf_empty <- function(file, skip = 0, col_names = NULL, comment = "", n = 100L) {
-  ds <- datasource(file, skip = skip)
+  ds <- datasource(file, skip = skip, comment = comment)
 
-  out <- whitespaceColumns(ds, comment = comment, n = n)
+  out <- whitespaceColumns(ds, n = n)
   out$end[length(out$end)] <- NA
 
   col_names <- fwf_col_names(col_names, length(out$begin))

--- a/R/read_lines_chunked.R
+++ b/R/read_lines_chunked.R
@@ -10,7 +10,12 @@ read_lines_chunked <- function(file, callback, chunk_size = 10000, skip = 0,
   if (empty_file(file)) {
     return(character())
   }
-  ds <- datasource(file, skip = skip)
+  if (missing(locale)) {
+    encoding <- NULL
+  } else {
+    encoding <- locale$encoding
+  }
+  ds <- datasource(file, skip = skip, encoding = encoding)
   callback <- as_chunk_callback(callback)
   on.exit(callback$finally(), add = TRUE)
 

--- a/R/read_table.R
+++ b/R/read_table.R
@@ -36,7 +36,12 @@ read_table <- function(file, col_names = TRUE, col_types = NULL,
                        locale = default_locale(), na = "NA", skip = 0,
                        n_max = Inf, guess_max = min(n_max, 1000),
                        progress = show_progress(), comment = "") {
-  ds <- datasource(file, skip = skip, comment = comment, encoding = locale$encoding)
+  if (missing(locale)) {
+    encoding <- NULL
+  } else {
+    encoding <- locale$encoding
+  }
+  ds <- datasource(file, skip = skip, comment = comment, encoding = encoding)
   columns <- fwf_empty(ds, skip = skip, n = guess_max, comment = comment)
 
   tokenizer <- tokenizer_fwf(columns$begin, columns$end, na = na, comment = comment)

--- a/R/read_table.R
+++ b/R/read_table.R
@@ -36,19 +36,19 @@ read_table <- function(file, col_names = TRUE, col_types = NULL,
                        locale = default_locale(), na = "NA", skip = 0,
                        n_max = Inf, guess_max = min(n_max, 1000),
                        progress = show_progress(), comment = "") {
-  ds <- datasource(file, skip = skip)
+  ds <- datasource(file, skip = skip, comment = comment, encoding = locale$encoding)
   columns <- fwf_empty(ds, skip = skip, n = guess_max, comment = comment)
-  skip <- skip + columns$skip
 
   tokenizer <- tokenizer_fwf(columns$begin, columns$end, na = na, comment = comment)
 
   spec <- col_spec_standardise(
     file = ds, skip = skip, guess_max = guess_max,
+    comment = comment,
     col_names = col_names, col_types = col_types,
     locale = locale, tokenizer = tokenizer
   )
 
-  ds <- datasource(file = ds, skip = skip + isTRUE(col_names))
+  ds <- datasource(ds, skip = skip + isTRUE(col_names))
   if (is.null(col_types) && !inherits(ds, "source_string")) {
     show_cols_spec(spec)
   }

--- a/R/source.R
+++ b/R/source.R
@@ -53,15 +53,24 @@ datasource <- function(file, skip = 0, comment = "", encoding = default_locale()
 
     file
   } else if (is.connection(file)) {
+    if (missing(encoding)) {
+      encoding <- "bytes"
+    }
     datasource_connection(file, skip, comment, encoding)
   } else if (is.raw(file)) {
     datasource_raw(file, skip, comment, encoding)
   } else if (is.character(file)) {
-    if (grepl("\n", file)) {
+    if (is_literal_data(file)) {
+      if (missing(encoding)) {
+        encoding <- encoding_from_literal_data(file)
+      }
       datasource_string(file, skip, comment, encoding)
     } else {
       file <- standardise_path(file)
       if (is.connection(file)) {
+        if (missing(encoding)) {
+          encoding <- "bytes"
+        }
         datasource_connection(file, skip, comment, encoding)
       } else {
         datasource_file(file, skip, comment, encoding)
@@ -72,6 +81,17 @@ datasource <- function(file, skip = 0, comment = "", encoding = default_locale()
   }
 }
 
+is_literal_data <- function(text) {
+  is.character(text) && grepl("\n", text)
+}
+
+encoding_from_literal_data <- function(text) {
+  enc <- Encoding(text)
+  if (enc == "unknown") {
+    return("latin1") # assume text is ASCII, and latin1 is faster than UTF-8
+  }
+  enc
+}
 
 # Constructors -----------------------------------------------------------------
 
@@ -80,7 +100,8 @@ new_datasource <- function(type, x, skip, comment = "", encoding, ...) {
     class = c(paste0("source_", type), "source"))
 }
 
-datasource_string <- function(text, skip, comment, encoding) {
+datasource_string <- function(text, skip, comment,
+                              encoding = encoding_from_literal_data(text)) {
   new_datasource("string", text, skip = skip, comment = comment, encoding = encoding)
 }
 
@@ -90,10 +111,16 @@ datasource_file <- function(path, skip, comment, encoding) {
 }
 
 datasource_connection <- function(path, skip, comment, encoding) {
+  if (missing(encoding)) {
+    encoding <- "bytes"
+  }
   datasource_raw(read_connection(path), skip, comment = comment, encoding = encoding)
 }
 
 datasource_raw <- function(text, skip, comment, encoding) {
+  if (missing(encoding)) {
+    encoding <- "bytes"
+  }
   new_datasource("raw", text, skip = skip, comment = comment, encoding = encoding)
 }
 

--- a/R/source.R
+++ b/R/source.R
@@ -12,6 +12,9 @@
 #'    Literal data is most useful for examples and tests. It must contain at
 #'    least one new line to be recognised as data (instead of a path).
 #' @param skip Number of lines to skip before reading data.
+#' @param comment A string or character vector used to identify comments. Any
+#'                text after the comment characters will be silently ignored.
+#' @param encoding The text encoding of the data given in `file`. "UTF-8" as default
 #' @keywords internal
 #' @export
 #' @examples

--- a/R/source.R
+++ b/R/source.R
@@ -31,7 +31,7 @@
 #' con <- rawConnection(charToRaw("abc\n123"))
 #' datasource(con)
 #' close(con)
-datasource <- function(file, skip = 0, comment = "") {
+datasource <- function(file, skip = 0, comment = "", encoding = default_locale()$encoding) {
   if (inherits(file, "source")) {
 
     # If `skip` and `comment` arguments are expliictly passed, we want to use
@@ -44,20 +44,24 @@ datasource <- function(file, skip = 0, comment = "") {
       file$comment <- comment
     }
 
+    if (!missing(encoding)) {
+      file$encoding <- encoding
+    }
+
     file
   } else if (is.connection(file)) {
-    datasource_connection(file, skip, comment)
+    datasource_connection(file, skip, comment, encoding)
   } else if (is.raw(file)) {
-    datasource_raw(file, skip, comment)
+    datasource_raw(file, skip, comment, encoding)
   } else if (is.character(file)) {
     if (grepl("\n", file)) {
-      datasource_string(file, skip, comment)
+      datasource_string(file, skip, comment, encoding)
     } else {
       file <- standardise_path(file)
       if (is.connection(file)) {
-        datasource_connection(file, skip, comment)
+        datasource_connection(file, skip, comment, encoding)
       } else {
-        datasource_file(file, skip, comment)
+        datasource_file(file, skip, comment, encoding)
       }
     }
   } else {
@@ -65,28 +69,29 @@ datasource <- function(file, skip = 0, comment = "") {
   }
 }
 
+
 # Constructors -----------------------------------------------------------------
 
-new_datasource <- function(type, x, skip, comment = "", ...) {
-  structure(list(x, skip = skip, comment = comment, ...),
+new_datasource <- function(type, x, skip, comment = "", encoding, ...) {
+  structure(list(x, skip = skip, comment = comment, encoding = encoding, ...),
     class = c(paste0("source_", type), "source"))
 }
 
-datasource_string <- function(text, skip, comment = "") {
-  new_datasource("string", text, skip = skip, comment = comment)
+datasource_string <- function(text, skip, comment, encoding) {
+  new_datasource("string", text, skip = skip, comment = comment, encoding = encoding)
 }
 
-datasource_file <- function(path, skip, comment = "") {
+datasource_file <- function(path, skip, comment, encoding) {
   path <- check_path(path)
-  new_datasource("file", path, skip = skip, comment = comment)
+  new_datasource("file", path, skip = skip, comment = comment, encoding = encoding)
 }
 
-datasource_connection <- function(path, skip, comment = "") {
-  datasource_raw(read_connection(path), skip, comment = comment)
+datasource_connection <- function(path, skip, comment, encoding) {
+  datasource_raw(read_connection(path), skip, comment = comment, encoding = encoding)
 }
 
-datasource_raw <- function(text, skip, comment) {
-  new_datasource("raw", text, skip = skip, comment = comment)
+datasource_raw <- function(text, skip, comment, encoding) {
+  new_datasource("raw", text, skip = skip, comment = comment, encoding = encoding)
 }
 
 # Helpers ----------------------------------------------------------------------

--- a/R/tokenizer.R
+++ b/R/tokenizer.R
@@ -16,8 +16,9 @@
 #'
 #' # Only tokenize first two lines
 #' tokenize("1,2\n3,4,5\n\n6", n = 2)
-tokenize <- function(file, tokenizer = tokenizer_csv(), skip = 0, n_max = -1L) {
-  ds <- datasource(file, skip = skip)
+tokenize <- function(file, tokenizer = tokenizer_csv(), skip = 0, n_max = -1L,
+                     encoding = NULL) {
+  ds <- datasource(file, skip = skip, encoding = encoding)
   tokenize_(ds, tokenizer, n_max)
 }
 

--- a/man/count_fields.Rd
+++ b/man/count_fields.Rd
@@ -4,7 +4,7 @@
 \alias{count_fields}
 \title{Count the number of fields in each line of a file}
 \usage{
-count_fields(file, tokenizer, skip = 0, n_max = -1L)
+count_fields(file, tokenizer, skip = 0, n_max = -1L, encoding = NULL)
 }
 \arguments{
 \item{file}{Either a path to a file, a connection, or literal data
@@ -26,6 +26,11 @@ up into fields, e.g., \code{\link[=tokenizer_csv]{tokenizer_csv()}},
 \item{skip}{Number of lines to skip before reading data.}
 
 \item{n_max}{Optionally, maximum number of rows to count fields for.}
+
+\item{encoding}{The text encoding of the data given in \code{file}. If \code{NULL} is
+passed (the default), then "UTF-8" is used for files,
+"bytes" is used for connections and raw vectors, and the
+string Encoding will be used for literal data strings.}
 }
 \description{
 This is useful for diagnosing problems with functions that fail

--- a/man/datasource.Rd
+++ b/man/datasource.Rd
@@ -4,7 +4,8 @@
 \alias{datasource}
 \title{Create a source object.}
 \usage{
-datasource(file, skip = 0, comment = "")
+datasource(file, skip = 0, comment = "",
+  encoding = default_locale()$encoding)
 }
 \arguments{
 \item{file}{Either a path to a file, a connection, or literal data
@@ -20,6 +21,11 @@ Literal data is most useful for examples and tests. It must contain at
 least one new line to be recognised as data (instead of a path).}
 
 \item{skip}{Number of lines to skip before reading data.}
+
+\item{comment}{A string or character vector used to identify comments. Any
+text after the comment characters will be silently ignored.}
+
+\item{encoding}{The text encoding of the data given in \code{file}. "UTF-8" as default}
 }
 \description{
 Create a source object.

--- a/man/datasource.Rd
+++ b/man/datasource.Rd
@@ -4,8 +4,7 @@
 \alias{datasource}
 \title{Create a source object.}
 \usage{
-datasource(file, skip = 0, comment = "",
-  encoding = default_locale()$encoding)
+datasource(file, skip = 0, comment = "", encoding = NULL)
 }
 \arguments{
 \item{file}{Either a path to a file, a connection, or literal data
@@ -25,7 +24,10 @@ least one new line to be recognised as data (instead of a path).}
 \item{comment}{A string or character vector used to identify comments. Any
 text after the comment characters will be silently ignored.}
 
-\item{encoding}{The text encoding of the data given in \code{file}. "UTF-8" as default}
+\item{encoding}{The text encoding of the data given in \code{file}. If \code{NULL} is
+passed (the default), then "UTF-8" is used for files,
+"bytes" is used for connections and raw vectors, and the
+string Encoding will be used for literal data strings.}
 }
 \description{
 Create a source object.

--- a/man/read_delim.Rd
+++ b/man/read_delim.Rd
@@ -98,8 +98,8 @@ option to \code{character()} to indicate no missing values.}
 \item{quoted_na}{Should missing values inside quotes be treated as missing
 values (the default) or strings.}
 
-\item{comment}{A string used to identify comments. Any text after the
-comment characters will be silently ignored.}
+\item{comment}{A string or character vector used to identify comments. Any
+text after the comment characters will be silently ignored.}
 
 \item{trim_ws}{Should leading and trailing whitespace be trimmed from
 each field before parsing it?}

--- a/man/read_delim_chunked.Rd
+++ b/man/read_delim_chunked.Rd
@@ -102,8 +102,8 @@ option to \code{character()} to indicate no missing values.}
 \item{quoted_na}{Should missing values inside quotes be treated as missing
 values (the default) or strings.}
 
-\item{comment}{A string used to identify comments. Any text after the
-comment characters will be silently ignored.}
+\item{comment}{A string or character vector used to identify comments. Any
+text after the comment characters will be silently ignored.}
 
 \item{trim_ws}{Should leading and trailing whitespace be trimmed from
 each field before parsing it?}

--- a/man/read_fwf.Rd
+++ b/man/read_fwf.Rd
@@ -12,7 +12,8 @@ read_fwf(file, col_positions, col_types = NULL, locale = default_locale(),
   na = c("", "NA"), comment = "", skip = 0, n_max = Inf,
   guess_max = min(n_max, 1000), progress = show_progress())
 
-fwf_empty(file, skip = 0, col_names = NULL, comment = "", n = 100L)
+fwf_empty(file, skip = 0, col_names = NULL, comment = "", n = 100L,
+  encoding = default_locale()$encoding)
 
 fwf_widths(widths, col_names = NULL)
 
@@ -64,8 +65,8 @@ names.}
 \item{na}{Character vector of strings to use for missing values. Set this
 option to \code{character()} to indicate no missing values.}
 
-\item{comment}{A string used to identify comments. Any text after the
-comment characters will be silently ignored.}
+\item{comment}{A string or character vector used to identify comments. Any
+text after the comment characters will be silently ignored.}
 
 \item{skip}{Number of lines to skip before reading data.}
 
@@ -83,6 +84,8 @@ setting option \code{readr.show_progress} to \code{FALSE}.}
 
 \item{n}{Number of lines the tokenizer will read to determine file structure. By default
 it is set to 100.}
+
+\item{encoding}{The text encoding of the data given in \code{file}. "UTF-8" as default}
 
 \item{widths}{Width of each field. Use NA as width of last field when
 reading a ragged fwf file.}

--- a/man/read_fwf.Rd
+++ b/man/read_fwf.Rd
@@ -13,7 +13,7 @@ read_fwf(file, col_positions, col_types = NULL, locale = default_locale(),
   guess_max = min(n_max, 1000), progress = show_progress())
 
 fwf_empty(file, skip = 0, col_names = NULL, comment = "", n = 100L,
-  encoding = default_locale()$encoding)
+  encoding = NULL)
 
 fwf_widths(widths, col_names = NULL)
 
@@ -85,7 +85,10 @@ setting option \code{readr.show_progress} to \code{FALSE}.}
 \item{n}{Number of lines the tokenizer will read to determine file structure. By default
 it is set to 100.}
 
-\item{encoding}{The text encoding of the data given in \code{file}. "UTF-8" as default}
+\item{encoding}{The text encoding of the data given in \code{file}. If \code{NULL} is
+passed (the default), then "UTF-8" is used for files,
+"bytes" is used for connections and raw vectors, and the
+string Encoding will be used for literal data strings.}
 
 \item{widths}{Width of each field. Use NA as width of last field when
 reading a ragged fwf file.}

--- a/man/read_table.Rd
+++ b/man/read_table.Rd
@@ -79,8 +79,8 @@ is updated every 50,000 values and will only display if estimated reading
 time is 5 seconds or more. The automatic progress bar can be disabled by
 setting option \code{readr.show_progress} to \code{FALSE}.}
 
-\item{comment}{A string used to identify comments. Any text after the
-comment characters will be silently ignored.}
+\item{comment}{A string or character vector used to identify comments. Any
+text after the comment characters will be silently ignored.}
 }
 \description{
 \code{read_table()} and \code{read_table2()} are designed to read the type of textual

--- a/man/spec_delim.Rd
+++ b/man/spec_delim.Rd
@@ -103,8 +103,8 @@ option to \code{character()} to indicate no missing values.}
 \item{quoted_na}{Should missing values inside quotes be treated as missing
 values (the default) or strings.}
 
-\item{comment}{A string used to identify comments. Any text after the
-comment characters will be silently ignored.}
+\item{comment}{A string or character vector used to identify comments. Any
+text after the comment characters will be silently ignored.}
 
 \item{trim_ws}{Should leading and trailing whitespace be trimmed from
 each field before parsing it?}

--- a/man/tokenize.Rd
+++ b/man/tokenize.Rd
@@ -4,7 +4,8 @@
 \alias{tokenize}
 \title{Tokenize a file/string.}
 \usage{
-tokenize(file, tokenizer = tokenizer_csv(), skip = 0, n_max = -1L)
+tokenize(file, tokenizer = tokenizer_csv(), skip = 0, n_max = -1L,
+  encoding = NULL)
 }
 \arguments{
 \item{file}{Either a path to a file, a connection, or literal data
@@ -24,6 +25,11 @@ least one new line to be recognised as data (instead of a path).}
 \item{skip}{Number of lines to skip before reading data.}
 
 \item{n_max}{Optionally, maximum number of rows to tokenize.}
+
+\item{encoding}{The text encoding of the data given in \code{file}. If \code{NULL} is
+passed (the default), then "UTF-8" is used for files,
+"bytes" is used for connections and raw vectors, and the
+string Encoding will be used for literal data strings.}
 }
 \description{
 Turns input into a character vector. Usually the tokenization is done purely

--- a/src/CodePointIterator.cpp
+++ b/src/CodePointIterator.cpp
@@ -6,8 +6,17 @@ using namespace Rcpp;
 
 #include "CodePointIterator.h"
 
-class UTF8Validator {
+static inline bool unicode_is_blank(uint32_t cp) {
+  return (cp == 0x20 || cp == 0xA0 || cp == 0x1680 ||
+          (cp >= 0x2000 && cp < 0x200B) ||
+          cp == 0x202F || cp == 0x205F || cp == 0x3000);
+}
+
+class CodePointIteratorUTF8 : public CodePointIterator {
 public:
+  CodePointIteratorUTF8(const char *begin, const char *end,
+                        std::string encoding, const char *pos) : CodePointIterator(begin, end, encoding, pos) {}
+private:
   static inline size_t codeUnitSize(const char c) {
     if (isLeadingSingleByte(c))
       return 1;
@@ -32,10 +41,10 @@ public:
     return (c & 0xF8) == 0xF0;
   }
   static inline bool isContByte(const char c) { return (c & 0xC0) == 0x80; }
-  static inline uint32_t get_code_point(const char c1) {
+  static inline uint32_t get_code_point1(const char c1) {
     return static_cast<uint32_t>(static_cast<unsigned char>(c1));
   };
-  static inline uint32_t get_code_point(const char c1, const char c2) {
+  static inline uint32_t get_code_point2(const char c1, const char c2) {
     uint32_t u1, u2;
     u1 = static_cast<uint32_t>(static_cast<unsigned char>(c1));
     u2 = static_cast<uint32_t>(static_cast<unsigned char>(c2));
@@ -43,8 +52,7 @@ public:
     u2 = u2 & 0x3F;
     return (u1 << 6) | u2;
   }
-  static inline uint32_t
-  get_code_point(const char c1, const char c2, const char c3) {
+  static inline uint32_t get_code_point3(const char c1, const char c2, const char c3) {
     uint32_t u1, u2, u3;
     u1 = static_cast<uint32_t>(static_cast<unsigned char>(c1));
     u2 = static_cast<uint32_t>(static_cast<unsigned char>(c2));
@@ -54,8 +62,7 @@ public:
     u3 = u3 & 0x3F;
     return (u1 << 12) | (u2 << 6) | u3;
   }
-  static inline uint32_t
-  get_code_point(const char c1, const char c2, const char c3, const char c4) {
+  static inline uint32_t get_code_point4(const char c1, const char c2, const char c3, const char c4) {
     uint32_t u1, u2, u3, u4;
     u1 = static_cast<uint32_t>(static_cast<unsigned char>(c1));
     u2 = static_cast<uint32_t>(static_cast<unsigned char>(c2));
@@ -67,10 +74,159 @@ public:
     u4 = u4 & 0x3F;
     return (u1 << 18) | (u2 << 12) | (u3 << 6) | u4;
   }
+
+  size_t get_prev_code_unit_length() const {
+    if (p_pos - 1 >= p_end)
+      return 0;
+    if (p_pos - 1 < p_begin)
+      return 0;
+
+    const char* pos = p_pos;
+    if (pos <= p_begin)
+      return 0;
+    size_t len = 0;
+    pos--;
+    len++;
+    while (len <= 5 && pos >= p_begin && isContByte(*pos)) {
+      len++;
+      pos--;
+    }
+    if (pos < p_begin) {
+      stop("Encoding error. First byte in stream is a UTF-8 continuation byte");
+    }
+    size_t should_be_length = codeUnitSize(*pos);
+    if (should_be_length != len) {
+      stop(
+        "Encoding error. Leading byte marked %d bytes, found %d",
+        should_be_length,
+        len);
+    }
+    return len;
+  }
+
+  size_t get_code_unit_length() const {
+    if (p_pos == p_end)
+      return 0;
+    if (p_pos < p_begin)
+      return 0;
+    const char* pos = p_pos;
+    if (isContByte(*pos)) {
+      stop("UTF-8 continuation byte in a leading position. Encoding error.");
+    }
+    if (isLeadingSingleByte(*pos)) {
+      return 1;
+    }
+    if (isLeadingDoubleByte(*pos)) {
+      if ((pos + 1 < p_end) && isContByte(*(pos + 1))) {
+        return 2;
+      } else {
+        stop("Invalid 2-byte UTF-8 character at position %d", pos - p_begin);
+      }
+    }
+    if (isLeadingTripleByte(*pos)) {
+      if ((pos + 2 < p_end) && isContByte(*(pos + 1)) &&
+          isContByte(*(pos + 2))) {
+        return 3;
+      } else {
+        stop("Invalid 3-byte UTF-8 character at position %d", pos - p_begin);
+      }
+    }
+    if (isLeadingQuadByte(*pos)) {
+      if ((pos + 3 < p_end) && isContByte(*(pos + 1)) &&
+          isContByte(*(pos + 2)) && isContByte(*(pos + 3))) {
+        return 4;
+      } else {
+        stop("Invalid 4-byte UTF-8 character at position %d", pos - p_begin);
+      }
+    }
+    stop("Invalid UTF-8 character at position %d", pos + 1 - p_begin);
+
+  }
+
+  uint32_t get_code_point() const {
+    if (p_pos < p_begin || p_pos == p_end)
+      return CODEPOINT_ERROR;
+    size_t len = get_code_unit_length();
+    switch (len) {
+    case 1:
+      return get_code_point1(*p_pos);
+    case 2:
+      return get_code_point2(*p_pos, *(p_pos + 1));
+    case 3:
+      return get_code_point3(*p_pos, *(p_pos + 1), *(p_pos + 2));
+    case 4:
+      return get_code_point4(*p_pos, *(p_pos + 1), *(p_pos + 2), *(p_pos + 3));
+    default:
+      return CODEPOINT_ERROR;
+    }
+  }
+
+  inline bool isblank(uint32_t cp) const {
+    return unicode_is_blank(cp);
+  }
 };
 
-class UTF16Validator {
+template <bool BigEndian>
+class CodePointIteratorUCS2 : public CodePointIterator {
 public:
+  CodePointIteratorUCS2(const char *begin, const char *end,
+                        std::string encoding, const char *pos) : CodePointIterator(begin, end, encoding, pos) {}
+private:
+  static inline uint32_t get_code_unit(const char c1, const char c2) {
+    uint32_t u1, u2;
+    u1 = static_cast<uint32_t>(static_cast<unsigned char>(c1));
+    u2 = static_cast<uint32_t>(static_cast<unsigned char>(c2));
+    if (BigEndian) {
+      u1 = (u1 << 8) | u2;
+    } else {
+      u1 = (u2 << 8) | u1;
+    }
+    return u1;
+  }
+
+  size_t get_prev_code_unit_length() const {
+    if (p_pos - 1 >= p_end)
+      return 0;
+    if (p_pos - 2 < p_begin) {
+      return 0;
+    }
+    return 2;
+  }
+
+  size_t get_code_unit_length() const {
+    if (p_pos == p_end)
+      return 0;
+    if (p_pos < p_begin)
+      return 0;
+    if (p_pos + 1 == p_end) {
+      stop("Truncated %s character", p_encoding.c_str());
+    }
+    uint32_t u1 = get_code_unit(*p_pos, *(p_pos + 1));
+    if (u1 > 0xD7FF && u1 < 0xE000) {
+      stop("Invalid %s character", p_encoding.c_str());
+    }
+    return 2;
+  }
+
+  uint32_t get_code_point() const {
+    if (p_pos < p_begin || p_pos == p_end)
+      return CODEPOINT_ERROR;
+    return get_code_unit(*p_pos, *(p_pos + 1));
+  }
+
+  inline bool isblank(uint32_t cp) const {
+    return unicode_is_blank(cp);
+  }
+
+};
+
+template <bool BigEndian>
+class CodePointIteratorUTF16 : public CodePointIterator {
+public:
+  CodePointIteratorUTF16(const char *begin, const char *end,
+                         std::string encoding, const char *pos) :
+  CodePointIterator(begin, end, encoding, pos) {}
+private:
   static inline uint32_t get_code_unitBE(const char c1, const char c2) {
     uint32_t u1, u2;
     u1 = static_cast<uint32_t>(static_cast<unsigned char>(c1));
@@ -85,25 +241,43 @@ public:
     u1 = (u2 << 8) | u1;
     return u1;
   }
-  static inline uint32_t get_code_pointBE(const char c1, const char c2) {
+  static inline uint32_t get_code_unit(const char c1, const char c2) {
+    if (BigEndian) {
+      return get_code_unitBE(c1, c2);
+    } else {
+      return get_code_unitLE(c1, c2);
+    }
+  }
+  static inline uint32_t get_code_pointBE2(const char c1, const char c2) {
     return get_code_unitBE(c1, c2);
   }
-  static inline uint32_t
-  get_code_pointBE(const char c1, const char c2, const char c3, const char c4) {
+  static inline uint32_t get_code_pointBE4(const char c1, const char c2, const char c3, const char c4) {
     uint32_t u1 = get_code_unitBE(c1, c2);
     uint32_t u2 = get_code_unitBE(c3, c4);
     return codePointFromSurrogates(u1, u2);
   }
-  static inline uint32_t get_code_pointLE(const char c1, const char c2) {
+  static inline uint32_t get_code_pointLE2(const char c1, const char c2) {
     return get_code_unitLE(c1, c2);
   }
-  static inline uint32_t
-  get_code_pointLE(const char c1, const char c2, const char c3, const char c4) {
+  static inline uint32_t get_code_pointLE4(const char c1, const char c2, const char c3, const char c4) {
     uint32_t u1 = get_code_unitLE(c1, c2);
     uint32_t u2 = get_code_unitLE(c3, c4);
     return codePointFromSurrogates(u1, u2);
   }
-
+  static inline uint32_t get_code_point2(const char c1, const char c2) {
+    if (BigEndian) {
+      return get_code_pointBE2(c1, c2);
+    } else {
+      return get_code_pointLE2(c1, c2);
+    }
+  }
+  static inline uint32_t get_code_point4(const char c1, const char c2, const char c3, const char c4) {
+    if (BigEndian) {
+      return get_code_pointBE4(c1, c2, c3, c4);
+    } else {
+      return get_code_pointLE4(c1, c2, c3, c4);
+    }
+  }
   static inline bool isBasicMultilingualPlane(uint32_t u1) {
     return (u1 <= 0xD7FF || (u1 >= 0xE000 && u1 <= 0xFFFF));
   }
@@ -120,10 +294,84 @@ public:
     high = high + 0x10000;
     return high;
   }
+
+  size_t get_prev_code_unit_length() const {
+    uint32_t u1, u2;
+    if (p_pos - 2 < p_begin) {
+      return 0;
+    }
+    u2 = get_code_point2((*p_pos - 2), (*p_pos - 1));
+    if (isBasicMultilingualPlane(u2)) {
+      return 2;
+    }
+    if (isLowSurrogate(u2)) {
+      if (p_pos - 4 < p_begin) {
+        return 0;
+      }
+      u1 = get_code_point2((*p_pos - 4), (*p_pos - 3));
+      if (!isHighSurrogate(u1)) {
+        stop("Encoding error. Mismatch high/low %s surrogates", p_encoding.c_str());
+      }
+      return 4;
+    }
+    stop("Invalid UTF16BE character found");
+
+  }
+
+  size_t get_code_unit_length() const {
+    if (p_pos + 1 == p_end) {
+      stop("Invalid/Truncated %s character", p_encoding.c_str());
+    }
+    uint32_t u1, u2;
+    u1 = get_code_unit(*p_pos, *(p_pos + 1));
+    if (isBasicMultilingualPlane(u1)) {
+      return 2;
+    }
+    if (!isHighSurrogate(u1)) {
+      stop(
+        "Invalid %s character: high surrogate too large", p_encoding.c_str());
+    }
+    /* Surrogate pair */
+    if (p_pos + 3 >= p_end) {
+      stop(
+        "Invalid/Truncated %s character. Surrogate pair ends too soon",
+        p_encoding.c_str());
+    }
+    u2 = get_code_unit(*(p_pos + 2), *(p_pos + 3));
+    if (!isLowSurrogate(u2)) {
+      stop(
+        "Invalid %s character: low surrogate out of range",
+        p_encoding.c_str());
+    }
+    return 4;
+  }
+
+  uint32_t get_code_point() const {
+    if (p_pos < p_begin || p_pos == p_end)
+      return CODEPOINT_ERROR;
+    size_t len = get_code_unit_length();
+    if (len == 2) {
+      return get_code_point2(*p_pos, *(p_pos + 1));
+    } else if (len == 4) {
+      return get_code_point4(*p_pos, *(p_pos + 1), *(p_pos + 2), *(p_pos + 3));
+    } else {
+      return CODEPOINT_ERROR;
+    }
+  }
+
+  inline bool isblank(uint32_t cp) const {
+    return unicode_is_blank(cp);
+  }
+
 };
 
-class UTF32Validator {
+template <bool BigEndian>
+class CodePointIteratorUTF32 : public CodePointIterator {
 public:
+  CodePointIteratorUTF32(const char *begin, const char *end,
+                         std::string encoding, const char *pos) :
+  CodePointIterator(begin, end, encoding, pos) {}
+private:
   static inline uint32_t
   get_code_pointBE(const char c1, const char c2, const char c3, const char c4) {
     uint32_t u1, u2, u3, u4;
@@ -142,296 +390,103 @@ public:
     u4 = static_cast<uint32_t>(static_cast<unsigned char>(c4));
     return (u4 << 24) | (u3 << 16) | (u2 << 8) | u1;
   }
+  size_t get_prev_code_unit_length() const {
+    if (p_pos - 1 >= p_end)
+      return 0;
+    if (p_pos - 1 < p_begin)
+      return 0;
+    return 4;
+  }
+
+  size_t get_code_unit_length() const {
+    if (p_pos + 3 >= p_end) {
+      stop("Invalid/Truncated %s character", p_encoding.c_str());
+    }
+    return 4;
+  }
+
+  uint32_t get_code_point() const {
+    if (p_pos < p_begin || p_pos == p_end)
+      return CODEPOINT_ERROR;
+    size_t len = get_code_unit_length();
+    if (BigEndian) {
+      return get_code_pointBE(
+        *p_pos, *(p_pos + 1), *(p_pos + 2), *(p_pos + 3));
+    } else {
+      return get_code_pointLE(
+        *p_pos, *(p_pos + 1), *(p_pos + 2), *(p_pos + 3));
+    }
+  }
+
 };
 
-class UCS2Validator {
+class CodePointIteratorEASCII : public CodePointIterator {
 public:
-  static inline uint32_t get_code_unitBE(const char c1, const char c2) {
-    uint32_t u1, u2;
-    u1 = static_cast<uint32_t>(static_cast<unsigned char>(c1));
-    u2 = static_cast<uint32_t>(static_cast<unsigned char>(c2));
-    u1 = (u1 << 8) | u2;
-    return u1;
-  }
-  static inline uint32_t get_code_unitLE(const char c1, const char c2) {
-    uint32_t u1, u2;
-    u1 = static_cast<uint32_t>(static_cast<unsigned char>(c1));
-    u2 = static_cast<uint32_t>(static_cast<unsigned char>(c2));
-    u1 = (u2 << 8) | u1;
-    return u1;
-  }
-};
-
-size_t CodePointIterator::get_prev_code_unit_length() const {
-  if (p_pos - 1 >= p_end)
-    return 0;
-  if (p_pos - 1 < p_begin)
-    return 0;
-
-  if (p_encoding == "UTF-8" || p_encoding == "UTF8") {
-    const char* pos = p_pos;
-    if (pos <= p_begin)
+  CodePointIteratorEASCII(const char *begin, const char *end,
+                        std::string encoding, const char *pos) : CodePointIterator(begin, end, encoding, pos) {}
+private:
+  size_t get_prev_code_unit_length() const {
+    if (p_pos - 1 >= p_end)
       return 0;
-    size_t len = 0;
-    pos--;
-    len++;
-    while (len <= 5 && pos >= p_begin && UTF8Validator::isContByte(*pos)) {
-      len++;
-      pos--;
-    }
-    if (pos < p_begin) {
-      stop("Encoding error. First byte in stream is a UTF-8 continuation byte");
-    }
-    size_t should_be_length = UTF8Validator::codeUnitSize(*pos);
-    if (should_be_length != len) {
-      stop(
-          "Encoding error. Leading byte marked %d bytes, found %d",
-          should_be_length,
-          len);
-    }
-    return len;
-  } else if (p_encoding == "UCS-2BE" || p_encoding == "UCS-2LE") {
-    if (p_pos - 2 < p_begin) {
+    if (p_pos - 1 < p_begin)
       return 0;
-    }
-    return 2;
-  } else if (p_encoding == "UTF-16BE" || p_encoding == "UTF16BE") {
-    uint32_t u1, u2;
-    if (p_pos - 2 < p_begin) {
-      return 0;
-    }
-    u2 = UTF16Validator::get_code_pointBE((*p_pos - 2), (*p_pos - 1));
-    if (UTF16Validator::isBasicMultilingualPlane(u2)) {
-      return 2;
-    }
-    if (UTF16Validator::isLowSurrogate(u2)) {
-      if (p_pos - 4 < p_begin) {
-        return 0;
-      }
-      u1 = UTF16Validator::get_code_pointBE((*p_pos - 4), (*p_pos - 3));
-      if (!UTF16Validator::isHighSurrogate(u1)) {
-        stop("Encoding error. Mismatch high/low UTF16BE surrogates");
-      }
-      return 4;
-    }
-    stop("Invalid UTF16BE character found");
-  } else if (p_encoding == "UTF-16LE" || p_encoding == "UTF16LE") {
-    uint32_t u1, u2;
-    if (p_pos - 2 < p_begin) {
-      return 0;
-    }
-    u2 = UTF16Validator::get_code_pointLE((*p_pos - 2), (*p_pos - 1));
-    if (UTF16Validator::isBasicMultilingualPlane(u2)) {
-      return 2;
-    }
-    if (UTF16Validator::isLowSurrogate(u2)) {
-      if (p_pos - 4 < p_begin) {
-        return 0;
-      }
-      u1 = UTF16Validator::get_code_pointLE((*p_pos - 4), (*p_pos - 3));
-      if (!UTF16Validator::isHighSurrogate(u1)) {
-        stop("Encoding error. Mismatch high/low UTF16LE surrogates");
-      }
-      return 4;
-    }
-    stop("Invalid UTF16LE character found");
-  } else if (
-      p_encoding == "UCS4" || p_encoding == "UCS-4" ||
-      p_encoding == "UCS-4BE" || p_encoding == "UCS-4LE" ||
-      p_encoding == "UTF32" || p_encoding == "UTF-32" ||
-      p_encoding == "UTF-32BE" || p_encoding == "UTF-32LE" ||
-      p_encoding == "UTF32BE" || p_encoding == "UTF32LE") {
-    return 4;
-  } else {
-    /* For most cases (latin-1...) this is true, FIXME: Big5 and ShiftJIS are
-     * not yet contemplated */
     return 1;
   }
-}
 
-size_t CodePointIterator::get_code_unit_length() const {
-  if (p_pos == p_end)
-    return 0;
-  if (p_pos < p_begin)
-    return 0;
+  size_t get_code_unit_length() const {
+    if (p_pos == p_end)
+      return 0;
+    if (p_pos < p_begin)
+      return 0;
 
-  if (p_encoding == "UTF-8" || p_encoding == "UTF8") {
-    const char* pos = p_pos;
-    if (UTF8Validator::isContByte(*pos)) {
-      stop("UTF-8 continuation byte in a leading position. Encoding error.");
-    }
-    if (UTF8Validator::isLeadingSingleByte(*pos)) {
-      return 1;
-    }
-    if (UTF8Validator::isLeadingDoubleByte(*pos)) {
-      if ((pos + 1 < p_end) && UTF8Validator::isContByte(*(pos + 1))) {
-        return 2;
-      } else {
-        stop("Invalid 2-byte UTF-8 character at position %d", pos - p_begin);
-      }
-    }
-    if (UTF8Validator::isLeadingTripleByte(*pos)) {
-      if ((pos + 2 < p_end) && UTF8Validator::isContByte(*(pos + 1)) &&
-          UTF8Validator::isContByte(*(pos + 2))) {
-        return 3;
-      } else {
-        stop("Invalid 3-byte UTF-8 character at position %d", pos - p_begin);
-      }
-    }
-    if (UTF8Validator::isLeadingQuadByte(*pos)) {
-      if ((pos + 3 < p_end) && UTF8Validator::isContByte(*(pos + 1)) &&
-          UTF8Validator::isContByte(*(pos + 2)) &&
-          UTF8Validator::isContByte(*(pos + 3))) {
-        return 4;
-      } else {
-        stop("Invalid 4-byte UTF-8 character at position %d", pos - p_begin);
-      }
-    }
-    stop("Invalid UTF-8 character at position %d", pos + 1 - p_begin);
-  } else if (p_encoding == "UCS-2BE") {
-    if (p_pos + 1 == p_end) {
-      stop("Truncated %s character", p_encoding.c_str());
-    }
-    uint32_t u1 = UCS2Validator::get_code_unitBE(*p_pos, *(p_pos + 1));
-    if (u1 > 0xD7FF && u1 < 0xE000) {
-      stop("Invalid %s character", p_encoding.c_str());
-    }
-    return 2;
-  } else if (p_encoding == "UCS-2LE") {
-    if (p_pos + 1 == p_end) {
-      stop("Truncated %s character", p_encoding.c_str());
-    }
-    uint32_t u1 = UCS2Validator::get_code_unitLE(*p_pos, *(p_pos + 1));
-    if (u1 > 0xD7FF && u1 < 0xE000) {
-      stop("Invalid %s character", p_encoding.c_str());
-    }
-    return 2;
-  } else if (p_encoding == "UTF-16BE" || p_encoding == "UTF16BE") {
-    if (p_pos + 1 == p_end) {
-      stop("Invalid/Truncated %s character", p_encoding.c_str());
-    }
-    uint32_t u1, u2;
-    u1 = UTF16Validator::get_code_unitBE(*p_pos, *(p_pos + 1));
-    if (UTF16Validator::isBasicMultilingualPlane(u1)) {
-      return 2;
-    }
-    if (!UTF16Validator::isHighSurrogate(u1)) {
-      stop(
-          "Invalid %s character: high surrogate too large", p_encoding.c_str());
-    }
-    /* Surrogate pair */
-    if (p_pos + 3 >= p_end) {
-      stop(
-          "Invalid/Truncated %s character. Surrogate pair ends too soon",
-          p_encoding.c_str());
-    }
-    u2 = UTF16Validator::get_code_unitBE(*(p_pos + 2), *(p_pos + 3));
-    if (!UTF16Validator::isLowSurrogate(u2)) {
-      stop(
-          "Invalid %s character: low surrogate out of range",
-          p_encoding.c_str());
-    }
-    return 4;
-  } else if (p_encoding == "UTF-16LE" || p_encoding == "UTF16LE") {
-    if (p_pos + 1 == p_end) {
-      stop(
-          "Invalid/Truncated %s character. Missing second byte of UTF-16LE "
-          "code unit.",
-          p_encoding.c_str());
-    }
-    uint32_t u1, u2;
-    u1 = UTF16Validator::get_code_unitLE(*p_pos, *(p_pos + 1));
-
-    if (UTF16Validator::isBasicMultilingualPlane(u1)) {
-      return 2;
-    }
-
-    if (!UTF16Validator::isHighSurrogate(u1)) {
-      stop(
-          "Invalid %s character: high surrogate too large", p_encoding.c_str());
-    }
-
-    /* Surrogate pair */
-
-    if (p_pos + 3 >= p_end) {
-      stop(
-          "Invalid/Truncated %s character. Surrogate pair ends too soon",
-          p_encoding.c_str());
-    }
-
-    u2 = UTF16Validator::get_code_unitLE(*(p_pos + 2), *(p_pos + 3));
-    if (!UTF16Validator::isLowSurrogate(u2)) {
-      stop(
-          "Invalid %s character: low surrogate out of range",
-          p_encoding.c_str());
-    }
-    return 4;
-  } else if (
-      p_encoding == "UCS4" || p_encoding == "UCS-4" ||
-      p_encoding == "UCS-4BE" || p_encoding == "UCS-4LE" ||
-      p_encoding == "UTF32" || p_encoding == "UTF-32" ||
-      p_encoding == "UTF-32BE" || p_encoding == "UTF-32LE" ||
-      p_encoding == "UTF32BE" || p_encoding == "UTF32LE") {
-    if (p_pos + 3 >= p_end) {
-      stop("Invalid/Truncated %s character", p_encoding.c_str());
-    }
-    return 4;
-  } else {
     return 1;
   }
-}
 
-uint32_t CodePointIterator::get_code_point() const {
-  if (p_pos < p_begin || p_pos == p_end)
-    return CODEPOINT_ERROR;
-  size_t len = get_code_unit_length();
-  if (p_encoding == "UTF-8" || p_encoding == "UTF8") {
-    switch (len) {
-    case 1:
-      return UTF8Validator::get_code_point(*p_pos);
-    case 2:
-      return UTF8Validator::get_code_point(*p_pos, *(p_pos + 1));
-    case 3:
-      return UTF8Validator::get_code_point(*p_pos, *(p_pos + 1), *(p_pos + 2));
-    case 4:
-      return UTF8Validator::get_code_point(
-          *p_pos, *(p_pos + 1), *(p_pos + 2), *(p_pos + 3));
-    default:
+  uint32_t get_code_point() const {
+    if (p_pos < p_begin || p_pos == p_end)
       return CODEPOINT_ERROR;
-    }
-  } else if (p_encoding == "UCS-2BE") {
-    return UCS2Validator::get_code_unitBE(*p_pos, *(p_pos + 1));
-  } else if (p_encoding == "UCS-2LE") {
-    return UCS2Validator::get_code_unitLE(*p_pos, *(p_pos + 1));
-  } else if (p_encoding == "UTF-16BE" || p_encoding == "UTF16BE") {
-    if (len == 2) {
-      return UTF16Validator::get_code_pointBE(*p_pos, *(p_pos + 1));
-    } else if (len == 4) {
-      return UTF16Validator::get_code_pointBE(
-          *p_pos, *(p_pos + 1), *(p_pos + 2), *(p_pos + 3));
-    } else {
-      return CODEPOINT_ERROR;
-    }
-  } else if (p_encoding == "UTF-16LE" || p_encoding == "UTF16LE") {
-    if (len == 2) {
-      return UTF16Validator::get_code_pointLE(*p_pos, *(p_pos + 1));
-    } else if (len == 4) {
-      return UTF16Validator::get_code_pointLE(
-          *p_pos, *(p_pos + 1), *(p_pos + 2), *(p_pos + 3));
-    } else {
-      return CODEPOINT_ERROR;
-    }
-  } else if (
-      p_encoding == "UCS-4BE" || p_encoding == "UTF-32BE" ||
-      p_encoding == "UTF32BE") {
-    return UTF32Validator::get_code_pointBE(
-        *p_pos, *(p_pos + 1), *(p_pos + 2), *(p_pos + 3));
-  } else if (
-      p_encoding == "UCS-4LE" || p_encoding == "UTF-32LE" ||
-      p_encoding == "UTF32LE") {
-    return UTF32Validator::get_code_pointLE(
-        *p_pos, *(p_pos + 1), *(p_pos + 2), *(p_pos + 3));
-  } else {
     return static_cast<uint32_t>(static_cast<unsigned char>(*p_pos));
   }
+};
+
+
+CodePointIteratorPtr CodePointIterator::create(const char *begin, const char *end,
+                            std::string encoding, const char *pos) {
+  if (encoding == "") {
+    stop("Encoding not specified");
+  }
+  if (encoding == "UTF-16" || encoding == "UTF-32" || encoding == "UCS-2" ||
+      encoding == "UCS-4") {
+    stop(
+      "Specify endianness in encoding as: %sLE or %sBE",
+      encoding.c_str(),
+      encoding.c_str());
+  }
+
+    if (encoding == "UTF-8" || encoding == "UTF8") {
+      return CodePointIteratorPtr(
+        new CodePointIteratorUTF8(begin, end, encoding, pos));
+    } else if (encoding == "UCS2-BE" || encoding == "UCS2BE") {
+      return CodePointIteratorPtr(
+        new CodePointIteratorUCS2<true>(begin, end, encoding, pos));
+    } else if (encoding == "UCS2-LE" || encoding == "UCS2LE") {
+      return CodePointIteratorPtr(
+        new CodePointIteratorUCS2<false>(begin, end, encoding, pos));
+    } else if (encoding == "UTF16-LE" || encoding == "UTF16LE") {
+      return CodePointIteratorPtr(
+        new CodePointIteratorUTF16<false>(begin, end, encoding, pos));
+    } else if (encoding == "UTF16-BE" || encoding == "UTF16BE") {
+      return CodePointIteratorPtr(
+        new CodePointIteratorUTF16<true>(begin, end, encoding, pos));
+    } else if (encoding == "UTF32-BE" || encoding == "UTF32BE" || encoding == "UCS-4BE") {
+      return CodePointIteratorPtr(
+        new CodePointIteratorUTF32<true>(begin, end, encoding, pos));
+    } else if (encoding == "UTF32-LE" || encoding == "UTF32LE" || encoding == "UCS-4LE") {
+      return CodePointIteratorPtr(
+        new CodePointIteratorUTF32<false>(begin, end, encoding, pos));
+    } else {
+      /* TO DO: Big5 and ShiftJIS? */
+      return CodePointIteratorPtr(
+        new CodePointIteratorEASCII(begin, end, encoding, pos));
+    }
 }

--- a/src/CodePointIterator.cpp
+++ b/src/CodePointIterator.cpp
@@ -1,0 +1,394 @@
+#include <Rcpp.h>
+using namespace Rcpp;
+#include "boost.h"
+
+#include <string>
+
+#include "CodePointIterator.h"
+
+class UTF8Validator {
+public:
+  static inline size_t codeUnitSize(const char c) {
+    if (isLeadingSingleByte(c)) return 1;
+    if (isLeadingDoubleByte(c)) return 2;
+    if (isLeadingTripleByte(c)) return 3;
+    if (isLeadingQuadByte(c)) return 4;
+    return 0;
+  }
+  static inline bool isLeadingSingleByte(const char c) {return (c & 0x80) == 0x00;}
+  static inline bool isLeadingDoubleByte(const char c) {return (c & 0xE0) == 0xC0;}
+  static inline bool isLeadingTripleByte(const char c) {return (c & 0xF0) == 0xE0;}
+  static inline bool isLeadingQuadByte(const char c) {return (c & 0xF8) == 0xF0;}
+  static inline bool isContByte(const char c) {return (c & 0xC0) == 0x80;}
+  static inline uint32_t get_code_point(const char c1) {
+    return static_cast<uint32_t>(static_cast<unsigned char>(c1));
+  };
+  static inline uint32_t get_code_point(const char c1, const char c2) {
+    uint32_t u1, u2;
+    u1 = static_cast<uint32_t>(static_cast<unsigned char>(c1));
+    u2 = static_cast<uint32_t>(static_cast<unsigned char>(c2));
+    u1 = u1 & 0x1F;
+    u2 = u2 & 0x3F;
+    return (u1 << 6) | u2;
+  }
+  static inline uint32_t get_code_point(const char c1, const char c2, const char c3) {
+    uint32_t u1, u2, u3;
+    u1 = static_cast<uint32_t>(static_cast<unsigned char>(c1));
+    u2 = static_cast<uint32_t>(static_cast<unsigned char>(c2));
+    u3 = static_cast<uint32_t>(static_cast<unsigned char>(c3));
+    u1 = u1 & 0x0F;
+    u2 = u2 & 0x3F;
+    u3 = u3 & 0x3F;
+    return (u1 << 12) | (u2 << 6) | u3;
+  }
+  static inline uint32_t get_code_point(const char c1, const char c2, const char c3, const char c4) {
+    uint32_t u1, u2, u3, u4;
+    u1 = static_cast<uint32_t>(static_cast<unsigned char>(c1));
+    u2 = static_cast<uint32_t>(static_cast<unsigned char>(c2));
+    u3 = static_cast<uint32_t>(static_cast<unsigned char>(c3));
+    u4 = static_cast<uint32_t>(static_cast<unsigned char>(c4));
+    u1 = u1 & 0x07;
+    u2 = u2 & 0x3F;
+    u3 = u3 & 0x3F;
+    u4 = u4 & 0x3F;
+    return (u1 << 18) | (u2 << 12) | (u3 << 6) | u4;
+  }
+};
+
+class UTF16Validator {
+public:
+  static inline uint32_t get_code_unitBE(const char c1, const char c2) {
+    uint32_t u1, u2;
+    u1 = static_cast<uint32_t>(static_cast<unsigned char>(c1));
+    u2 = static_cast<uint32_t>(static_cast<unsigned char>(c2));
+    u1 = (u1 << 8) | u2;
+    return u1;
+  }
+  static inline uint32_t get_code_unitLE(const char c1, const char c2) {
+    uint32_t u1, u2;
+    u1 = static_cast<uint32_t>(static_cast<unsigned char>(c1));
+    u2 = static_cast<uint32_t>(static_cast<unsigned char>(c2));
+    u1 = (u2 << 8) | u1;
+    return u1;
+  }
+  static inline uint32_t get_code_pointBE(const char c1, const char c2) {
+    return get_code_unitBE(c1, c2);
+  }
+  static inline uint32_t get_code_pointBE(const char c1, const char c2, const char c3, const char c4) {
+    uint32_t u1 = get_code_unitBE(c1, c2);
+    uint32_t u2 = get_code_unitBE(c3, c4);
+    return codePointFromSurrogates(u1, u2);
+  }
+  static inline uint32_t get_code_pointLE(const char c1, const char c2) {
+    return get_code_unitLE(c1, c2);
+  }
+  static inline uint32_t get_code_pointLE(const char c1, const char c2, const char c3, const char c4) {
+    uint32_t u1 = get_code_unitLE(c1, c2);
+    uint32_t u2 = get_code_unitLE(c3, c4);
+    return codePointFromSurrogates(u1, u2);
+  }
+
+  static inline bool isBasicMultilingualPlane(uint32_t u1) {
+    return (u1 <= 0xD7FF || (u1 >=0xE000 && u1 <= 0xFFFF));
+  }
+  static inline bool isHighSurrogate(uint32_t u1) {
+    return (u1 >= 0xD800 && u1 <= 0xDBFF);
+  }
+  static inline bool isLowSurrogate(uint32_t u1) {
+    return (u1 >= 0xDC00 && u1 <= 0xDFFF);
+  }
+  static inline uint32_t codePointFromSurrogates(uint32_t high, uint32_t low) {
+    high = high - 0xD800;
+    low = low - 0xDC00;
+    high = (high << 10) | low;
+    high = high + 0x10000;
+    return high;
+  }
+};
+
+class UTF32Validator {
+public:
+  static inline uint32_t get_code_pointBE(const char c1, const char c2, const char c3, const char c4) {
+    uint32_t u1, u2, u3, u4;
+    u1 = static_cast<uint32_t>(static_cast<unsigned char>(c1));
+    u2 = static_cast<uint32_t>(static_cast<unsigned char>(c2));
+    u3 = static_cast<uint32_t>(static_cast<unsigned char>(c3));
+    u4 = static_cast<uint32_t>(static_cast<unsigned char>(c4));
+    return (u1 << 24) | (u2 << 16) | (u3 << 8) | u4;
+  }
+  static inline uint32_t get_code_pointLE(const char c1, const char c2, const char c3, const char c4) {
+    uint32_t u1, u2, u3, u4;
+    u1 = static_cast<uint32_t>(static_cast<unsigned char>(c1));
+    u2 = static_cast<uint32_t>(static_cast<unsigned char>(c2));
+    u3 = static_cast<uint32_t>(static_cast<unsigned char>(c3));
+    u4 = static_cast<uint32_t>(static_cast<unsigned char>(c4));
+    return (u4 << 24) | (u3 << 16) | (u2 << 8) | u1;
+  }
+};
+
+class UCS2Validator {
+public:
+  static inline uint32_t get_code_unitBE(const char c1, const char c2) {
+    uint32_t u1, u2;
+    u1 = static_cast<uint32_t>(static_cast<unsigned char>(c1));
+    u2 = static_cast<uint32_t>(static_cast<unsigned char>(c2));
+    u1 = (u1 << 8) | u2;
+    return u1;
+  }
+  static inline uint32_t get_code_unitLE(const char c1, const char c2) {
+    uint32_t u1, u2;
+    u1 = static_cast<uint32_t>(static_cast<unsigned char>(c1));
+    u2 = static_cast<uint32_t>(static_cast<unsigned char>(c2));
+    u1 = (u2 << 8) | u1;
+    return u1;
+  }
+};
+
+size_t CodePointIterator::get_prev_code_unit_length() const {
+  if (p_pos -1 >= p_end) return 0;
+  if (p_pos -1 < p_begin) return 0;
+
+  if (p_encoding == "UTF-8" || p_encoding == "UTF8") {
+    const char *pos = p_pos;
+    if (pos <= p_begin) return 0;
+    size_t len = 0;
+    pos--;
+    len++;
+    while (len <= 5 && pos >= p_begin && UTF8Validator::isContByte(*pos)) {
+      len++;
+      pos--;
+    }
+    if (pos < p_begin) {
+      stop("Encoding error. First byte in stream is a UTF-8 continuation byte");
+    }
+    size_t should_be_length = UTF8Validator::codeUnitSize(*pos);
+    if (should_be_length != len) {
+      stop("Encoding error. Leading byte marked %d bytes, found %d", should_be_length, len);
+    }
+    return len;
+  } else if (p_encoding == "UCS-2BE" || p_encoding == "UCS-2LE") {
+    if (p_pos - 2 < p_begin) {
+      return 0;
+    }
+    return 2;
+  } else if (p_encoding == "UTF-16BE" || p_encoding == "UTF16BE") {
+    uint32_t u1, u2;
+    if (p_pos - 2 < p_begin) {
+      return 0;
+    }
+    u2 = UTF16Validator::get_code_pointBE((*p_pos - 2), (*p_pos - 1));
+    if (UTF16Validator::isBasicMultilingualPlane(u2)) {
+      return 2;
+    }
+    if (UTF16Validator::isLowSurrogate(u2)) {
+      if (p_pos - 4 < p_begin) {
+        return 0;
+      }
+      u1 = UTF16Validator::get_code_pointBE((*p_pos - 4), (*p_pos - 3));
+      if (!UTF16Validator::isHighSurrogate(u1)) {
+        stop("Encoding error. Mismatch high/low UTF16BE surrogates");
+      }
+      return 4;
+    }
+    stop("Invalid UTF16BE character found");
+  } else if (p_encoding == "UTF-16LE" || p_encoding == "UTF16LE") {
+    uint32_t u1, u2;
+    if (p_pos - 2 < p_begin) {
+      return 0;
+    }
+    u2 = UTF16Validator::get_code_pointLE((*p_pos - 2), (*p_pos - 1));
+    if (UTF16Validator::isBasicMultilingualPlane(u2)) {
+      return 2;
+    }
+    if (UTF16Validator::isLowSurrogate(u2)) {
+      if (p_pos - 4 < p_begin) {
+        return 0;
+      }
+      u1 = UTF16Validator::get_code_pointLE((*p_pos - 4), (*p_pos - 3));
+      if (!UTF16Validator::isHighSurrogate(u1)) {
+        stop("Encoding error. Mismatch high/low UTF16LE surrogates");
+      }
+      return 4;
+    }
+    stop("Invalid UTF16LE character found");
+  } else if (p_encoding == "UCS4" || p_encoding == "UCS-4" ||
+    p_encoding == "UCS-4BE" || p_encoding == "UCS-4LE" ||
+    p_encoding == "UTF32" || p_encoding == "UTF-32" ||
+    p_encoding == "UTF-32BE" || p_encoding == "UTF-32LE" ||
+    p_encoding == "UTF32BE" || p_encoding == "UTF32LE") {
+    return 4;
+  } else {
+    /* For most cases (latin-1...) this is true, FIXME: Big5 and ShiftJIS are not yet contemplated */
+    return 1;
+  }
+}
+
+size_t CodePointIterator::get_code_unit_length() const {
+  if (p_pos == p_end) return 0;
+  if (p_pos < p_begin) return 0;
+
+  if (p_encoding == "UTF-8" || p_encoding == "UTF8") {
+    size_t len = 0;
+    const char *pos = p_pos;
+    if (UTF8Validator::isContByte(*pos)) {
+      stop("UTF-8 continuation byte in a leading position. Encoding error.");
+    }
+    if (UTF8Validator::isLeadingSingleByte(*pos)) {
+      return 1;
+    }
+    if (UTF8Validator::isLeadingDoubleByte(*pos)) {
+      if ((pos + 1 < p_end) && UTF8Validator::isContByte(*(pos+1))) {
+        return 2;
+      } else {
+        stop("Invalid 2-byte UTF-8 character at position %d", pos - p_begin);
+      }
+    }
+    if (UTF8Validator::isLeadingTripleByte(*pos)) {
+      if ((pos + 2 < p_end) &&
+          UTF8Validator::isContByte(*(pos+1)) &&
+          UTF8Validator::isContByte(*(pos+2))) {
+        return 3;
+      } else {
+        stop("Invalid 3-byte UTF-8 character at position %d", pos - p_begin);
+      }
+    }
+    if (UTF8Validator::isLeadingQuadByte(*pos)) {
+      if ((pos + 3 < p_end) &&
+          UTF8Validator::isContByte(*(pos+1)) &&
+          UTF8Validator::isContByte(*(pos+2)) &&
+          UTF8Validator::isContByte(*(pos+3))) {
+        return 4;
+      } else {
+        stop("Invalid 4-byte UTF-8 character at position %d", pos - p_begin);
+      }
+    }
+    stop("Invalid UTF-8 character at position %d", pos +1 - p_begin);
+  } else if (p_encoding == "UCS-2BE") {
+    if (p_pos + 1 == p_end) {
+      stop("Truncated %s character", p_encoding.c_str());
+    }
+    uint32_t u1 = UCS2Validator::get_code_unitBE(*p_pos, *(p_pos + 1));
+    if (u1 > 0xD7FF && u1 < 0xE000) {
+      stop("Invalid %s character", p_encoding.c_str());
+    }
+    return 2;
+  } else if (p_encoding == "UCS-2LE") {
+    if (p_pos + 1 == p_end) {
+      stop("Truncated %s character", p_encoding.c_str());
+    }
+    uint32_t u1 = UCS2Validator::get_code_unitLE(*p_pos, *(p_pos + 1));
+    if (u1 > 0xD7FF && u1 < 0xE000) {
+      stop("Invalid %s character", p_encoding.c_str());
+    }
+    return 2;
+  } else if (p_encoding == "UTF-16BE" || p_encoding == "UTF16BE") {
+    if (p_pos + 1 == p_end) {
+      stop("Invalid/Truncated %s character", p_encoding.c_str());
+    }
+    uint32_t u1, u2;
+    u1 = UTF16Validator::get_code_unitBE(*p_pos, *(p_pos+1));
+    if (UTF16Validator::isBasicMultilingualPlane(u1)) {
+      return 2;
+    }
+    if (!UTF16Validator::isHighSurrogate(u1)) {
+      stop("Invalid %s character: high surrogate too large", p_encoding.c_str());
+    }
+    /* Surrogate pair */
+    if (p_pos + 3 >= p_end) {
+      stop("Invalid/Truncated %s character. Surrogate pair ends too soon", p_encoding.c_str());
+    }
+    u2 = UTF16Validator::get_code_unitBE(*(p_pos+2), *(p_pos+3));
+    if (!UTF16Validator::isLowSurrogate(u2)) {
+      stop("Invalid %s character: low surrogate out of range", p_encoding.c_str());
+    }
+    return 4;
+  } else if (p_encoding == "UTF-16LE" ||  p_encoding == "UTF16LE") {
+    if (p_pos + 1 == p_end) {
+      stop("Invalid/Truncated %s character. Missing second byte of UTF-16LE code unit.", p_encoding.c_str());
+    }
+    uint32_t u1, u2;
+    u1 = UTF16Validator::get_code_unitLE(*p_pos, *(p_pos+1));
+
+    if (UTF16Validator::isBasicMultilingualPlane(u1)) {
+      return 2;
+    }
+
+    if (!UTF16Validator::isHighSurrogate(u1)) {
+      stop("Invalid %s character: high surrogate too large", p_encoding.c_str());
+    }
+
+    /* Surrogate pair */
+
+    if (p_pos + 3 >= p_end) {
+      stop("Invalid/Truncated %s character. Surrogate pair ends too soon", p_encoding.c_str());
+    }
+
+    u2 = UTF16Validator::get_code_unitLE(*(p_pos+2), *(p_pos+3));
+    if (!UTF16Validator::isLowSurrogate(u2)) {
+      stop("Invalid %s character: low surrogate out of range", p_encoding.c_str());
+    }
+    return 4;
+  } else if (p_encoding == "UCS4" || p_encoding == "UCS-4" ||
+    p_encoding == "UCS-4BE" || p_encoding == "UCS-4LE" ||
+    p_encoding == "UTF32" || p_encoding == "UTF-32" ||
+    p_encoding == "UTF-32BE" || p_encoding == "UTF-32LE" ||
+    p_encoding == "UTF32BE" || p_encoding == "UTF32LE") {
+    if (p_pos + 3 >= p_end) {
+      stop("Invalid/Truncated %s character", p_encoding.c_str());
+    }
+    return 4;
+  } else {
+    return 1;
+  }
+}
+
+uint32_t CodePointIterator::get_code_point() const {
+  if (p_pos < p_begin || p_pos == p_end) return CODEPOINT_ERROR;
+  uint32_t u1, u2, u3, u4;
+  size_t len = get_code_unit_length();
+  if (p_encoding == "UTF-8" || p_encoding == "UTF8") {
+    switch (len) {
+    case 1:
+      return UTF8Validator::get_code_point(*p_pos);
+    case 2:
+      return UTF8Validator::get_code_point(*p_pos, *(p_pos + 1));
+    case 3:
+      return UTF8Validator::get_code_point(*p_pos, *(p_pos + 1), *(p_pos + 2));
+    case 4:
+      return UTF8Validator::get_code_point(*p_pos, *(p_pos + 1), *(p_pos + 2),
+                                           *(p_pos + 3));
+    default:
+      return CODEPOINT_ERROR;
+    }
+  } else if (p_encoding == "UCS-2BE") {
+    return UCS2Validator::get_code_unitBE(*p_pos, *(p_pos + 1));
+  } else if (p_encoding == "UCS-2LE") {
+    return UCS2Validator::get_code_unitLE(*p_pos, *(p_pos + 1));
+  } else if (p_encoding == "UTF-16BE" || p_encoding == "UTF16BE") {
+    if (len == 2) {
+      return UTF16Validator::get_code_pointBE(*p_pos, *(p_pos + 1));
+    } else if (len == 4) {
+      return UTF16Validator::get_code_pointBE(*p_pos, *(p_pos + 1),
+                                              *(p_pos + 2), *(p_pos + 3));
+    } else {
+      return CODEPOINT_ERROR;
+    }
+  } else if (p_encoding == "UTF-16LE" ||  p_encoding == "UTF16LE") {
+    if (len == 2) {
+      return UTF16Validator::get_code_pointLE(*p_pos, *(p_pos + 1));
+    } else if (len == 4) {
+      return UTF16Validator::get_code_pointLE(*p_pos, *(p_pos + 1),
+                                              *(p_pos + 2), *(p_pos + 3));
+    } else {
+      return CODEPOINT_ERROR;
+    }
+  } else if (p_encoding == "UCS-4BE" || p_encoding == "UTF-32BE" || p_encoding == "UTF32BE") {
+    return UTF32Validator::get_code_pointBE(*p_pos, *(p_pos + 1),
+                                            *(p_pos + 2), *(p_pos + 3));
+  } else if (p_encoding == "UCS-4LE" || p_encoding == "UTF-32LE" || p_encoding == "UTF32LE") {
+    return UTF32Validator::get_code_pointLE(*p_pos, *(p_pos + 1),
+                                            *(p_pos + 2), *(p_pos + 3));
+  } else {
+    return static_cast<uint32_t>(static_cast<unsigned char>(*p_pos));
+  }
+}

--- a/src/CodePointIterator.cpp
+++ b/src/CodePointIterator.cpp
@@ -256,7 +256,6 @@ size_t CodePointIterator::get_code_unit_length() const {
     return 0;
 
   if (p_encoding == "UTF-8" || p_encoding == "UTF8") {
-    size_t len = 0;
     const char* pos = p_pos;
     if (UTF8Validator::isContByte(*pos)) {
       stop("UTF-8 continuation byte in a leading position. Encoding error.");
@@ -385,7 +384,6 @@ size_t CodePointIterator::get_code_unit_length() const {
 uint32_t CodePointIterator::get_code_point() const {
   if (p_pos < p_begin || p_pos == p_end)
     return CODEPOINT_ERROR;
-  uint32_t u1, u2, u3, u4;
   size_t len = get_code_unit_length();
   if (p_encoding == "UTF-8" || p_encoding == "UTF8") {
     switch (len) {

--- a/src/CodePointIterator.cpp
+++ b/src/CodePointIterator.cpp
@@ -9,17 +9,29 @@ using namespace Rcpp;
 class UTF8Validator {
 public:
   static inline size_t codeUnitSize(const char c) {
-    if (isLeadingSingleByte(c)) return 1;
-    if (isLeadingDoubleByte(c)) return 2;
-    if (isLeadingTripleByte(c)) return 3;
-    if (isLeadingQuadByte(c)) return 4;
+    if (isLeadingSingleByte(c))
+      return 1;
+    if (isLeadingDoubleByte(c))
+      return 2;
+    if (isLeadingTripleByte(c))
+      return 3;
+    if (isLeadingQuadByte(c))
+      return 4;
     return 0;
   }
-  static inline bool isLeadingSingleByte(const char c) {return (c & 0x80) == 0x00;}
-  static inline bool isLeadingDoubleByte(const char c) {return (c & 0xE0) == 0xC0;}
-  static inline bool isLeadingTripleByte(const char c) {return (c & 0xF0) == 0xE0;}
-  static inline bool isLeadingQuadByte(const char c) {return (c & 0xF8) == 0xF0;}
-  static inline bool isContByte(const char c) {return (c & 0xC0) == 0x80;}
+  static inline bool isLeadingSingleByte(const char c) {
+    return (c & 0x80) == 0x00;
+  }
+  static inline bool isLeadingDoubleByte(const char c) {
+    return (c & 0xE0) == 0xC0;
+  }
+  static inline bool isLeadingTripleByte(const char c) {
+    return (c & 0xF0) == 0xE0;
+  }
+  static inline bool isLeadingQuadByte(const char c) {
+    return (c & 0xF8) == 0xF0;
+  }
+  static inline bool isContByte(const char c) { return (c & 0xC0) == 0x80; }
   static inline uint32_t get_code_point(const char c1) {
     return static_cast<uint32_t>(static_cast<unsigned char>(c1));
   };
@@ -31,7 +43,8 @@ public:
     u2 = u2 & 0x3F;
     return (u1 << 6) | u2;
   }
-  static inline uint32_t get_code_point(const char c1, const char c2, const char c3) {
+  static inline uint32_t
+  get_code_point(const char c1, const char c2, const char c3) {
     uint32_t u1, u2, u3;
     u1 = static_cast<uint32_t>(static_cast<unsigned char>(c1));
     u2 = static_cast<uint32_t>(static_cast<unsigned char>(c2));
@@ -41,7 +54,8 @@ public:
     u3 = u3 & 0x3F;
     return (u1 << 12) | (u2 << 6) | u3;
   }
-  static inline uint32_t get_code_point(const char c1, const char c2, const char c3, const char c4) {
+  static inline uint32_t
+  get_code_point(const char c1, const char c2, const char c3, const char c4) {
     uint32_t u1, u2, u3, u4;
     u1 = static_cast<uint32_t>(static_cast<unsigned char>(c1));
     u2 = static_cast<uint32_t>(static_cast<unsigned char>(c2));
@@ -74,7 +88,8 @@ public:
   static inline uint32_t get_code_pointBE(const char c1, const char c2) {
     return get_code_unitBE(c1, c2);
   }
-  static inline uint32_t get_code_pointBE(const char c1, const char c2, const char c3, const char c4) {
+  static inline uint32_t
+  get_code_pointBE(const char c1, const char c2, const char c3, const char c4) {
     uint32_t u1 = get_code_unitBE(c1, c2);
     uint32_t u2 = get_code_unitBE(c3, c4);
     return codePointFromSurrogates(u1, u2);
@@ -82,14 +97,15 @@ public:
   static inline uint32_t get_code_pointLE(const char c1, const char c2) {
     return get_code_unitLE(c1, c2);
   }
-  static inline uint32_t get_code_pointLE(const char c1, const char c2, const char c3, const char c4) {
+  static inline uint32_t
+  get_code_pointLE(const char c1, const char c2, const char c3, const char c4) {
     uint32_t u1 = get_code_unitLE(c1, c2);
     uint32_t u2 = get_code_unitLE(c3, c4);
     return codePointFromSurrogates(u1, u2);
   }
 
   static inline bool isBasicMultilingualPlane(uint32_t u1) {
-    return (u1 <= 0xD7FF || (u1 >=0xE000 && u1 <= 0xFFFF));
+    return (u1 <= 0xD7FF || (u1 >= 0xE000 && u1 <= 0xFFFF));
   }
   static inline bool isHighSurrogate(uint32_t u1) {
     return (u1 >= 0xD800 && u1 <= 0xDBFF);
@@ -108,7 +124,8 @@ public:
 
 class UTF32Validator {
 public:
-  static inline uint32_t get_code_pointBE(const char c1, const char c2, const char c3, const char c4) {
+  static inline uint32_t
+  get_code_pointBE(const char c1, const char c2, const char c3, const char c4) {
     uint32_t u1, u2, u3, u4;
     u1 = static_cast<uint32_t>(static_cast<unsigned char>(c1));
     u2 = static_cast<uint32_t>(static_cast<unsigned char>(c2));
@@ -116,7 +133,8 @@ public:
     u4 = static_cast<uint32_t>(static_cast<unsigned char>(c4));
     return (u1 << 24) | (u2 << 16) | (u3 << 8) | u4;
   }
-  static inline uint32_t get_code_pointLE(const char c1, const char c2, const char c3, const char c4) {
+  static inline uint32_t
+  get_code_pointLE(const char c1, const char c2, const char c3, const char c4) {
     uint32_t u1, u2, u3, u4;
     u1 = static_cast<uint32_t>(static_cast<unsigned char>(c1));
     u2 = static_cast<uint32_t>(static_cast<unsigned char>(c2));
@@ -145,12 +163,15 @@ public:
 };
 
 size_t CodePointIterator::get_prev_code_unit_length() const {
-  if (p_pos -1 >= p_end) return 0;
-  if (p_pos -1 < p_begin) return 0;
+  if (p_pos - 1 >= p_end)
+    return 0;
+  if (p_pos - 1 < p_begin)
+    return 0;
 
   if (p_encoding == "UTF-8" || p_encoding == "UTF8") {
-    const char *pos = p_pos;
-    if (pos <= p_begin) return 0;
+    const char* pos = p_pos;
+    if (pos <= p_begin)
+      return 0;
     size_t len = 0;
     pos--;
     len++;
@@ -163,7 +184,10 @@ size_t CodePointIterator::get_prev_code_unit_length() const {
     }
     size_t should_be_length = UTF8Validator::codeUnitSize(*pos);
     if (should_be_length != len) {
-      stop("Encoding error. Leading byte marked %d bytes, found %d", should_be_length, len);
+      stop(
+          "Encoding error. Leading byte marked %d bytes, found %d",
+          should_be_length,
+          len);
     }
     return len;
   } else if (p_encoding == "UCS-2BE" || p_encoding == "UCS-2LE") {
@@ -211,25 +235,29 @@ size_t CodePointIterator::get_prev_code_unit_length() const {
       return 4;
     }
     stop("Invalid UTF16LE character found");
-  } else if (p_encoding == "UCS4" || p_encoding == "UCS-4" ||
-    p_encoding == "UCS-4BE" || p_encoding == "UCS-4LE" ||
-    p_encoding == "UTF32" || p_encoding == "UTF-32" ||
-    p_encoding == "UTF-32BE" || p_encoding == "UTF-32LE" ||
-    p_encoding == "UTF32BE" || p_encoding == "UTF32LE") {
+  } else if (
+      p_encoding == "UCS4" || p_encoding == "UCS-4" ||
+      p_encoding == "UCS-4BE" || p_encoding == "UCS-4LE" ||
+      p_encoding == "UTF32" || p_encoding == "UTF-32" ||
+      p_encoding == "UTF-32BE" || p_encoding == "UTF-32LE" ||
+      p_encoding == "UTF32BE" || p_encoding == "UTF32LE") {
     return 4;
   } else {
-    /* For most cases (latin-1...) this is true, FIXME: Big5 and ShiftJIS are not yet contemplated */
+    /* For most cases (latin-1...) this is true, FIXME: Big5 and ShiftJIS are
+     * not yet contemplated */
     return 1;
   }
 }
 
 size_t CodePointIterator::get_code_unit_length() const {
-  if (p_pos == p_end) return 0;
-  if (p_pos < p_begin) return 0;
+  if (p_pos == p_end)
+    return 0;
+  if (p_pos < p_begin)
+    return 0;
 
   if (p_encoding == "UTF-8" || p_encoding == "UTF8") {
     size_t len = 0;
-    const char *pos = p_pos;
+    const char* pos = p_pos;
     if (UTF8Validator::isContByte(*pos)) {
       stop("UTF-8 continuation byte in a leading position. Encoding error.");
     }
@@ -237,32 +265,30 @@ size_t CodePointIterator::get_code_unit_length() const {
       return 1;
     }
     if (UTF8Validator::isLeadingDoubleByte(*pos)) {
-      if ((pos + 1 < p_end) && UTF8Validator::isContByte(*(pos+1))) {
+      if ((pos + 1 < p_end) && UTF8Validator::isContByte(*(pos + 1))) {
         return 2;
       } else {
         stop("Invalid 2-byte UTF-8 character at position %d", pos - p_begin);
       }
     }
     if (UTF8Validator::isLeadingTripleByte(*pos)) {
-      if ((pos + 2 < p_end) &&
-          UTF8Validator::isContByte(*(pos+1)) &&
-          UTF8Validator::isContByte(*(pos+2))) {
+      if ((pos + 2 < p_end) && UTF8Validator::isContByte(*(pos + 1)) &&
+          UTF8Validator::isContByte(*(pos + 2))) {
         return 3;
       } else {
         stop("Invalid 3-byte UTF-8 character at position %d", pos - p_begin);
       }
     }
     if (UTF8Validator::isLeadingQuadByte(*pos)) {
-      if ((pos + 3 < p_end) &&
-          UTF8Validator::isContByte(*(pos+1)) &&
-          UTF8Validator::isContByte(*(pos+2)) &&
-          UTF8Validator::isContByte(*(pos+3))) {
+      if ((pos + 3 < p_end) && UTF8Validator::isContByte(*(pos + 1)) &&
+          UTF8Validator::isContByte(*(pos + 2)) &&
+          UTF8Validator::isContByte(*(pos + 3))) {
         return 4;
       } else {
         stop("Invalid 4-byte UTF-8 character at position %d", pos - p_begin);
       }
     }
-    stop("Invalid UTF-8 character at position %d", pos +1 - p_begin);
+    stop("Invalid UTF-8 character at position %d", pos + 1 - p_begin);
   } else if (p_encoding == "UCS-2BE") {
     if (p_pos + 1 == p_end) {
       stop("Truncated %s character", p_encoding.c_str());
@@ -286,53 +312,67 @@ size_t CodePointIterator::get_code_unit_length() const {
       stop("Invalid/Truncated %s character", p_encoding.c_str());
     }
     uint32_t u1, u2;
-    u1 = UTF16Validator::get_code_unitBE(*p_pos, *(p_pos+1));
+    u1 = UTF16Validator::get_code_unitBE(*p_pos, *(p_pos + 1));
     if (UTF16Validator::isBasicMultilingualPlane(u1)) {
       return 2;
     }
     if (!UTF16Validator::isHighSurrogate(u1)) {
-      stop("Invalid %s character: high surrogate too large", p_encoding.c_str());
+      stop(
+          "Invalid %s character: high surrogate too large", p_encoding.c_str());
     }
     /* Surrogate pair */
     if (p_pos + 3 >= p_end) {
-      stop("Invalid/Truncated %s character. Surrogate pair ends too soon", p_encoding.c_str());
+      stop(
+          "Invalid/Truncated %s character. Surrogate pair ends too soon",
+          p_encoding.c_str());
     }
-    u2 = UTF16Validator::get_code_unitBE(*(p_pos+2), *(p_pos+3));
+    u2 = UTF16Validator::get_code_unitBE(*(p_pos + 2), *(p_pos + 3));
     if (!UTF16Validator::isLowSurrogate(u2)) {
-      stop("Invalid %s character: low surrogate out of range", p_encoding.c_str());
+      stop(
+          "Invalid %s character: low surrogate out of range",
+          p_encoding.c_str());
     }
     return 4;
-  } else if (p_encoding == "UTF-16LE" ||  p_encoding == "UTF16LE") {
+  } else if (p_encoding == "UTF-16LE" || p_encoding == "UTF16LE") {
     if (p_pos + 1 == p_end) {
-      stop("Invalid/Truncated %s character. Missing second byte of UTF-16LE code unit.", p_encoding.c_str());
+      stop(
+          "Invalid/Truncated %s character. Missing second byte of UTF-16LE "
+          "code unit.",
+          p_encoding.c_str());
     }
     uint32_t u1, u2;
-    u1 = UTF16Validator::get_code_unitLE(*p_pos, *(p_pos+1));
+    u1 = UTF16Validator::get_code_unitLE(*p_pos, *(p_pos + 1));
 
     if (UTF16Validator::isBasicMultilingualPlane(u1)) {
       return 2;
     }
 
     if (!UTF16Validator::isHighSurrogate(u1)) {
-      stop("Invalid %s character: high surrogate too large", p_encoding.c_str());
+      stop(
+          "Invalid %s character: high surrogate too large", p_encoding.c_str());
     }
 
     /* Surrogate pair */
 
     if (p_pos + 3 >= p_end) {
-      stop("Invalid/Truncated %s character. Surrogate pair ends too soon", p_encoding.c_str());
+      stop(
+          "Invalid/Truncated %s character. Surrogate pair ends too soon",
+          p_encoding.c_str());
     }
 
-    u2 = UTF16Validator::get_code_unitLE(*(p_pos+2), *(p_pos+3));
+    u2 = UTF16Validator::get_code_unitLE(*(p_pos + 2), *(p_pos + 3));
     if (!UTF16Validator::isLowSurrogate(u2)) {
-      stop("Invalid %s character: low surrogate out of range", p_encoding.c_str());
+      stop(
+          "Invalid %s character: low surrogate out of range",
+          p_encoding.c_str());
     }
     return 4;
-  } else if (p_encoding == "UCS4" || p_encoding == "UCS-4" ||
-    p_encoding == "UCS-4BE" || p_encoding == "UCS-4LE" ||
-    p_encoding == "UTF32" || p_encoding == "UTF-32" ||
-    p_encoding == "UTF-32BE" || p_encoding == "UTF-32LE" ||
-    p_encoding == "UTF32BE" || p_encoding == "UTF32LE") {
+  } else if (
+      p_encoding == "UCS4" || p_encoding == "UCS-4" ||
+      p_encoding == "UCS-4BE" || p_encoding == "UCS-4LE" ||
+      p_encoding == "UTF32" || p_encoding == "UTF-32" ||
+      p_encoding == "UTF-32BE" || p_encoding == "UTF-32LE" ||
+      p_encoding == "UTF32BE" || p_encoding == "UTF32LE") {
     if (p_pos + 3 >= p_end) {
       stop("Invalid/Truncated %s character", p_encoding.c_str());
     }
@@ -343,7 +383,8 @@ size_t CodePointIterator::get_code_unit_length() const {
 }
 
 uint32_t CodePointIterator::get_code_point() const {
-  if (p_pos < p_begin || p_pos == p_end) return CODEPOINT_ERROR;
+  if (p_pos < p_begin || p_pos == p_end)
+    return CODEPOINT_ERROR;
   uint32_t u1, u2, u3, u4;
   size_t len = get_code_unit_length();
   if (p_encoding == "UTF-8" || p_encoding == "UTF8") {
@@ -355,8 +396,8 @@ uint32_t CodePointIterator::get_code_point() const {
     case 3:
       return UTF8Validator::get_code_point(*p_pos, *(p_pos + 1), *(p_pos + 2));
     case 4:
-      return UTF8Validator::get_code_point(*p_pos, *(p_pos + 1), *(p_pos + 2),
-                                           *(p_pos + 3));
+      return UTF8Validator::get_code_point(
+          *p_pos, *(p_pos + 1), *(p_pos + 2), *(p_pos + 3));
     default:
       return CODEPOINT_ERROR;
     }
@@ -368,26 +409,30 @@ uint32_t CodePointIterator::get_code_point() const {
     if (len == 2) {
       return UTF16Validator::get_code_pointBE(*p_pos, *(p_pos + 1));
     } else if (len == 4) {
-      return UTF16Validator::get_code_pointBE(*p_pos, *(p_pos + 1),
-                                              *(p_pos + 2), *(p_pos + 3));
+      return UTF16Validator::get_code_pointBE(
+          *p_pos, *(p_pos + 1), *(p_pos + 2), *(p_pos + 3));
     } else {
       return CODEPOINT_ERROR;
     }
-  } else if (p_encoding == "UTF-16LE" ||  p_encoding == "UTF16LE") {
+  } else if (p_encoding == "UTF-16LE" || p_encoding == "UTF16LE") {
     if (len == 2) {
       return UTF16Validator::get_code_pointLE(*p_pos, *(p_pos + 1));
     } else if (len == 4) {
-      return UTF16Validator::get_code_pointLE(*p_pos, *(p_pos + 1),
-                                              *(p_pos + 2), *(p_pos + 3));
+      return UTF16Validator::get_code_pointLE(
+          *p_pos, *(p_pos + 1), *(p_pos + 2), *(p_pos + 3));
     } else {
       return CODEPOINT_ERROR;
     }
-  } else if (p_encoding == "UCS-4BE" || p_encoding == "UTF-32BE" || p_encoding == "UTF32BE") {
-    return UTF32Validator::get_code_pointBE(*p_pos, *(p_pos + 1),
-                                            *(p_pos + 2), *(p_pos + 3));
-  } else if (p_encoding == "UCS-4LE" || p_encoding == "UTF-32LE" || p_encoding == "UTF32LE") {
-    return UTF32Validator::get_code_pointLE(*p_pos, *(p_pos + 1),
-                                            *(p_pos + 2), *(p_pos + 3));
+  } else if (
+      p_encoding == "UCS-4BE" || p_encoding == "UTF-32BE" ||
+      p_encoding == "UTF32BE") {
+    return UTF32Validator::get_code_pointBE(
+        *p_pos, *(p_pos + 1), *(p_pos + 2), *(p_pos + 3));
+  } else if (
+      p_encoding == "UCS-4LE" || p_encoding == "UTF-32LE" ||
+      p_encoding == "UTF32LE") {
+    return UTF32Validator::get_code_pointLE(
+        *p_pos, *(p_pos + 1), *(p_pos + 2), *(p_pos + 3));
   } else {
     return static_cast<uint32_t>(static_cast<unsigned char>(*p_pos));
   }

--- a/src/CodePointIterator.cpp
+++ b/src/CodePointIterator.cpp
@@ -7,15 +7,18 @@ using namespace Rcpp;
 #include "CodePointIterator.h"
 
 static inline bool unicode_is_blank(uint32_t cp) {
-  return (cp == 0x20 || cp == 0xA0 || cp == 0x1680 ||
-          (cp >= 0x2000 && cp < 0x200B) ||
-          cp == 0x202F || cp == 0x205F || cp == 0x3000);
+  return (
+      cp == 0x20 || cp == 0xA0 || cp == 0x1680 ||
+      (cp >= 0x2000 && cp < 0x200B) || cp == 0x202F || cp == 0x205F ||
+      cp == 0x3000);
 }
 
 class CodePointIteratorUTF8 : public CodePointIterator {
 public:
-  CodePointIteratorUTF8(const char *begin, const char *end,
-                        std::string encoding, const char *pos) : CodePointIterator(begin, end, encoding, pos) {}
+  CodePointIteratorUTF8(
+      const char* begin, const char* end, std::string encoding, const char* pos)
+      : CodePointIterator(begin, end, encoding, pos) {}
+
 private:
   static inline size_t codeUnitSize(const char c) {
     if (isLeadingSingleByte(c))
@@ -52,7 +55,8 @@ private:
     u2 = u2 & 0x3F;
     return (u1 << 6) | u2;
   }
-  static inline uint32_t get_code_point3(const char c1, const char c2, const char c3) {
+  static inline uint32_t
+  get_code_point3(const char c1, const char c2, const char c3) {
     uint32_t u1, u2, u3;
     u1 = static_cast<uint32_t>(static_cast<unsigned char>(c1));
     u2 = static_cast<uint32_t>(static_cast<unsigned char>(c2));
@@ -62,7 +66,8 @@ private:
     u3 = u3 & 0x3F;
     return (u1 << 12) | (u2 << 6) | u3;
   }
-  static inline uint32_t get_code_point4(const char c1, const char c2, const char c3, const char c4) {
+  static inline uint32_t
+  get_code_point4(const char c1, const char c2, const char c3, const char c4) {
     uint32_t u1, u2, u3, u4;
     u1 = static_cast<uint32_t>(static_cast<unsigned char>(c1));
     u2 = static_cast<uint32_t>(static_cast<unsigned char>(c2));
@@ -97,9 +102,9 @@ private:
     size_t should_be_length = codeUnitSize(*pos);
     if (should_be_length != len) {
       stop(
-        "Encoding error. Leading byte marked %d bytes, found %d",
-        should_be_length,
-        len);
+          "Encoding error. Leading byte marked %d bytes, found %d",
+          should_be_length,
+          len);
     }
     return len;
   }
@@ -140,7 +145,6 @@ private:
       }
     }
     stop("Invalid UTF-8 character at position %d", pos + 1 - p_begin);
-
   }
 
   uint32_t get_code_point() const {
@@ -161,16 +165,16 @@ private:
     }
   }
 
-  inline bool isblank(uint32_t cp) const {
-    return unicode_is_blank(cp);
-  }
+  inline bool isblank(uint32_t cp) const { return unicode_is_blank(cp); }
 };
 
 template <bool BigEndian>
 class CodePointIteratorUCS2 : public CodePointIterator {
 public:
-  CodePointIteratorUCS2(const char *begin, const char *end,
-                        std::string encoding, const char *pos) : CodePointIterator(begin, end, encoding, pos) {}
+  CodePointIteratorUCS2(
+      const char* begin, const char* end, std::string encoding, const char* pos)
+      : CodePointIterator(begin, end, encoding, pos) {}
+
 private:
   static inline uint32_t get_code_unit(const char c1, const char c2) {
     uint32_t u1, u2;
@@ -214,18 +218,16 @@ private:
     return get_code_unit(*p_pos, *(p_pos + 1));
   }
 
-  inline bool isblank(uint32_t cp) const {
-    return unicode_is_blank(cp);
-  }
-
+  inline bool isblank(uint32_t cp) const { return unicode_is_blank(cp); }
 };
 
 template <bool BigEndian>
 class CodePointIteratorUTF16 : public CodePointIterator {
 public:
-  CodePointIteratorUTF16(const char *begin, const char *end,
-                         std::string encoding, const char *pos) :
-  CodePointIterator(begin, end, encoding, pos) {}
+  CodePointIteratorUTF16(
+      const char* begin, const char* end, std::string encoding, const char* pos)
+      : CodePointIterator(begin, end, encoding, pos) {}
+
 private:
   static inline uint32_t get_code_unitBE(const char c1, const char c2) {
     uint32_t u1, u2;
@@ -251,7 +253,8 @@ private:
   static inline uint32_t get_code_pointBE2(const char c1, const char c2) {
     return get_code_unitBE(c1, c2);
   }
-  static inline uint32_t get_code_pointBE4(const char c1, const char c2, const char c3, const char c4) {
+  static inline uint32_t get_code_pointBE4(
+      const char c1, const char c2, const char c3, const char c4) {
     uint32_t u1 = get_code_unitBE(c1, c2);
     uint32_t u2 = get_code_unitBE(c3, c4);
     return codePointFromSurrogates(u1, u2);
@@ -259,7 +262,8 @@ private:
   static inline uint32_t get_code_pointLE2(const char c1, const char c2) {
     return get_code_unitLE(c1, c2);
   }
-  static inline uint32_t get_code_pointLE4(const char c1, const char c2, const char c3, const char c4) {
+  static inline uint32_t get_code_pointLE4(
+      const char c1, const char c2, const char c3, const char c4) {
     uint32_t u1 = get_code_unitLE(c1, c2);
     uint32_t u2 = get_code_unitLE(c3, c4);
     return codePointFromSurrogates(u1, u2);
@@ -271,7 +275,8 @@ private:
       return get_code_pointLE2(c1, c2);
     }
   }
-  static inline uint32_t get_code_point4(const char c1, const char c2, const char c3, const char c4) {
+  static inline uint32_t
+  get_code_point4(const char c1, const char c2, const char c3, const char c4) {
     if (BigEndian) {
       return get_code_pointBE4(c1, c2, c3, c4);
     } else {
@@ -310,12 +315,13 @@ private:
       }
       u1 = get_code_point2((*p_pos - 4), (*p_pos - 3));
       if (!isHighSurrogate(u1)) {
-        stop("Encoding error. Mismatch high/low %s surrogates", p_encoding.c_str());
+        stop(
+            "Encoding error. Mismatch high/low %s surrogates",
+            p_encoding.c_str());
       }
       return 4;
     }
     stop("Invalid UTF16BE character found");
-
   }
 
   size_t get_code_unit_length() const {
@@ -329,19 +335,19 @@ private:
     }
     if (!isHighSurrogate(u1)) {
       stop(
-        "Invalid %s character: high surrogate too large", p_encoding.c_str());
+          "Invalid %s character: high surrogate too large", p_encoding.c_str());
     }
     /* Surrogate pair */
     if (p_pos + 3 >= p_end) {
       stop(
-        "Invalid/Truncated %s character. Surrogate pair ends too soon",
-        p_encoding.c_str());
+          "Invalid/Truncated %s character. Surrogate pair ends too soon",
+          p_encoding.c_str());
     }
     u2 = get_code_unit(*(p_pos + 2), *(p_pos + 3));
     if (!isLowSurrogate(u2)) {
       stop(
-        "Invalid %s character: low surrogate out of range",
-        p_encoding.c_str());
+          "Invalid %s character: low surrogate out of range",
+          p_encoding.c_str());
     }
     return 4;
   }
@@ -359,18 +365,16 @@ private:
     }
   }
 
-  inline bool isblank(uint32_t cp) const {
-    return unicode_is_blank(cp);
-  }
-
+  inline bool isblank(uint32_t cp) const { return unicode_is_blank(cp); }
 };
 
 template <bool BigEndian>
 class CodePointIteratorUTF32 : public CodePointIterator {
 public:
-  CodePointIteratorUTF32(const char *begin, const char *end,
-                         std::string encoding, const char *pos) :
-  CodePointIterator(begin, end, encoding, pos) {}
+  CodePointIteratorUTF32(
+      const char* begin, const char* end, std::string encoding, const char* pos)
+      : CodePointIterator(begin, end, encoding, pos) {}
+
 private:
   static inline uint32_t
   get_code_pointBE(const char c1, const char c2, const char c3, const char c4) {
@@ -410,20 +414,19 @@ private:
       return CODEPOINT_ERROR;
     size_t len = get_code_unit_length();
     if (BigEndian) {
-      return get_code_pointBE(
-        *p_pos, *(p_pos + 1), *(p_pos + 2), *(p_pos + 3));
+      return get_code_pointBE(*p_pos, *(p_pos + 1), *(p_pos + 2), *(p_pos + 3));
     } else {
-      return get_code_pointLE(
-        *p_pos, *(p_pos + 1), *(p_pos + 2), *(p_pos + 3));
+      return get_code_pointLE(*p_pos, *(p_pos + 1), *(p_pos + 2), *(p_pos + 3));
     }
   }
-
 };
 
 class CodePointIteratorEASCII : public CodePointIterator {
 public:
-  CodePointIteratorEASCII(const char *begin, const char *end,
-                        std::string encoding, const char *pos) : CodePointIterator(begin, end, encoding, pos) {}
+  CodePointIteratorEASCII(
+      const char* begin, const char* end, std::string encoding, const char* pos)
+      : CodePointIterator(begin, end, encoding, pos) {}
+
 private:
   size_t get_prev_code_unit_length() const {
     if (p_pos - 1 >= p_end)
@@ -449,44 +452,47 @@ private:
   }
 };
 
-
-CodePointIteratorPtr CodePointIterator::create(const char *begin, const char *end,
-                            std::string encoding, const char *pos) {
+CodePointIteratorPtr CodePointIterator::create(
+    const char* begin, const char* end, std::string encoding, const char* pos) {
   if (encoding == "") {
     stop("Encoding not specified");
   }
   if (encoding == "UTF-16" || encoding == "UTF-32" || encoding == "UCS-2" ||
       encoding == "UCS-4") {
     stop(
-      "Specify endianness in encoding as: %sLE or %sBE",
-      encoding.c_str(),
-      encoding.c_str());
+        "Specify endianness in encoding as: %sLE or %sBE",
+        encoding.c_str(),
+        encoding.c_str());
   }
 
-    if (encoding == "UTF-8" || encoding == "UTF8") {
-      return CodePointIteratorPtr(
+  if (encoding == "UTF-8" || encoding == "UTF8") {
+    return CodePointIteratorPtr(
         new CodePointIteratorUTF8(begin, end, encoding, pos));
-    } else if (encoding == "UCS2-BE" || encoding == "UCS2BE") {
-      return CodePointIteratorPtr(
+  } else if (encoding == "UCS2-BE" || encoding == "UCS2BE") {
+    return CodePointIteratorPtr(
         new CodePointIteratorUCS2<true>(begin, end, encoding, pos));
-    } else if (encoding == "UCS2-LE" || encoding == "UCS2LE") {
-      return CodePointIteratorPtr(
+  } else if (encoding == "UCS2-LE" || encoding == "UCS2LE") {
+    return CodePointIteratorPtr(
         new CodePointIteratorUCS2<false>(begin, end, encoding, pos));
-    } else if (encoding == "UTF16-LE" || encoding == "UTF16LE") {
-      return CodePointIteratorPtr(
+  } else if (encoding == "UTF16-LE" || encoding == "UTF16LE") {
+    return CodePointIteratorPtr(
         new CodePointIteratorUTF16<false>(begin, end, encoding, pos));
-    } else if (encoding == "UTF16-BE" || encoding == "UTF16BE") {
-      return CodePointIteratorPtr(
+  } else if (encoding == "UTF16-BE" || encoding == "UTF16BE") {
+    return CodePointIteratorPtr(
         new CodePointIteratorUTF16<true>(begin, end, encoding, pos));
-    } else if (encoding == "UTF32-BE" || encoding == "UTF32BE" || encoding == "UCS-4BE") {
-      return CodePointIteratorPtr(
+  } else if (
+      encoding == "UTF32-BE" || encoding == "UTF32BE" ||
+      encoding == "UCS-4BE") {
+    return CodePointIteratorPtr(
         new CodePointIteratorUTF32<true>(begin, end, encoding, pos));
-    } else if (encoding == "UTF32-LE" || encoding == "UTF32LE" || encoding == "UCS-4LE") {
-      return CodePointIteratorPtr(
+  } else if (
+      encoding == "UTF32-LE" || encoding == "UTF32LE" ||
+      encoding == "UCS-4LE") {
+    return CodePointIteratorPtr(
         new CodePointIteratorUTF32<false>(begin, end, encoding, pos));
-    } else {
-      /* TO DO: Big5 and ShiftJIS? */
-      return CodePointIteratorPtr(
+  } else {
+    /* TO DO: Big5 and ShiftJIS? */
+    return CodePointIteratorPtr(
         new CodePointIteratorEASCII(begin, end, encoding, pos));
-    }
+  }
 }

--- a/src/CodePointIterator.h
+++ b/src/CodePointIterator.h
@@ -9,6 +9,9 @@ using namespace Rcpp;
 #include <iterator>
 #include <string>
 
+class CodePointIterator;
+typedef boost::shared_ptr<CodePointIterator> CodePointIteratorPtr;
+
 class CodePointIterator
     : public std::iterator<std::bidirectional_iterator_tag, uint32_t> {
 public:
@@ -18,10 +21,10 @@ public:
 
   static size_t code_points_between(
       const char* begin, const char* end, std::string encoding) {
-    CodePointIterator tmp(begin, end, encoding);
+    CodePointIteratorPtr tmp = create(begin, end, encoding);
     size_t out = 0;
-    while (!tmp.is_end()) {
-      ++tmp;
+    while (!tmp->is_end()) {
+      tmp->next();
       ++out;
     }
     return out;
@@ -36,18 +39,7 @@ public:
       : p_pos(pos == 0 ? begin : pos),
         p_begin(begin),
         p_end(end),
-        p_encoding(encoding) {
-    if (encoding == "") {
-      stop("Encoding not specified");
-    }
-    if (encoding == "UTF-16" || encoding == "UTF-32" || encoding == "UCS-2" ||
-        encoding == "UCS-4") {
-      stop(
-          "Specify endianness in encoding as: %sLE or %sBE",
-          encoding.c_str(),
-          encoding.c_str());
-    }
-  };
+        p_encoding(encoding) {};
 
   CodePointIterator(const CodePointIterator& obj) {
     p_begin = obj.p_begin;
@@ -57,14 +49,6 @@ public:
   }
 
   CodePointIterator() : p_pos(NULL), p_begin(NULL), p_end(NULL), p_encoding() {}
-
-  CodePointIterator begin() {
-    return CodePointIterator(p_begin, p_end, p_encoding, p_begin);
-  }
-
-  CodePointIterator end() {
-    return CodePointIterator(p_begin, p_end, p_encoding, p_end);
-  }
 
   bool is_begin() const { return (p_pos == p_begin); }
 
@@ -78,33 +62,41 @@ public:
     return !(*this == rhs);
   }
 
-  CodePointIterator& operator++() {
+  void next() {
     size_t point_size = get_code_unit_length();
     if (p_pos + point_size > p_end) {
       stop("Advancing goes past the end");
     }
     p_pos += point_size;
+  }
+
+  CodePointIterator& operator++() {
+    this->next();
     return *this;
   }
 
-  CodePointIterator operator++(int) {
-    CodePointIterator tmp(*this);
-    ++(*this);
+  CodePointIteratorPtr operator++(int) {
+    CodePointIteratorPtr tmp = create(*this);
+    this->next();
     return tmp;
   }
 
-  CodePointIterator& operator--() {
+  void prev() {
     size_t point_size = get_prev_code_unit_length();
     if (p_pos - point_size < p_begin) {
       stop("Going back before the beginning");
     }
     p_pos -= point_size;
+  }
+
+  CodePointIterator& operator--() {
+    this->prev();
     return *this;
   }
 
-  CodePointIterator operator--(int) {
-    CodePointIterator tmp(*this);
-    --(*this);
+  CodePointIteratorPtr operator--(int) {
+    CodePointIteratorPtr tmp = create(*this);
+    this->prev();
     return tmp;
   }
 
@@ -114,31 +106,37 @@ public:
 
   const char* get_end() const { return p_end; }
 
-  uint32_t operator*() const { return get_code_point(); }
+  uint32_t cp() const { return get_code_point();}
+  uint32_t operator*() const { return cp();}
 
-  CodePointIterator operator+(int i) {
-    CodePointIterator tmp(*this);
-    if (i > 0) {
-      for (int j = 0; j < i; ++j) {
-        ++tmp;
+
+  static CodePointIteratorPtr shift(const CodePointIterator* pt, int offset) {
+    CodePointIteratorPtr tmp = create(*pt);
+    if (offset > 0) {
+      for (int j = 0; j < offset; ++j) {
+        tmp->next();
       }
-    } else if (i < 0) {
-      for (int j = 0; j < -i; ++j) {
-        --tmp;
+    } else if (offset < 0) {
+      for (int j = 0; j < -offset; ++j) {
+        tmp->prev();
       }
     }
     return tmp;
   }
 
-  CodePointIterator operator-(int i) {
-    CodePointIterator tmp(*this);
+  CodePointIteratorPtr operator+(int i) {
+    return shift(this, i);
+  }
+
+  CodePointIteratorPtr operator-(int i) {
+    CodePointIteratorPtr tmp = create(*this);
     if (i > 0) {
       for (int j = 0; j < i; ++j) {
-        --tmp;
+        tmp->prev();
       }
     } else if (i < 0) {
       for (int j = 0; j < -i; ++j) {
-        ++tmp;
+        tmp->next();
       }
     }
     return tmp;
@@ -146,82 +144,47 @@ public:
 
   /* For most encodings (UTF-8, UTF-16, UTF-32, latin1...), the code points are
      ascii-compatible. Even for encodings like UTF-16, where ASCII characters
-     are
-     represented as code units of 2 bytes, the code point that represents those
+     are represented as code units of 2 bytes, the code point that represents those
      code units is Unicode and the unicode numbering starts like the ASCII.
 
      However, there are some encodings (e.g. CP1026, that is EBCDIC based) where
      there is not ASCII compatibility. If you want to add support to those
-     encodings
-     you just need to modify these cp_* functions.
+     encodings you just need to modify these cp_* functions, or make them virtual
+     and edit the inherited function.
   */
-  inline uint32_t cp_null() const { return 0x00; }
+  static inline uint32_t cp_null() { return 0x00; }
 
-  inline uint32_t cp_alert() const { return 0x07; }
+  static inline uint32_t cp_alert() { return 0x07; }
 
-  inline uint32_t cp_backspace() const {
-    if (p_encoding == "CP1026") {
-      return 0x16;
-    }
+  static inline uint32_t cp_backspace() {
     return 0x08;
   }
 
-  inline uint32_t cp_htab() const {
-    if (p_encoding == "CP1026") {
-      return 0x05;
-    }
+  static inline uint32_t cp_htab() {
     return 0x09;
   }
 
-  inline uint32_t cp_lf() const {
-    if (p_encoding == "CP1026") {
-      return 0x25;
-    }
+  static inline uint32_t cp_lf() {
     return 0x0A;
   }
 
-  inline uint32_t cp_vtab() const { return 0x0B; }
+  static inline uint32_t cp_vtab() { return 0x0B; }
 
-  inline uint32_t cp_formfeed() const { return 0x0C; }
+  static inline uint32_t cp_formfeed() { return 0x0C; }
 
-  inline uint32_t cp_cr() const { return 0x0D; }
+  static inline uint32_t cp_cr() { return 0x0D; }
 
-  inline uint32_t cp_space() const {
-    if (p_encoding == "CP1026") {
-      return 0x40;
-    }
-    return 0x20;
-  }
+  static inline uint32_t cp_space() { return 0x20; }
 
-  inline uint32_t cp_quotation_mark() const {
-    if (p_encoding == "CP1026") {
-      return 0xFC;
-    }
-    return 0x22;
-  }
+  static inline uint32_t cp_quotation_mark() { return 0x22; }
 
-  inline uint32_t cp_left_square_bracket() const {
-    if (p_encoding == "CP1026") {
-      return 0x68;
-    }
-    return 0x5B;
-  }
+  static inline uint32_t cp_left_square_bracket() { return 0x5B; }
 
-  inline uint32_t cp_backslash() const {
-    if (p_encoding == "CP1026") {
-      return 0xDC;
-    }
-    return 0x5C;
-  }
+  static inline uint32_t cp_backslash() { return 0x5C; }
 
-  inline uint32_t cp_right_square_bracket() const {
-    if (p_encoding == "CP1026") {
-      return 0xAC;
-    }
-    return 0x5D;
-  }
+  static inline uint32_t cp_right_square_bracket() { return 0x5D; }
 
-  inline bool isblank(uint32_t cp) const {
+  virtual inline bool isblank(uint32_t cp) const {
     return cp == cp_htab() || cp == cp_space();
   }
 
@@ -239,8 +202,8 @@ public:
     uint32_t cr = cp_cr();
     uint32_t lf = cp_lf();
     uint32_t unit;
-    for (; !is_end(); ++(*this)) {
-      unit = this->get_code_point();
+    for (; !is_end(); next()) {
+      unit = this->cp();
       if (unit == cr || unit == lf) {
         break;
       }
@@ -249,21 +212,33 @@ public:
   }
 
   void advance_if_crlf() {
-    if (this->get_code_point() == cp_cr() && !((*this + 1).is_end()) &&
-        *((*this) + 1) == cp_lf()) {
-      ++(*this);
+    if (this->get_code_point() == cp_cr() && !((*this + 1)->is_end()) &&
+        ((*this) + 1)->cp() == cp_lf()) {
+      this->next();
     }
   }
 
-private:
+  static CodePointIteratorPtr create(const CodePointIterator& obj) {
+    return CodePointIterator::create(obj.p_begin, obj.p_end, obj.p_encoding, obj.p_pos);
+
+  }
+
+  static CodePointIteratorPtr create(
+      const char* begin,
+      const char* end,
+      std::string encoding,
+      const char* pos = 0);
+
+protected:
   const char* p_pos;
   const char* p_begin;
   const char* p_end;
   std::string p_encoding;
 
-  size_t get_prev_code_unit_length() const;
-  size_t get_code_unit_length() const;
-  uint32_t get_code_point() const;
+private:
+  virtual size_t get_prev_code_unit_length() const = 0;
+  virtual size_t get_code_unit_length() const = 0;
+  virtual uint32_t get_code_point() const = 0;
 };
 
 #endif

--- a/src/CodePointIterator.h
+++ b/src/CodePointIterator.h
@@ -6,20 +6,18 @@ using namespace Rcpp;
 #include "boost.h"
 #include <boost/cstdint.hpp>
 
-#include <string>
 #include <iterator>
+#include <string>
 
-class CodePointIterator : public std::iterator<std::bidirectional_iterator_tag, uint32_t> {
+class CodePointIterator
+    : public std::iterator<std::bidirectional_iterator_tag, uint32_t> {
 public:
-  inline size_t bytes_passed() const {
-    return get_pos() - get_begin();
-  }
+  inline size_t bytes_passed() const { return get_pos() - get_begin(); }
 
-  inline size_t bytes_total() const {
-    return get_end() - get_begin();
-  }
+  inline size_t bytes_total() const { return get_end() - get_begin(); }
 
-  static size_t code_points_between(const char *begin, const char *end, std::string encoding) {
+  static size_t code_points_between(
+      const char* begin, const char* end, std::string encoding) {
     CodePointIterator tmp(begin, end, encoding);
     size_t out = 0;
     while (!tmp.is_end()) {
@@ -30,20 +28,28 @@ public:
   }
 
   static const uint32_t CODEPOINT_ERROR = 0xFFFFFFFF;
-  CodePointIterator(const char *begin, const char *end, std::string encoding,
-                    const char *pos = 0) : p_encoding(encoding),
-                    p_pos(pos == 0 ? begin : pos),
-                    p_begin(begin),
-                    p_end(end) {
+  CodePointIterator(
+      const char* begin,
+      const char* end,
+      std::string encoding,
+      const char* pos = 0)
+      : p_encoding(encoding),
+        p_pos(pos == 0 ? begin : pos),
+        p_begin(begin),
+        p_end(end) {
     if (encoding == "") {
       stop("Encoding not specified");
     }
-    if (encoding == "UTF-16" || encoding == "UTF-32" || encoding == "UCS-2" || encoding == "UCS-4") {
-      stop("Specify endianness in encoding as: %sLE or %sBE", encoding.c_str(), encoding.c_str());
+    if (encoding == "UTF-16" || encoding == "UTF-32" || encoding == "UCS-2" ||
+        encoding == "UCS-4") {
+      stop(
+          "Specify endianness in encoding as: %sLE or %sBE",
+          encoding.c_str(),
+          encoding.c_str());
     }
   };
 
-  CodePointIterator(const CodePointIterator &obj) {
+  CodePointIterator(const CodePointIterator& obj) {
     p_begin = obj.p_begin;
     p_pos = obj.p_pos;
     p_end = obj.p_end;
@@ -60,20 +66,16 @@ public:
     return CodePointIterator(p_begin, p_end, p_encoding, p_end);
   }
 
-  bool is_begin() const {
-    return (p_pos == p_begin);
-  }
+  bool is_begin() const { return (p_pos == p_begin); }
 
-  bool is_end() const {
-    return (p_pos == p_end);
-  }
+  bool is_end() const { return (p_pos == p_end); }
 
   bool operator==(CodePointIterator const& rhs) const {
     return (p_pos == rhs.p_pos);
   }
 
   bool operator!=(CodePointIterator const& rhs) const {
-    return !(*this==rhs);
+    return !(*this == rhs);
   }
 
   CodePointIterator& operator++() {
@@ -86,7 +88,7 @@ public:
   }
 
   CodePointIterator operator++(int) {
-    CodePointIterator tmp (*this);
+    CodePointIterator tmp(*this);
     ++(*this);
     return tmp;
   }
@@ -101,49 +103,41 @@ public:
   }
 
   CodePointIterator operator--(int) {
-    CodePointIterator tmp (*this);
+    CodePointIterator tmp(*this);
     --(*this);
     return tmp;
   }
 
-  const char * get_begin() const {
-    return p_begin;
-  }
+  const char* get_begin() const { return p_begin; }
 
-  const char * get_pos() const {
-    return p_pos;
-  }
+  const char* get_pos() const { return p_pos; }
 
-  const char * get_end() const {
-    return p_end;
-  }
+  const char* get_end() const { return p_end; }
 
-  uint32_t operator* () const {
-    return get_code_point();
-  }
+  uint32_t operator*() const { return get_code_point(); }
 
-  CodePointIterator operator+ (int i) {
+  CodePointIterator operator+(int i) {
     CodePointIterator tmp(*this);
     if (i > 0) {
-      for (int j=0; j<i;++j) {
+      for (int j = 0; j < i; ++j) {
         ++tmp;
       }
     } else if (i < 0) {
-      for (int j=0; j<-i;++j) {
+      for (int j = 0; j < -i; ++j) {
         --tmp;
       }
     }
     return tmp;
   }
 
-  CodePointIterator operator- (int i) {
+  CodePointIterator operator-(int i) {
     CodePointIterator tmp(*this);
     if (i > 0) {
-      for (int j=0; j<i;++j) {
+      for (int j = 0; j < i; ++j) {
         --tmp;
       }
     } else if (i < 0) {
-      for (int j=0; j<-i;++j) {
+      for (int j = 0; j < -i; ++j) {
         ++tmp;
       }
     }
@@ -151,21 +145,19 @@ public:
   }
 
   /* For most encodings (UTF-8, UTF-16, UTF-32, latin1...), the code points are
-     ascii-compatible. Even for encodings like UTF-16, where ASCII characters are
+     ascii-compatible. Even for encodings like UTF-16, where ASCII characters
+     are
      represented as code units of 2 bytes, the code point that represents those
      code units is Unicode and the unicode numbering starts like the ASCII.
 
      However, there are some encodings (e.g. CP1026, that is EBCDIC based) where
-     there is not ASCII compatibility. If you want to add support to those encodings
+     there is not ASCII compatibility. If you want to add support to those
+     encodings
      you just need to modify these cp_* functions.
   */
-  inline uint32_t cp_null() const {
-    return 0x00;
-  }
+  inline uint32_t cp_null() const { return 0x00; }
 
-  inline uint32_t cp_alert() const {
-    return 0x07;
-  }
+  inline uint32_t cp_alert() const { return 0x07; }
 
   inline uint32_t cp_backspace() const {
     if (p_encoding == "CP1026") {
@@ -188,17 +180,11 @@ public:
     return 0x0A;
   }
 
-  inline uint32_t cp_vtab() const {
-    return 0x0B;
-  }
+  inline uint32_t cp_vtab() const { return 0x0B; }
 
-  inline uint32_t cp_formfeed() const {
-    return 0x0C;
-  }
+  inline uint32_t cp_formfeed() const { return 0x0C; }
 
-  inline uint32_t cp_cr() const {
-    return 0x0D;
-  }
+  inline uint32_t cp_cr() const { return 0x0D; }
 
   inline uint32_t cp_space() const {
     if (p_encoding == "CP1026") {
@@ -236,12 +222,12 @@ public:
   }
 
   inline bool isblank(uint32_t cp) const {
-    return cp == cp_htab() || cp ==  cp_space();
+    return cp == cp_htab() || cp == cp_space();
   }
 
   inline bool isspace(uint32_t cp) const {
-    return cp == cp_htab() || cp ==  cp_space() || cp == cp_lf() ||
-      cp == cp_cr() || cp == cp_formfeed() || cp == cp_vtab();
+    return cp == cp_htab() || cp == cp_space() || cp == cp_lf() ||
+           cp == cp_cr() || cp == cp_formfeed() || cp == cp_vtab();
   }
 
   boost::iterator_range<const char*> get_iterator_range() const {
@@ -253,7 +239,7 @@ public:
     uint32_t cr = cp_cr();
     uint32_t lf = cp_lf();
     uint32_t unit;
-    for (;!is_end(); ++(*this)) {
+    for (; !is_end(); ++(*this)) {
       unit = this->get_code_point();
       if (unit == cr || unit == lf) {
         break;
@@ -263,17 +249,16 @@ public:
   }
 
   void advance_if_crlf() {
-    if ( this->get_code_point() == cp_cr() &&
-         !((*this + 1).is_end()) &&
-         *((*this) + 1) == cp_lf()) {
+    if (this->get_code_point() == cp_cr() && !((*this + 1).is_end()) &&
+        *((*this) + 1) == cp_lf()) {
       ++(*this);
     }
   }
 
 private:
   const char* p_pos;
-  const char *p_begin;
-  const char *p_end;
+  const char* p_begin;
+  const char* p_end;
   std::string p_encoding;
 
   size_t get_prev_code_unit_length() const;

--- a/src/CodePointIterator.h
+++ b/src/CodePointIterator.h
@@ -39,7 +39,7 @@ public:
       : p_pos(pos == 0 ? begin : pos),
         p_begin(begin),
         p_end(end),
-        p_encoding(encoding) {};
+        p_encoding(encoding){};
 
   CodePointIterator(const CodePointIterator& obj) {
     p_begin = obj.p_begin;
@@ -106,9 +106,8 @@ public:
 
   const char* get_end() const { return p_end; }
 
-  uint32_t cp() const { return get_code_point();}
-  uint32_t operator*() const { return cp();}
-
+  uint32_t cp() const { return get_code_point(); }
+  uint32_t operator*() const { return cp(); }
 
   static CodePointIteratorPtr shift(const CodePointIterator* pt, int offset) {
     CodePointIteratorPtr tmp = create(*pt);
@@ -124,9 +123,7 @@ public:
     return tmp;
   }
 
-  CodePointIteratorPtr operator+(int i) {
-    return shift(this, i);
-  }
+  CodePointIteratorPtr operator+(int i) { return shift(this, i); }
 
   CodePointIteratorPtr operator-(int i) {
     CodePointIteratorPtr tmp = create(*this);
@@ -144,29 +141,25 @@ public:
 
   /* For most encodings (UTF-8, UTF-16, UTF-32, latin1...), the code points are
      ascii-compatible. Even for encodings like UTF-16, where ASCII characters
-     are represented as code units of 2 bytes, the code point that represents those
+     are represented as code units of 2 bytes, the code point that represents
+     those
      code units is Unicode and the unicode numbering starts like the ASCII.
 
      However, there are some encodings (e.g. CP1026, that is EBCDIC based) where
      there is not ASCII compatibility. If you want to add support to those
-     encodings you just need to modify these cp_* functions, or make them virtual
+     encodings you just need to modify these cp_* functions, or make them
+     virtual
      and edit the inherited function.
   */
   static inline uint32_t cp_null() { return 0x00; }
 
   static inline uint32_t cp_alert() { return 0x07; }
 
-  static inline uint32_t cp_backspace() {
-    return 0x08;
-  }
+  static inline uint32_t cp_backspace() { return 0x08; }
 
-  static inline uint32_t cp_htab() {
-    return 0x09;
-  }
+  static inline uint32_t cp_htab() { return 0x09; }
 
-  static inline uint32_t cp_lf() {
-    return 0x0A;
-  }
+  static inline uint32_t cp_lf() { return 0x0A; }
 
   static inline uint32_t cp_vtab() { return 0x0B; }
 
@@ -219,8 +212,8 @@ public:
   }
 
   static CodePointIteratorPtr create(const CodePointIterator& obj) {
-    return CodePointIterator::create(obj.p_begin, obj.p_end, obj.p_encoding, obj.p_pos);
-
+    return CodePointIterator::create(
+        obj.p_begin, obj.p_end, obj.p_encoding, obj.p_pos);
   }
 
   static CodePointIteratorPtr create(

--- a/src/CodePointIterator.h
+++ b/src/CodePointIterator.h
@@ -249,6 +249,19 @@ public:
     return haystack;
   }
 
+  void advance_until_crlf() {
+    uint32_t cr = cp_cr();
+    uint32_t lf = cp_lf();
+    uint32_t unit;
+    for (;!is_end(); ++(*this)) {
+      unit = this->get_code_point();
+      if (unit == cr || unit == lf) {
+        break;
+      }
+    }
+    return;
+  }
+
   void advance_if_crlf() {
     if ( this->get_code_point() == cp_cr() &&
          !((*this + 1).is_end()) &&

--- a/src/CodePointIterator.h
+++ b/src/CodePointIterator.h
@@ -33,10 +33,10 @@ public:
       const char* end,
       std::string encoding,
       const char* pos = 0)
-      : p_encoding(encoding),
-        p_pos(pos == 0 ? begin : pos),
+      : p_pos(pos == 0 ? begin : pos),
         p_begin(begin),
-        p_end(end) {
+        p_end(end),
+        p_encoding(encoding) {
     if (encoding == "") {
       stop("Encoding not specified");
     }
@@ -56,7 +56,7 @@ public:
     p_encoding = obj.p_encoding;
   }
 
-  CodePointIterator() : p_begin(NULL), p_pos(NULL), p_end(NULL), p_encoding() {}
+  CodePointIterator() : p_pos(NULL), p_begin(NULL), p_end(NULL), p_encoding() {}
 
   CodePointIterator begin() {
     return CodePointIterator(p_begin, p_end, p_encoding, p_begin);

--- a/src/CodePointIterator.h
+++ b/src/CodePointIterator.h
@@ -1,0 +1,271 @@
+#ifndef FASTREAD_CODEUNITITERATOR_H_
+#define FASTREAD_CODEUNITITERATOR_H_
+
+#include <Rcpp.h>
+using namespace Rcpp;
+#include "boost.h"
+#include <boost/cstdint.hpp>
+
+#include <string>
+#include <iterator>
+
+class CodePointIterator : public std::iterator<std::bidirectional_iterator_tag, uint32_t> {
+public:
+  inline size_t bytes_passed() const {
+    return get_pos() - get_begin();
+  }
+
+  inline size_t bytes_total() const {
+    return get_end() - get_begin();
+  }
+
+  static size_t code_points_between(const char *begin, const char *end, std::string encoding) {
+    CodePointIterator tmp(begin, end, encoding);
+    size_t out = 0;
+    while (!tmp.is_end()) {
+      ++tmp;
+      ++out;
+    }
+    return out;
+  }
+
+  static const uint32_t CODEPOINT_ERROR = 0xFFFFFFFF;
+  CodePointIterator(const char *begin, const char *end, std::string encoding,
+                    const char *pos = 0) : p_encoding(encoding),
+                    p_pos(pos == 0 ? begin : pos),
+                    p_begin(begin),
+                    p_end(end) {
+    if (encoding == "") {
+      stop("Encoding not specified");
+    }
+    if (encoding == "UTF-16" || encoding == "UTF-32" || encoding == "UCS-2" || encoding == "UCS-4") {
+      stop("Specify endianness in encoding as: %sLE or %sBE", encoding.c_str(), encoding.c_str());
+    }
+  };
+
+  CodePointIterator(const CodePointIterator &obj) {
+    p_begin = obj.p_begin;
+    p_pos = obj.p_pos;
+    p_end = obj.p_end;
+    p_encoding = obj.p_encoding;
+  }
+
+  CodePointIterator() : p_begin(NULL), p_pos(NULL), p_end(NULL), p_encoding() {}
+
+  CodePointIterator begin() {
+    return CodePointIterator(p_begin, p_end, p_encoding, p_begin);
+  }
+
+  CodePointIterator end() {
+    return CodePointIterator(p_begin, p_end, p_encoding, p_end);
+  }
+
+  bool is_begin() const {
+    return (p_pos == p_begin);
+  }
+
+  bool is_end() const {
+    return (p_pos == p_end);
+  }
+
+  bool operator==(CodePointIterator const& rhs) const {
+    return (p_pos == rhs.p_pos);
+  }
+
+  bool operator!=(CodePointIterator const& rhs) const {
+    return !(*this==rhs);
+  }
+
+  CodePointIterator& operator++() {
+    size_t point_size = get_code_unit_length();
+    if (p_pos + point_size > p_end) {
+      stop("Advancing goes past the end");
+    }
+    p_pos += point_size;
+    return *this;
+  }
+
+  CodePointIterator operator++(int) {
+    CodePointIterator tmp (*this);
+    ++(*this);
+    return tmp;
+  }
+
+  CodePointIterator& operator--() {
+    size_t point_size = get_prev_code_unit_length();
+    if (p_pos - point_size < p_begin) {
+      stop("Going back before the beginning");
+    }
+    p_pos -= point_size;
+    return *this;
+  }
+
+  CodePointIterator operator--(int) {
+    CodePointIterator tmp (*this);
+    --(*this);
+    return tmp;
+  }
+
+  const char * get_begin() const {
+    return p_begin;
+  }
+
+  const char * get_pos() const {
+    return p_pos;
+  }
+
+  const char * get_end() const {
+    return p_end;
+  }
+
+  uint32_t operator* () const {
+    return get_code_point();
+  }
+
+  CodePointIterator operator+ (int i) {
+    CodePointIterator tmp(*this);
+    if (i > 0) {
+      for (int j=0; j<i;++j) {
+        ++tmp;
+      }
+    } else if (i < 0) {
+      for (int j=0; j<-i;++j) {
+        --tmp;
+      }
+    }
+    return tmp;
+  }
+
+  CodePointIterator operator- (int i) {
+    CodePointIterator tmp(*this);
+    if (i > 0) {
+      for (int j=0; j<i;++j) {
+        --tmp;
+      }
+    } else if (i < 0) {
+      for (int j=0; j<-i;++j) {
+        ++tmp;
+      }
+    }
+    return tmp;
+  }
+
+  /* For most encodings (UTF-8, UTF-16, UTF-32, latin1...), the code points are
+     ascii-compatible. Even for encodings like UTF-16, where ASCII characters are
+     represented as code units of 2 bytes, the code point that represents those
+     code units is Unicode and the unicode numbering starts like the ASCII.
+
+     However, there are some encodings (e.g. CP1026, that is EBCDIC based) where
+     there is not ASCII compatibility. If you want to add support to those encodings
+     you just need to modify these cp_* functions.
+  */
+  inline uint32_t cp_null() const {
+    return 0x00;
+  }
+
+  inline uint32_t cp_alert() const {
+    return 0x07;
+  }
+
+  inline uint32_t cp_backspace() const {
+    if (p_encoding == "CP1026") {
+      return 0x16;
+    }
+    return 0x08;
+  }
+
+  inline uint32_t cp_htab() const {
+    if (p_encoding == "CP1026") {
+      return 0x05;
+    }
+    return 0x09;
+  }
+
+  inline uint32_t cp_lf() const {
+    if (p_encoding == "CP1026") {
+      return 0x25;
+    }
+    return 0x0A;
+  }
+
+  inline uint32_t cp_vtab() const {
+    return 0x0B;
+  }
+
+  inline uint32_t cp_formfeed() const {
+    return 0x0C;
+  }
+
+  inline uint32_t cp_cr() const {
+    return 0x0D;
+  }
+
+  inline uint32_t cp_space() const {
+    if (p_encoding == "CP1026") {
+      return 0x40;
+    }
+    return 0x20;
+  }
+
+  inline uint32_t cp_quotation_mark() const {
+    if (p_encoding == "CP1026") {
+      return 0xFC;
+    }
+    return 0x22;
+  }
+
+  inline uint32_t cp_left_square_bracket() const {
+    if (p_encoding == "CP1026") {
+      return 0x68;
+    }
+    return 0x5B;
+  }
+
+  inline uint32_t cp_backslash() const {
+    if (p_encoding == "CP1026") {
+      return 0xDC;
+    }
+    return 0x5C;
+  }
+
+  inline uint32_t cp_right_square_bracket() const {
+    if (p_encoding == "CP1026") {
+      return 0xAC;
+    }
+    return 0x5D;
+  }
+
+  inline bool isblank(uint32_t cp) const {
+    return cp == cp_htab() || cp ==  cp_space();
+  }
+
+  inline bool isspace(uint32_t cp) const {
+    return cp == cp_htab() || cp ==  cp_space() || cp == cp_lf() ||
+      cp == cp_cr() || cp == cp_formfeed() || cp == cp_vtab();
+  }
+
+  boost::iterator_range<const char*> get_iterator_range() const {
+    boost::iterator_range<const char*> haystack(p_pos, p_end);
+    return haystack;
+  }
+
+  void advance_if_crlf() {
+    if ( this->get_code_point() == cp_cr() &&
+         !((*this + 1).is_end()) &&
+         *((*this) + 1) == cp_lf()) {
+      ++(*this);
+    }
+  }
+
+private:
+  const char* p_pos;
+  const char *p_begin;
+  const char *p_end;
+  std::string p_encoding;
+
+  size_t get_prev_code_unit_length() const;
+  size_t get_code_unit_length() const;
+  uint32_t get_code_point() const;
+};
+
+#endif

--- a/src/Iconv.cpp
+++ b/src/Iconv.cpp
@@ -3,8 +3,9 @@ using namespace Rcpp;
 
 #include "Iconv.h"
 
-Iconv::Iconv(const std::string& from, const std::string& to) {
-  if (from == "UTF-8") {
+Iconv::Iconv(const std::string& from, const std::string& to)
+  : from(from), to(to) {
+  if (from == to) {
     cd_ = NULL;
   } else {
     cd_ = Riconv_open(to.c_str(), from.c_str());
@@ -83,6 +84,9 @@ SEXP Iconv::makeSEXP(const char* start, const char* end, bool hasNull) {
     return safeMakeChar(start, end - start, hasNull);
 
   int n = convert(start, end);
+  if (to != "UTF-8") {
+    stop("makeSEXP not to UTF-8, should not happen");
+  }
   return safeMakeChar(&buffer_[0], n, hasNull);
 }
 
@@ -92,4 +96,13 @@ std::string Iconv::makeString(const char* start, const char* end) {
 
   int n = convert(start, end);
   return std::string(&buffer_[0], n);
+}
+
+std::string Iconv::makeString(const std::string& what) {
+  return makeString(what.c_str(), what.c_str() + what.length());
+}
+
+/* Use only if `what` is a Cstring (strlen works, zero byte marks the end) */
+std::string Iconv::makeString(const char* what) {
+  return makeString(what, what + strlen(what));
 }

--- a/src/Iconv.cpp
+++ b/src/Iconv.cpp
@@ -4,7 +4,7 @@ using namespace Rcpp;
 #include "Iconv.h"
 
 Iconv::Iconv(const std::string& from, const std::string& to)
-  : from(from), to(to) {
+    : from(from), to(to) {
   if (from == to) {
     cd_ = NULL;
   } else {

--- a/src/Iconv.cpp
+++ b/src/Iconv.cpp
@@ -5,7 +5,7 @@ using namespace Rcpp;
 
 Iconv::Iconv(const std::string& from, const std::string& to)
     : from(from), to(to) {
-  if (from == to) {
+  if (from == to || from == "bytes" || to == "bytes") {
     cd_ = NULL;
   } else {
     cd_ = Riconv_open(to.c_str(), from.c_str());

--- a/src/Iconv.h
+++ b/src/Iconv.h
@@ -22,23 +22,6 @@ public:
   /* Use only if `what` is a Cstring (strlen works, zero byte marks the end) */
   std::string makeString(const char* what);
 
-  static std::string encode(SEXP what, std::string encoding) {
-    cetype_t what_encoding = Rf_getCharCE(what);
-    std::string what_encoding_str;
-    if (what_encoding == CE_UTF8) {
-      what_encoding_str = "UTF-8";
-    } else if (what_encoding == CE_LATIN1) {
-      what_encoding_str = "latin1";
-    } else if (what_encoding == CE_NATIVE) {
-      what_encoding_str = "";
-    } else {
-      //what_encoding_str = "bytes";
-      return Rcpp::as<std::string>(what);
-    }
-    Iconv encoder(what_encoding_str, encoding);
-    return encoder.makeString(Rcpp::as<std::string>(what));
-  }
-
 private:
   // Returns number of characters in buffer
   size_t convert(const char* start, const char* end);

--- a/src/Iconv.h
+++ b/src/Iconv.h
@@ -3,17 +3,41 @@
 
 #include "R_ext/Riconv.h"
 #include <errno.h>
+#include <string.h>
 
 class Iconv {
   void* cd_;
   std::string buffer_;
 
 public:
-  Iconv(const std::string& from, const std::string& to = "UTF-8");
+  Iconv(const std::string& from = "UTF-8", const std::string& to = "UTF-8");
   virtual ~Iconv();
+  std::string from;
+  std::string to;
 
   SEXP makeSEXP(const char* start, const char* end, bool hasNull = true);
   std::string makeString(const char* start, const char* end);
+  std::string makeString(const std::string& what);
+
+  /* Use only if `what` is a Cstring (strlen works, zero byte marks the end) */
+  std::string makeString(const char* what);
+
+  static std::string encode(SEXP what, std::string encoding) {
+    cetype_t what_encoding = Rf_getCharCE(what);
+    std::string what_encoding_str;
+    if (what_encoding == CE_UTF8) {
+      what_encoding_str = "UTF-8";
+    } else if (what_encoding == CE_LATIN1) {
+      what_encoding_str = "latin1";
+    } else if (what_encoding == CE_NATIVE) {
+      what_encoding_str = "";
+    } else {
+      //what_encoding_str = "bytes";
+      return Rcpp::as<std::string>(what);
+    }
+    Iconv encoder(what_encoding_str, encoding);
+    return encoder.makeString(Rcpp::as<std::string>(what));
+  }
 
 private:
   // Returns number of characters in buffer

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -226,15 +226,14 @@ BEGIN_RCPP
 END_RCPP
 }
 // whitespaceColumns
-List whitespaceColumns(List sourceSpec, int n, std::string comment);
-RcppExport SEXP readr_whitespaceColumns(SEXP sourceSpecSEXP, SEXP nSEXP, SEXP commentSEXP) {
+List whitespaceColumns(List sourceSpec, int n);
+RcppExport SEXP readr_whitespaceColumns(SEXP sourceSpecSEXP, SEXP nSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< List >::type sourceSpec(sourceSpecSEXP);
     Rcpp::traits::input_parameter< int >::type n(nSEXP);
-    Rcpp::traits::input_parameter< std::string >::type comment(commentSEXP);
-    rcpp_result_gen = Rcpp::wrap(whitespaceColumns(sourceSpec, n, comment));
+    rcpp_result_gen = Rcpp::wrap(whitespaceColumns(sourceSpec, n));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -251,22 +250,6 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const std::vector<std::string>& >::type na(naSEXP);
     Rcpp::traits::input_parameter< bool >::type trim_ws(trim_wsSEXP);
     rcpp_result_gen = Rcpp::wrap(type_convert_col(x, spec, locale_, col, na, trim_ws));
-    return rcpp_result_gen;
-END_RCPP
-}
-// stream_delim_
-std::string stream_delim_(const List& df, RObject connection, char delim, const std::string& na, bool col_names, bool bom);
-RcppExport SEXP readr_stream_delim_(SEXP dfSEXP, SEXP connectionSEXP, SEXP delimSEXP, SEXP naSEXP, SEXP col_namesSEXP, SEXP bomSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const List& >::type df(dfSEXP);
-    Rcpp::traits::input_parameter< RObject >::type connection(connectionSEXP);
-    Rcpp::traits::input_parameter< char >::type delim(delimSEXP);
-    Rcpp::traits::input_parameter< const std::string& >::type na(naSEXP);
-    Rcpp::traits::input_parameter< bool >::type col_names(col_namesSEXP);
-    Rcpp::traits::input_parameter< bool >::type bom(bomSEXP);
-    rcpp_result_gen = Rcpp::wrap(stream_delim_(df, connection, delim, na, col_names, bom));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -313,5 +296,21 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< RObject >::type connection(connectionSEXP);
     write_file_raw_(x, connection);
     return R_NilValue;
+END_RCPP
+}
+// stream_delim_
+std::string stream_delim_(const List& df, RObject connection, char delim, const std::string& na, bool col_names, bool bom);
+RcppExport SEXP readr_stream_delim_(SEXP dfSEXP, SEXP connectionSEXP, SEXP delimSEXP, SEXP naSEXP, SEXP col_namesSEXP, SEXP bomSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const List& >::type df(dfSEXP);
+    Rcpp::traits::input_parameter< RObject >::type connection(connectionSEXP);
+    Rcpp::traits::input_parameter< char >::type delim(delimSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type na(naSEXP);
+    Rcpp::traits::input_parameter< bool >::type col_names(col_namesSEXP);
+    Rcpp::traits::input_parameter< bool >::type bom(bomSEXP);
+    rcpp_result_gen = Rcpp::wrap(stream_delim_(df, connection, delim, na, col_names, bom));
+    return rcpp_result_gen;
 END_RCPP
 }

--- a/src/Source.cpp
+++ b/src/Source.cpp
@@ -1,12 +1,11 @@
 #include <Rcpp.h>
 using namespace Rcpp;
 
+#include "Iconv.h"
 #include "Source.h"
 #include "SourceFile.h"
 #include "SourceRaw.h"
 #include "SourceString.h"
-#include "Iconv.h"
-
 
 SourcePtr Source::create(List spec) {
   std::string subclass(as<CharacterVector>(spec.attr("class"))[0]);
@@ -14,7 +13,7 @@ SourcePtr Source::create(List spec) {
   int skip = as<int>(spec["skip"]);
   SEXP comment_sexp = spec["comment"];
   std::vector<std::string> comments;
-  for (size_t i=0; i< Rf_xlength(comment_sexp); ++i) {
+  for (size_t i = 0; i < Rf_xlength(comment_sexp); ++i) {
     SEXP comm = STRING_ELT(comment_sexp, i);
     std::string comment = Rf_translateCharUTF8(comm);
     if (comment.length() > 0) {
@@ -24,10 +23,11 @@ SourcePtr Source::create(List spec) {
   std::string encoding = as<std::string>(spec["encoding"]);
 
   if (subclass == "source_raw") {
-    return SourcePtr(new SourceRaw(as<RawVector>(spec[0]), skip, comments, encoding));
-  } else if (subclass == "source_string") {
     return SourcePtr(
-        new SourceString(as<CharacterVector>(spec[0]), skip, comments, encoding));
+        new SourceRaw(as<RawVector>(spec[0]), skip, comments, encoding));
+  } else if (subclass == "source_string") {
+    return SourcePtr(new SourceString(
+        as<CharacterVector>(spec[0]), skip, comments, encoding));
   } else if (subclass == "source_file") {
     std::string path(as<CharacterVector>(spec[0])[0]);
     return SourcePtr(new SourceFile(path, skip, comments, encoding));

--- a/src/Source.cpp
+++ b/src/Source.cpp
@@ -13,7 +13,7 @@ SourcePtr Source::create(List spec) {
   int skip = as<int>(spec["skip"]);
   SEXP comment_sexp = spec["comment"];
   std::vector<std::string> comments;
-  for (size_t i = 0; i < Rf_xlength(comment_sexp); ++i) {
+  for (R_xlen_t i = 0; i < Rf_xlength(comment_sexp); ++i) {
     SEXP comm = STRING_ELT(comment_sexp, i);
     std::string comment = Rf_translateCharUTF8(comm);
     if (comment.length() > 0) {

--- a/src/Source.cpp
+++ b/src/Source.cpp
@@ -5,21 +5,26 @@ using namespace Rcpp;
 #include "SourceFile.h"
 #include "SourceRaw.h"
 #include "SourceString.h"
+#include "Iconv.h"
+
+
 
 SourcePtr Source::create(List spec) {
   std::string subclass(as<CharacterVector>(spec.attr("class"))[0]);
 
   int skip = as<int>(spec["skip"]);
-  std::string comment = as<std::string>(spec["comment"]);
+  SEXP comment = STRING_ELT(spec["comment"], 0);
+  std::string encoding = as<std::string>(spec["encoding"]);
+  std::string encoded_comment = Iconv::encode(comment, encoding);
 
   if (subclass == "source_raw") {
-    return SourcePtr(new SourceRaw(as<RawVector>(spec[0]), skip, comment));
+    return SourcePtr(new SourceRaw(as<RawVector>(spec[0]), skip, encoded_comment, encoding));
   } else if (subclass == "source_string") {
     return SourcePtr(
-        new SourceString(as<CharacterVector>(spec[0]), skip, comment));
+        new SourceString(as<CharacterVector>(spec[0]), skip, encoded_comment, encoding));
   } else if (subclass == "source_file") {
     std::string path(as<CharacterVector>(spec[0])[0]);
-    return SourcePtr(new SourceFile(path, skip, comment));
+    return SourcePtr(new SourceFile(path, skip, encoded_comment, encoding));
   }
 
   Rcpp::stop("Unknown source type");

--- a/src/Source.h
+++ b/src/Source.h
@@ -67,7 +67,8 @@ public:
     bool hasComment = pComments.size() != 0;
     bool isComment = false, lineStart = true;
 
-    CodePointIteratorPtr cur = CodePointIterator::create(begin(), end(), encoding());
+    CodePointIteratorPtr cur =
+        CodePointIterator::create(begin(), end(), encoding());
     uint32_t cp_lf = cur->cp_lf();
     uint32_t cp_cr = cur->cp_cr();
     uint32_t unit;

--- a/src/Source.h
+++ b/src/Source.h
@@ -4,22 +4,67 @@
 #include "boost.h"
 #include <Rcpp.h>
 #include "CodePointIterator.h"
+#include "Iconv.h"
 
 class Source;
 typedef boost::shared_ptr<Source> SourcePtr;
 
 class Source {
 public:
-  Source(const std::string& comment, const std::string& encoding) : pComment(comment), pEncoding(encoding) {}
+  Source() { }
   virtual ~Source() {}
 
   virtual const char* begin() = 0;
   virtual const char* end() = 0;
-  inline std::string encoding() { return pEncoding;}
-  inline std::string comment() { return pComment;}
+  inline std::string encoding() {
+    if (pEncoding == "") {
+      stop("Encoding not set at Source");
+    } else {
+      return pEncoding;
+    }
+  }
+  inline const std::vector<std::string>& get_comments() { return pComments;}
+
+  void set_comments(std::vector<std::string> utf8comments) {
+    pCommentsUTF8 = utf8comments;
+    if (pEncoding == "") {
+      stop("No encoding set to source. This should not happen");
+    }
+    reencode_comments();
+  }
+
+  void reencode_comments() {
+    if (pCommentsUTF8.size() == 0) {
+      pComments.clear();
+      return;
+    }
+    if (pEncoding == "UTF-8" || pEncoding == "UTF8") {
+      pComments = pCommentsUTF8;
+      return;
+    }
+    Iconv encoder("UTF-8", pEncoding);
+    pComments.clear();
+    for (std::vector<std::string>::const_iterator i = pCommentsUTF8.begin();
+         i != pCommentsUTF8.end();
+         ++i) {
+      pComments.push_back(encoder.makeString(*i));
+    }
+  }
+
+  void set_encoding(const std::string encoding) {
+    if (pEncoding == "") {
+      pEncoding = encoding;
+      return;
+    }
+    if (encoding != pEncoding) {
+      reencode_comments();
+    }
+    pEncoding = encoding;
+    return;
+  }
 
   const char *skipLines(int skip) {
-    bool hasComment = pComment != "";
+    bool hasComment = pComments.size() != 0;
     bool isComment = false, lineStart = true;
 
     CodePointIterator cur(begin(), end(), encoding());
@@ -69,9 +114,9 @@ public:
       if (end - begin >= 4 && begin[1] == '\x00' && begin[2] == '\xFE' &&
           begin[3] == '\xFF') {
         if (pEncoding == "UTF-32" || pEncoding == "UTF32") {
-          pEncoding = "UTF-32BE";
+          set_encoding("UTF-32BE");
         } else if (pEncoding == "UCS-4" || pEncoding == "UCS4") {
-          pEncoding = "UCS-4BE";
+          set_encoding("UCS-4BE");
         }
         return begin + 4;
       }
@@ -88,9 +133,9 @@ public:
     case '\xfe':
       if (end - begin >= 2 && begin[1] == '\xff') {
         if (pEncoding == "UTF-16" || pEncoding == "UTF16") {
-          pEncoding = "UTF-16BE";
+          set_encoding("UTF-16BE");
         } else if (pEncoding == "UCS2" || pEncoding == "UCS-2") {
-          pEncoding = "UCS2-BE";
+          set_encoding("UCS2-BE");
         }
         return begin + 2;
       }
@@ -102,18 +147,18 @@ public:
         // UTF-32 LE
         if (end - begin >= 4 && begin[2] == '\x00' && begin[3] == '\x00') {
           if (pEncoding == "UTF-32" || pEncoding == "UTF32") {
-            pEncoding = "UTF-32LE";
+            set_encoding("UTF-32LE");
           } else if (pEncoding == "UCS-4" || pEncoding == "UCS4") {
-            pEncoding = "UCS-4LE";
+            set_encoding("UCS-4LE");
           }
           return begin + 4;
         }
 
         // UTF-16 LE
         if (pEncoding == "UTF-16" || pEncoding == "UTF16") {
-          pEncoding = "UTF-16LE";
+          set_encoding("UTF-16LE");
         } else if (pEncoding == "UCS2" || pEncoding == "UCS-2") {
-          pEncoding = "UCS2-LE";
+          set_encoding("UCS2-LE");
         }
         return begin + 2;
       }
@@ -126,11 +171,20 @@ public:
 
 private:
   std::string pEncoding;
-  std::string pComment;
+  std::vector<std::string> pComments;
+  std::vector<std::string> pCommentsUTF8;
+
   bool
   inComment(CodePointIterator& cur) {
     boost::iterator_range<const char*> haystack = cur.get_iterator_range();
-    return boost::starts_with(haystack, pComment);
+    for (std::vector<std::string>::const_iterator i = pComments.begin();
+         i != pComments.end();
+         ++i) {
+      if (boost::starts_with(haystack, *i)) {
+        return true;
+      }
+    }
+    return false;
   }
 };
 

--- a/src/Source.h
+++ b/src/Source.h
@@ -1,17 +1,17 @@
 #ifndef FASTREAD_SOURCE_H_
 #define FASTREAD_SOURCE_H_
 
-#include "boost.h"
-#include <Rcpp.h>
 #include "CodePointIterator.h"
 #include "Iconv.h"
+#include "boost.h"
+#include <Rcpp.h>
 
 class Source;
 typedef boost::shared_ptr<Source> SourcePtr;
 
 class Source {
 public:
-  Source() { }
+  Source() {}
   virtual ~Source() {}
 
   virtual const char* begin() = 0;
@@ -23,7 +23,7 @@ public:
       return pEncoding;
     }
   }
-  inline const std::vector<std::string>& get_comments() { return pComments;}
+  inline const std::vector<std::string>& get_comments() { return pComments; }
 
   void set_comments(std::vector<std::string> utf8comments) {
     pCommentsUTF8 = utf8comments;
@@ -63,7 +63,7 @@ public:
     return;
   }
 
-  const char *skipLines(int skip) {
+  const char* skipLines(int skip) {
     bool hasComment = pComments.size() != 0;
     bool isComment = false, lineStart = true;
 
@@ -174,8 +174,7 @@ private:
   std::vector<std::string> pComments;
   std::vector<std::string> pCommentsUTF8;
 
-  bool
-  inComment(CodePointIterator& cur) {
+  bool inComment(CodePointIterator& cur) {
     boost::iterator_range<const char*> haystack = cur.get_iterator_range();
     for (std::vector<std::string>::const_iterator i = pComments.begin();
          i != pComments.end();

--- a/src/Source.h
+++ b/src/Source.h
@@ -67,21 +67,21 @@ public:
     bool hasComment = pComments.size() != 0;
     bool isComment = false, lineStart = true;
 
-    CodePointIterator cur(begin(), end(), encoding());
-    uint32_t cp_lf = cur.cp_lf();
-    uint32_t cp_cr = cur.cp_cr();
+    CodePointIteratorPtr cur = CodePointIterator::create(begin(), end(), encoding());
+    uint32_t cp_lf = cur->cp_lf();
+    uint32_t cp_cr = cur->cp_cr();
     uint32_t unit;
 
-    while (skip > 0 && !cur.is_end()) {
+    while (skip > 0 && !cur->is_end()) {
       if (lineStart) {
-        isComment = hasComment && inComment(cur);
+        isComment = hasComment && inComment(*cur);
         lineStart = false;
       }
 
-      unit = *cur;
+      unit = cur->cp();
 
       if (unit == cp_cr) {
-        cur.advance_if_crlf();
+        cur->advance_if_crlf();
         if (!isComment)
           skip--;
         lineStart = true;
@@ -90,10 +90,10 @@ public:
           skip--;
         lineStart = true;
       }
-      ++cur;
+      cur->next();
     }
 
-    return cur.get_pos();
+    return cur->get_pos();
   }
 
   const char* skipBom(const char* begin, const char* end) {

--- a/src/Source.h
+++ b/src/Source.h
@@ -80,12 +80,12 @@ public:
 
       unit = *cur;
 
-      if (unit == cp_lf) {
+      if (unit == cp_cr) {
         cur.advance_if_crlf();
         if (!isComment)
           skip--;
         lineStart = true;
-      } else if (unit == cp_cr) {
+      } else if (unit == cp_lf) {
         if (!isComment)
           skip--;
         lineStart = true;

--- a/src/SourceFile.h
+++ b/src/SourceFile.h
@@ -14,8 +14,12 @@ class SourceFile : public Source {
 
 public:
   SourceFile(
-      const std::string& path, int skip, const std::string& comment,
-      const std::string encoding) : Source(comment, encoding)  {
+      const std::string& path, int skip, std::vector<std::string> comments,
+      const std::string encoding) {
+
+    set_encoding(encoding);
+    set_comments(comments);
+
     try {
       fm_ = boost::interprocess::file_mapping(
           path.c_str(), boost::interprocess::read_only);

--- a/src/SourceFile.h
+++ b/src/SourceFile.h
@@ -14,7 +14,9 @@ class SourceFile : public Source {
 
 public:
   SourceFile(
-      const std::string& path, int skip, std::vector<std::string> comments,
+      const std::string& path,
+      int skip,
+      std::vector<std::string> comments,
       const std::string encoding) {
 
     set_encoding(encoding);

--- a/src/SourceFile.h
+++ b/src/SourceFile.h
@@ -14,7 +14,8 @@ class SourceFile : public Source {
 
 public:
   SourceFile(
-      const std::string& path, int skip = 0, const std::string& comment = "") {
+      const std::string& path, int skip, const std::string& comment,
+      const std::string encoding) : Source(comment, encoding)  {
     try {
       fm_ = boost::interprocess::file_mapping(
           path.c_str(), boost::interprocess::read_only);
@@ -31,7 +32,7 @@ public:
     begin_ = skipBom(begin_, end_);
 
     // Skip lines, if needed
-    begin_ = skipLines(begin_, end_, skip, comment);
+    begin_ = skipLines(skip);
   }
 
   const char* begin() { return begin_; }

--- a/src/SourceRaw.h
+++ b/src/SourceRaw.h
@@ -10,8 +10,9 @@ class SourceRaw : public Source {
   const char* end_;
 
 public:
-  SourceRaw(Rcpp::RawVector x, int skip = 0, const std::string& comment = "")
-      : x_(x) {
+  SourceRaw(Rcpp::RawVector x, int skip, const std::string& comment,
+            const std::string encoding)
+      : x_(x), Source(comment, encoding) {
     begin_ = (const char*)RAW(x);
     end_ = (const char*)RAW(x) + Rf_xlength(x);
 
@@ -19,7 +20,7 @@ public:
     begin_ = skipBom(begin_, end_);
 
     // Skip lines, if needed
-    begin_ = skipLines(begin_, end_, skip, comment);
+    begin_ = skipLines(skip);
   }
 
   const char* begin() { return begin_; }

--- a/src/SourceRaw.h
+++ b/src/SourceRaw.h
@@ -10,8 +10,11 @@ class SourceRaw : public Source {
   const char* end_;
 
 public:
-  SourceRaw(Rcpp::RawVector x, int skip, std::vector<std::string> comments,
-            const std::string encoding)
+  SourceRaw(
+      Rcpp::RawVector x,
+      int skip,
+      std::vector<std::string> comments,
+      const std::string encoding)
       : x_(x) {
     set_encoding(encoding);
     set_comments(comments);

--- a/src/SourceRaw.h
+++ b/src/SourceRaw.h
@@ -10,9 +10,12 @@ class SourceRaw : public Source {
   const char* end_;
 
 public:
-  SourceRaw(Rcpp::RawVector x, int skip, const std::string& comment,
+  SourceRaw(Rcpp::RawVector x, int skip, std::vector<std::string> comments,
             const std::string encoding)
-      : x_(x), Source(comment, encoding) {
+      : x_(x) {
+    set_encoding(encoding);
+    set_comments(comments);
+
     begin_ = (const char*)RAW(x);
     end_ = (const char*)RAW(x) + Rf_xlength(x);
 

--- a/src/SourceString.h
+++ b/src/SourceString.h
@@ -12,7 +12,9 @@ class SourceString : public Source {
 
 public:
   SourceString(
-      Rcpp::CharacterVector x, int skip, std::vector<std::string> comments,
+      Rcpp::CharacterVector x,
+      int skip,
+      std::vector<std::string> comments,
       const std::string encoding) {
     set_encoding(encoding);
     set_comments(comments);

--- a/src/SourceString.h
+++ b/src/SourceString.h
@@ -12,7 +12,8 @@ class SourceString : public Source {
 
 public:
   SourceString(
-      Rcpp::CharacterVector x, int skip = 0, const std::string& comment = "") {
+      Rcpp::CharacterVector x, int skip, const std::string& comment,
+      const std::string encoding) : Source(comment, encoding) {
     string_ = x[0];
 
     begin_ = CHAR(string_);
@@ -22,7 +23,7 @@ public:
     begin_ = skipBom(begin_, end_);
 
     // Skip lines, if needed
-    begin_ = skipLines(begin_, end_, skip, comment);
+    begin_ = skipLines(skip);
   }
 
   const char* begin() { return begin_; }

--- a/src/SourceString.h
+++ b/src/SourceString.h
@@ -12,8 +12,11 @@ class SourceString : public Source {
 
 public:
   SourceString(
-      Rcpp::CharacterVector x, int skip, const std::string& comment,
-      const std::string encoding) : Source(comment, encoding) {
+      Rcpp::CharacterVector x, int skip, std::vector<std::string> comments,
+      const std::string encoding) {
+    set_encoding(encoding);
+    set_comments(comments);
+
     string_ = x[0];
 
     begin_ = CHAR(string_);

--- a/src/Tokenizer.cpp
+++ b/src/Tokenizer.cpp
@@ -8,6 +8,11 @@ using namespace Rcpp;
 #include "TokenizerLog.h"
 #include "TokenizerWs.h"
 
+static std::string get_comment(SEXP comment) {
+  SEXP comm = STRING_ELT(comment, 0);
+  return std::string(Rf_translateCharUTF8(comm));
+}
+
 TokenizerPtr Tokenizer::create(List spec) {
   std::string subclass(as<CharacterVector>(spec.attr("class"))[0]);
 
@@ -15,7 +20,8 @@ TokenizerPtr Tokenizer::create(List spec) {
     char delim = as<char>(spec["delim"]);
     char quote = as<char>(spec["quote"]);
     std::vector<std::string> na = as<std::vector<std::string> >(spec["na"]);
-    std::string comment = as<std::string>(spec["comment"]);
+    std::string comment = get_comment(spec["comment"]);
+
     bool trimWs = as<bool>(spec["trim_ws"]);
     bool escapeDouble = as<bool>(spec["escape_double"]);
     bool escapeBackslash = as<bool>(spec["escape_backslash"]);
@@ -34,7 +40,7 @@ TokenizerPtr Tokenizer::create(List spec) {
     std::vector<int> begin = as<std::vector<int> >(spec["begin"]),
                      end = as<std::vector<int> >(spec["end"]);
     std::vector<std::string> na = as<std::vector<std::string> >(spec["na"]);
-    std::string comment = as<std::string>(spec["comment"]);
+    std::string comment = get_comment(spec["comment"]);
 
     return TokenizerPtr(new TokenizerFwf(begin, end, na, comment));
   } else if (subclass == "tokenizer_line") {
@@ -44,7 +50,7 @@ TokenizerPtr Tokenizer::create(List spec) {
     return TokenizerPtr(new TokenizerLog());
   } else if (subclass == "tokenizer_ws") {
     std::vector<std::string> na = as<std::vector<std::string> >(spec["na"]);
-    std::string comment = as<std::string>(spec["comment"]);
+    std::string comment = get_comment(spec["comment"]);
     return TokenizerPtr(new TokenizerWs(na, comment));
   }
 

--- a/src/TokenizerFwf.cpp
+++ b/src/TokenizerFwf.cpp
@@ -11,10 +11,22 @@ struct skip_t {
   int lines;
 };
 
+static bool is_comment(boost::iterator_range<const char*>haystack,
+                       const std::vector<std::string>& comments) {
+  for (std::vector<std::string>::const_iterator i = comments.begin();
+       i != comments.end();
+       ++i) {
+    if (boost::starts_with(haystack, *i)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 skip_t skip_comments(
-    SourceIterator begin, SourceIterator end, std::string comment = "") {
+    SourceIterator begin, SourceIterator end, const std::vector<std::string>& comments) {
   skip_t out;
-  if (comment.length() == 0) {
+  if (comments.size() == 0) {
     out.begin = begin;
     out.lines = 0;
     return out;
@@ -23,7 +35,7 @@ skip_t skip_comments(
   SourceIterator cur = begin;
   int skip = 0;
   boost::iterator_range<const char*> haystack(cur, end);
-  while (boost::starts_with(haystack, comment)) {
+  while (is_comment(haystack, comments)) {
     // Rcpp::Rcout << boost::starts_with(haystack, comment);
     // Skip rest of line
     while (cur != end && *cur != '\n' && *cur != '\r') {
@@ -44,10 +56,10 @@ skip_t skip_comments(
 std::vector<bool> emptyCols_(
     SourceIterator begin,
     SourceIterator end,
-    size_t n = 100,
-    std::string comment = "") {
+    size_t n,
+    const std::vector<std::string>& comments) {
 
-  bool has_comment = comment != "";
+  bool has_comment = comments.size() > 0;
   std::vector<bool> is_white;
   boost::iterator_range<const char*> haystack;
 
@@ -56,8 +68,7 @@ std::vector<bool> emptyCols_(
     if (row > n)
       break;
 
-    while (has_comment &&
-           boost::starts_with(boost::iterator_range<const char*>(cur, end), comment)) {
+    while (is_comment(boost::iterator_range<const char*>(cur, end), comments)) {
       while (cur != end && *cur != '\n' && *cur != '\r') {
         ++cur;
       }
@@ -97,9 +108,9 @@ std::vector<bool> emptyCols_(
 List whitespaceColumns(List sourceSpec, int n = 100) {
   SourcePtr source = Source::create(sourceSpec);
 
-  skip_t s = skip_comments(source->begin(), source->end(), source->comment());
+  skip_t s = skip_comments(source->begin(), source->end(), source->get_comments());
 
-  std::vector<bool> empty = emptyCols_(s.begin, source->end(), n, source->comment());
+  std::vector<bool> empty = emptyCols_(s.begin, source->end(), n, source->get_comments());
   std::vector<int> begin, end;
 
   bool in_col = false;

--- a/src/TokenizerFwf.cpp
+++ b/src/TokenizerFwf.cpp
@@ -62,7 +62,6 @@ std::vector<bool> emptyCols_(
     size_t n,
     const std::vector<std::string>& comments) {
 
-  bool has_comment = comments.size() > 0;
   std::vector<bool> is_white;
   boost::iterator_range<const char*> haystack;
 

--- a/src/TokenizerFwf.cpp
+++ b/src/TokenizerFwf.cpp
@@ -11,8 +11,9 @@ struct skip_t {
   int lines;
 };
 
-static bool is_comment(boost::iterator_range<const char*>haystack,
-                       const std::vector<std::string>& comments) {
+static bool is_comment(
+    boost::iterator_range<const char*> haystack,
+    const std::vector<std::string>& comments) {
   for (std::vector<std::string>::const_iterator i = comments.begin();
        i != comments.end();
        ++i) {
@@ -24,7 +25,9 @@ static bool is_comment(boost::iterator_range<const char*>haystack,
 }
 
 skip_t skip_comments(
-    SourceIterator begin, SourceIterator end, const std::vector<std::string>& comments) {
+    SourceIterator begin,
+    SourceIterator end,
+    const std::vector<std::string>& comments) {
   skip_t out;
   if (comments.size() == 0) {
     out.begin = begin;
@@ -108,9 +111,11 @@ std::vector<bool> emptyCols_(
 List whitespaceColumns(List sourceSpec, int n = 100) {
   SourcePtr source = Source::create(sourceSpec);
 
-  skip_t s = skip_comments(source->begin(), source->end(), source->get_comments());
+  skip_t s =
+      skip_comments(source->begin(), source->end(), source->get_comments());
 
-  std::vector<bool> empty = emptyCols_(s.begin, source->end(), n, source->get_comments());
+  std::vector<bool> empty =
+      emptyCols_(s.begin, source->end(), n, source->get_comments());
   std::vector<int> begin, end;
 
   bool in_col = false;

--- a/src/parse.cpp
+++ b/src/parse.cpp
@@ -53,8 +53,9 @@ std::vector<int> count_fields_(List sourceSpec, List tokenizerSpec, int n_max) {
 // [[Rcpp::export]]
 RObject guess_header_(List sourceSpec, List tokenizerSpec, List locale_) {
   Warnings warnings;
-  LocaleInfo locale(locale_);
   SourcePtr source = Source::create(sourceSpec);
+  locale_["encoding"] = source->encoding();
+  LocaleInfo locale(locale_);
   TokenizerPtr tokenizer = Tokenizer::create(tokenizerSpec);
   tokenizer->tokenize(source->begin(), source->end());
   tokenizer->setWarnings(&warnings);

--- a/src/read.cpp
+++ b/src/read.cpp
@@ -13,6 +13,7 @@ using namespace Rcpp;
 // [[Rcpp::export]]
 CharacterVector read_file_(List sourceSpec, List locale_) {
   SourcePtr source = Source::create(sourceSpec);
+  locale_["encoding"] = source->encoding();
   LocaleInfo locale(locale_);
 
   return CharacterVector::create(
@@ -36,9 +37,11 @@ CharacterVector read_lines_(
     int n_max = -1,
     bool progress = true) {
 
+  SourcePtr source = Source::create(sourceSpec);
+  locale_["encoding"] = source->encoding();
   LocaleInfo locale(locale_);
   Reader r(
-      Source::create(sourceSpec),
+      source,
       TokenizerPtr(new TokenizerLine(na)),
       CollectorPtr(new CollectorCharacter(&locale.encoder_)),
       progress);
@@ -65,9 +68,11 @@ void read_lines_chunked_(
     Environment callback,
     bool progress = true) {
 
+  SourcePtr source = Source::create(sourceSpec);
+  locale_["encoding"] = source->encoding();
   LocaleInfo locale(locale_);
   Reader r(
-      Source::create(sourceSpec),
+      source,
       TokenizerPtr(new TokenizerLine(na)),
       CollectorPtr(new CollectorCharacter(&locale.encoder_)),
       progress);
@@ -111,9 +116,11 @@ RObject read_tokens_(
     int n_max = -1,
     bool progress = true) {
 
+  SourcePtr src = Source::create(sourceSpec);
+  locale_["encoding"] = src->encoding();
   LocaleInfo l(locale_);
   Reader r(
-      Source::create(sourceSpec),
+      src,
       Tokenizer::create(tokenizerSpec),
       collectorsCreate(colSpecs, &l),
       progress,
@@ -133,9 +140,11 @@ void read_tokens_chunked_(
     List locale_,
     bool progress = true) {
 
+  SourcePtr src = Source::create(sourceSpec);
+  locale_["encoding"] = src->encoding();
   LocaleInfo l(locale_);
   Reader r(
-      Source::create(sourceSpec),
+      src,
       Tokenizer::create(tokenizerSpec),
       collectorsCreate(colSpecs, &l),
       progress,
@@ -163,6 +172,7 @@ std::vector<std::string> guess_types_(
   tokenizer->tokenize(source->begin(), source->end());
   tokenizer->setWarnings(&warnings); // silence warnings
 
+  locale_["encoding"] = source->encoding();
   LocaleInfo locale(locale_);
 
   std::vector<CollectorPtr> collectors;

--- a/tests/testthat/test-parsing-datetime.R
+++ b/tests/testthat/test-parsing-datetime.R
@@ -179,10 +179,8 @@ test_that("locale affects both guessing and parsing", {
 })
 
 test_that("text re-encoded before strings are parsed", {
-  skip_on_cran() # need to figure out why this fails
-
   x <- "1 f\u00e9vrier 2010"
-  y <- iconv(x, to = "ISO-8859-1")
+  y <- iconv(x, from = "UTF-8", to = "latin1")
   feb01 <- as.Date(ISOdate(2010, 02, 01))
 
   expect_equal(
@@ -191,7 +189,7 @@ test_that("text re-encoded before strings are parsed", {
   )
 
   expect_equal(
-    parse_date(y, "%d %B %Y", locale = locale("fr", encoding = "ISO-8859-1")),
+    parse_date(y, "%d %B %Y", locale = locale("fr", encoding = "latin1")),
     feb01
   )
 })

--- a/tests/testthat/test-read-csv.R
+++ b/tests/testthat/test-read-csv.R
@@ -167,7 +167,7 @@ test_that("n_max 0 gives zero row data frame", {
 })
 
 test_that("empty file with col_names and col_types creates correct columns", {
-  x <- read_csv(datasource_string("", skip = 0, comment = "", encoding = "UTF-8"),
+  x <- read_csv(datasource_string("", skip = 0, comment = ""),
                 c("a", "b"), "ii", progress = FALSE)
   expect_equal(dim(x), c(0, 2))
   expect_equal(class(x$a), "integer")

--- a/tests/testthat/test-read-csv.R
+++ b/tests/testthat/test-read-csv.R
@@ -167,7 +167,8 @@ test_that("n_max 0 gives zero row data frame", {
 })
 
 test_that("empty file with col_names and col_types creates correct columns", {
-  x <- read_csv(datasource_string("", 0), c("a", "b"), "ii", progress = FALSE)
+  x <- read_csv(datasource_string("", skip = 0, comment = "", encoding = "UTF-8"),
+                c("a", "b"), "ii", progress = FALSE)
   expect_equal(dim(x), c(0, 2))
   expect_equal(class(x$a), "integer")
   expect_equal(class(x$b), "integer")

--- a/tests/testthat/test-read-file.R
+++ b/tests/testthat/test-read-file.R
@@ -21,7 +21,7 @@ test_that("read_file works with a local text file passed as character", {
 
 test_that("read_file works with a local text file, skipping one line", {
   expect_equal(
-    read_file(datasource("sample_text.txt", skip = 1)),
+    read_file(datasource("sample_text.txt", skip = 1, encoding = "UTF-8")),
     paste(tail(strsplit(sample_text_str,"\n")[[1]], -1), collapse = "\n")
   )
 })

--- a/tests/testthat/test-read-file.R
+++ b/tests/testthat/test-read-file.R
@@ -21,7 +21,7 @@ test_that("read_file works with a local text file passed as character", {
 
 test_that("read_file works with a local text file, skipping one line", {
   expect_equal(
-    read_file(datasource("sample_text.txt", skip = 1, encoding = "UTF-8")),
+    read_file(datasource("sample_text.txt", skip = 1)),
     paste(tail(strsplit(sample_text_str,"\n")[[1]], -1), collapse = "\n")
   )
 })

--- a/tests/testthat/test-read-table.R
+++ b/tests/testthat/test-read-table.R
@@ -39,3 +39,28 @@ test_that("read_table2 can read from a pipe (552)", {
   x <- read_table2(pipe("echo a b c && echo 1 2 3 && echo 4 5 6"))
   expect_equal(x$a, c(1, 4))
 })
+
+
+test_that("Source skips comments in header", {
+  x <- "SKIP\nCOMMENT\nSKIP\na b\n1 2"
+  expected_result <- read_table("a b\n1 2", col_names = TRUE)
+  result1 <- read_table(x, skip = 2, comment = "COMMENT", col_names = TRUE)
+  expect_equal(expected_result, result1)
+})
+
+test_that("Source skips comments in header even if comment has a different encoding", {
+  x <- "SKIP\nCÖMMENT\nSKIP\na b\n1 2"
+  Encoding(x) <- "UTF-8"
+  comment <- "CÖMMENT"
+  Encoding(comment) <- "UTF-8"
+  comment_latin1 <- iconv("CÖMMENT", "UTF-8", "latin1")
+  expected_result <- read_table("a b\n1 2", col_names = TRUE)
+  result1 <- read_table(x, comment = comment, col_names = TRUE, skip = 2)
+  result2 <- read_table(x, comment = comment_latin1, col_names = TRUE, skip = 2)
+  expect_equal(expected_result, result1)
+  expect_equal(result1, result2)
+})
+
+
+
+

--- a/tests/testthat/test-read-table.R
+++ b/tests/testthat/test-read-table.R
@@ -61,6 +61,20 @@ test_that("Source skips comments in header even if comment has a different encod
   expect_equal(result1, result2)
 })
 
+test_that("Source skips multiple comments in header", {
+  x <- "KOMMENT\nCOMMENT\nSKIP\na b\n1 2"
+  comment <- c("KOMMENT", "COMMENT")
+  expected_result <- read_table("a b\n1 2", col_names = TRUE)
+  result1 <- read_table(x, comment = comment, col_names = TRUE, skip = 1)
+  expect_equal(result1, expected_result)
+})
 
+test_that("Encoding conversion for comments in header works", {
+  x <- "KÖMMENT\nCÖMMENT\nSKIP\na b\n1 2"
+  comment <- c(iconv("KÖMMENT", "UTF-8", "latin1"), "CÖMMENT")
+  expected_result <- read_table("a b\n1 2", col_names = TRUE)
+  result1 <- read_table(x, comment = comment, col_names = TRUE, skip = 1)
+  expect_equal(result1, expected_result)
+})
 
 

--- a/tests/testthat/test-read-table.R
+++ b/tests/testthat/test-read-table.R
@@ -49,11 +49,11 @@ test_that("Source skips comments in header", {
 })
 
 test_that("Source skips comments in header even if comment has a different encoding", {
-  x <- "SKIP\nCÖMMENT\nSKIP\na b\n1 2"
+  x <- "SKIP\nC\u00d6MMENT\nSKIP\na b\n1 2"
   Encoding(x) <- "UTF-8"
-  comment <- "CÖMMENT"
+  comment <- "C\u00d6MMENT"
   Encoding(comment) <- "UTF-8"
-  comment_latin1 <- iconv("CÖMMENT", "UTF-8", "latin1")
+  comment_latin1 <- iconv("C\u00d6MMENT", "UTF-8", "latin1")
   expected_result <- read_table("a b\n1 2", col_names = TRUE)
   result1 <- read_table(x, comment = comment, col_names = TRUE, skip = 2)
   result2 <- read_table(x, comment = comment_latin1, col_names = TRUE, skip = 2)
@@ -70,8 +70,8 @@ test_that("Source skips multiple comments in header", {
 })
 
 test_that("Encoding conversion for comments in header works", {
-  x <- "KÖMMENT\nCÖMMENT\nSKIP\na b\n1 2"
-  comment <- c(iconv("KÖMMENT", "UTF-8", "latin1"), "CÖMMENT")
+  x <- "C\u00d6MMENT\nK\u00d6MMENT\nSKIP\na b\n1 2"
+  comment <- c(iconv("K\u00d6MMENT", "UTF-8", "latin1"), "C\u00d6MMENT")
   expected_result <- read_table("a b\n1 2", col_names = TRUE)
   result1 <- read_table(x, comment = comment, col_names = TRUE, skip = 1)
   expect_equal(result1, expected_result)

--- a/tests/testthat/test-tokenizer-delim.R
+++ b/tests/testthat/test-tokenizer-delim.R
@@ -3,11 +3,11 @@ context("TokenizerDelim")
 
 parse_b <- function(x, ...) {
   tok <- tokenizer_delim(",", escape_double = FALSE, escape_backslash = TRUE, ...)
-  tokenize(datasource_string(x, 0), tok)
+  tokenize(datasource_string(x, skip = 0, comment = "", encoding = "UTF-8"), tok)
 }
 parse_d <- function(x, ...) {
   tok <- tokenizer_delim(",", escape_double = TRUE, escape_backslash = FALSE, ...)
-  tokenize(datasource_string(x, 0), tok)
+  tokenize(datasource_string(x, skip = 0, comment = "", encoding = "UTF-8"), tok)
 }
 
 test_that("simple sequence parsed correctly", {

--- a/tests/testthat/test-tokenizer-delim.R
+++ b/tests/testthat/test-tokenizer-delim.R
@@ -3,11 +3,11 @@ context("TokenizerDelim")
 
 parse_b <- function(x, ...) {
   tok <- tokenizer_delim(",", escape_double = FALSE, escape_backslash = TRUE, ...)
-  tokenize(datasource_string(x, skip = 0, comment = "", encoding = "UTF-8"), tok)
+  tokenize(datasource_string(x, skip = 0, comment = ""), tok)
 }
 parse_d <- function(x, ...) {
   tok <- tokenizer_delim(",", escape_double = TRUE, escape_backslash = FALSE, ...)
-  tokenize(datasource_string(x, skip = 0, comment = "", encoding = "UTF-8"), tok)
+  tokenize(datasource_string(x, skip = 0, comment = ""), tok)
 }
 
 test_that("simple sequence parsed correctly", {


### PR DESCRIPTION
This PR starts dealing with #306.

Basically, if we want to fully support UTF-16 --and other encodings-- then the tokenizer in readr needs to be aware of the text encoding. So, for starters, the `source` class needs to provide the encoding to the tokenizer.

In this PR I just fix the `datasource` object (and the underlying C++ "Source" classes) so they provide the encoding to the tokenizer. It was going to be a much smaller PR, but the C++ Source class also parses comments found in the file (at the header), so this PR also needs to provide the `CodePointIterator` class I wrote, that can iterate through code points instead of raw bytes. 

Instead of: "1 byte == 1 character" with Unicode encodings there are code units, code points and graphemes. See http://stackoverflow.com/a/27331885/446149 for a simple and good description of these terms. While the most faithful approach to text parsing is to iterate through graphemes, here we stay at the approximation "1 grapheme == 1 code point". This approximation is good enough for the tokenizers in readr, as the graphemes we are interested in detecting (e.g. `\r`, `\n`, `,`, `;`...) work well under that approximation and other graphemes won't be affected.

As you will see if you review the PR, the detection of comments in the Source class is done in the encoding of the source, so the whole file does not need to be converted. I just need to convert the `comment` value to whatever the encoding is in the original file.

Additionally the source can now provide more than one comment pattern, so once the tokenizers are also adapted, we will be able to tell readr to skip all lines that start with either "#" or "//" easily.

The `CodePointIterator` class takes two `const char*` (`begin` and `end`) and an encoding. And it allows to iterate through the code points between `begin` and `end`. Improvements or changes to this class may have a significant impact to `readr` performance, especially once the tokenizers use it. For instance, we could make things faster by "checking less" and assuming files are properly encoded.

As a final note/rant, the `datasource_string` R function may have issues with the encoding of the string. The way `CHARSXP` represents the encoding (as "UTF-8", "latin1", "bytes", "native" or "unknown/any") is annoying, as it is hard for me to know what "native" may be, and it is confusing that "unknown" is the result when the string is pure "ASCII". Tips are welcome.



