### PR TITLE
Don't test error message that is created by tibble

### DIFF
--- a/tests/testthat/test-read-fwf.R
+++ b/tests/testthat/test-read-fwf.R
@@ -147,9 +147,8 @@ test_that("fwf_cols produces correct fwf_positions object with elements of lengt
 
 
 test_that("fwf_cols throws error when arguments are not length 1 or 2", {
-  pattern <- "Variables must be length 1 or .*"
-  expect_error(fwf_cols(a = 1:3, b = 4:5), pattern)
-  expect_error(fwf_cols(a = c(), b = 4:5), pattern)
+  expect_error(fwf_cols(a = 1:3, b = 4:5))
+  expect_error(fwf_cols(a = c(), b = 4:5))
 })
 
 test_that("fwf_cols works with unnamed columns", {


### PR DESCRIPTION
As discussed in https://github.com/krlmlr/readr/commit/4d1021e7ab09a66bd432b25590603d7c7f6baf88#commitcomment-22129539. I've stripped the CRAN comments because they don't apply anymore, and the version number update. Thanks again for your help.