### PR TITLE
Make the Source class report the encoding

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -5,6 +5,14 @@ collectorGuess <- function(input, locale_) {
     .Call(`_readr_collectorGuess`, input, locale_)
 }
 
+source_encoding <- function(spec) {
+    .Call(`_readr_source_encoding`, spec)
+}
+
+whitespaceColumns <- function(sourceSpec, n = 100L, comment = "") {
+    .Call(`_readr_whitespaceColumns`, sourceSpec, n, comment)
+}
+
 read_connection_ <- function(con, chunk_size = 64 * 1024L) {
     .Call(`_readr_read_connection_`, con, chunk_size)
 }
@@ -65,16 +73,8 @@ guess_types_ <- function(sourceSpec, tokenizerSpec, locale_, n = 100L) {
     .Call(`_readr_guess_types_`, sourceSpec, tokenizerSpec, locale_, n)
 }
 
-whitespaceColumns <- function(sourceSpec, n = 100L, comment = "") {
-    .Call(`_readr_whitespaceColumns`, sourceSpec, n, comment)
-}
-
 type_convert_col <- function(x, spec, locale_, col, na, trim_ws) {
     .Call(`_readr_type_convert_col`, x, spec, locale_, col, na, trim_ws)
-}
-
-stream_delim_ <- function(df, connection, delim, na, col_names = TRUE, bom = FALSE) {
-    .Call(`_readr_stream_delim_`, df, connection, delim, na, col_names, bom)
 }
 
 write_lines_ <- function(lines, connection, na, sep = "\n") {
@@ -91,5 +91,9 @@ write_file_ <- function(x, connection) {
 
 write_file_raw_ <- function(x, connection) {
     invisible(.Call(`_readr_write_file_raw_`, x, connection))
+}
+
+stream_delim_ <- function(df, connection, delim, na, col_names = TRUE, bom = FALSE) {
+    .Call(`_readr_stream_delim_`, df, connection, delim, na, col_names, bom)
 }
 

--- a/R/col_types.R
+++ b/R/col_types.R
@@ -240,7 +240,7 @@ col_spec_standardise <- function(file, col_names = TRUE, col_types = NULL,
 
   # Figure out the column names -----------------------------------------------
   if (is.logical(col_names) && length(col_names) == 1) {
-    ds_header <- datasource(file, skip = skip, comment = comment)
+    ds_header <- datasource(file, skip = skip, comment = comment, encoding = locale$encoding)
     if (col_names) {
       col_names <- guess_header(ds_header, tokenizer, locale)
       skip <- skip + 1
@@ -367,7 +367,7 @@ col_spec_standardise <- function(file, col_names = TRUE, col_types = NULL,
   is_guess <- vapply(spec$cols, function(x) inherits(x, "collector_guess"), logical(1))
   if (any(is_guess)) {
     if (is.null(guessed_types)) {
-      ds <- datasource(file, skip = skip, comment = comment)
+      ds <- datasource(file, skip = skip, comment = comment, encoding = locale$encoding)
       guessed_types <- guess_types(ds, tokenizer, locale, guess_max = guess_max)
     }
 

--- a/R/count_fields.R
+++ b/R/count_fields.R
@@ -11,7 +11,7 @@
 #' @export
 #' @examples
 #' count_fields(readr_example("mtcars.csv"), tokenizer_csv())
-count_fields <- function(file, tokenizer, skip = 0, n_max = -1L) {
-  ds <- datasource(file, skip = skip)
+count_fields <- function(file, tokenizer, skip = 0, n_max = -1L, encoding = "UTF-8") {
+  ds <- datasource(file, skip = skip, encoding = encoding)
   count_fields_(ds, tokenizer, n_max)
 }

--- a/R/file.R
+++ b/R/file.R
@@ -28,18 +28,18 @@ read_file <- function(file, locale = default_locale()) {
     return("")
   }
 
-  ds <- datasource(file)
+  ds <- datasource(file, encoding = locale$encoding)
   read_file_(ds, locale)
 }
 
 #' @export
 #' @rdname read_file
-read_file_raw <- function(file) {
+read_file_raw <- function(file, encoding = "UTF-8") {
   if (empty_file(file)) {
     return(raw())
   }
 
-  ds <- datasource(file)
+  ds <- datasource(file, encoding = encoding)
   read_file_raw_(ds)
 }
 

--- a/R/lines.R
+++ b/R/lines.R
@@ -35,17 +35,17 @@ read_lines <- function(file, skip = 0, n_max = -1L,
   if (empty_file(file)) {
     return(character())
   }
-  ds <- datasource(file, skip = skip)
+  ds <- datasource(file, skip = skip, encoding = locale$encoding)
   read_lines_(ds, locale_ = locale, na = na, n_max = n_max, progress = progress)
 }
 
 #' @export
 #' @rdname read_lines
-read_lines_raw <- function(file, skip = 0, n_max = -1L, progress = show_progress()) {
+read_lines_raw <- function(file, skip = 0, n_max = -1L, progress = show_progress(), encoding = "UTF-8") {
   if (empty_file(file)) {
     return(list())
   }
-  ds <- datasource(file, skip = skip)
+  ds <- datasource(file, skip = skip, encoding = encoding)
   read_lines_raw_(ds, n_max = n_max, progress = progress)
 }
 

--- a/R/read_delim.R
+++ b/R/read_delim.R
@@ -190,7 +190,7 @@ read_delimited <- function(file, tokenizer, col_names = TRUE, col_types = NULL,
     col_names = col_names, col_types = col_types, tokenizer = tokenizer,
     locale = locale)
 
-  ds <- datasource(data, skip = skip + isTRUE(col_names), comment = comment)
+  ds <- datasource(data, skip = skip + isTRUE(col_names), comment = comment, encoding = locale$encoding)
 
   if (is.null(col_types) && !inherits(ds, "source_string")) {
     show_cols_spec(spec)

--- a/R/read_fwf.R
+++ b/R/read_fwf.R
@@ -37,7 +37,7 @@ read_fwf <- function(file, col_positions, col_types = NULL,
                      locale = default_locale(), na = c("", "NA"),
                      comment = "", trim_ws = TRUE, skip = 0, n_max = Inf,
                      guess_max = min(n_max, 1000), progress = show_progress()) {
-  ds <- datasource(file, skip = skip)
+  ds <- datasource(file, skip = skip, encoding = locale$encoding)
   if (inherits(ds, "source_file") && empty_file(file)) {
     return(tibble::tibble())
   }
@@ -72,8 +72,8 @@ read_fwf <- function(file, col_positions, col_types = NULL,
 #' @export
 #' @param n Number of lines the tokenizer will read to determine file structure. By default
 #'      it is set to 100.
-fwf_empty <- function(file, skip = 0, col_names = NULL, comment = "", n = 100L) {
-  ds <- datasource(file, skip = skip)
+fwf_empty <- function(file, skip = 0, col_names = NULL, comment = "", n = 100L, encoding = "UTF-8") {
+  ds <- datasource(file, skip = skip, encoding = encoding)
 
   out <- whitespaceColumns(ds, comment = comment, n = n)
   out$end[length(out$end)] <- NA

--- a/R/read_lines_chunked.R
+++ b/R/read_lines_chunked.R
@@ -10,7 +10,7 @@ read_lines_chunked <- function(file, callback, chunk_size = 10000, skip = 0,
   if (empty_file(file)) {
     return(character())
   }
-  ds <- datasource(file, skip = skip)
+  ds <- datasource(file, skip = skip, encoding = locale$encoding)
   callback <- as_chunk_callback(callback)
   on.exit(callback$finally(), add = TRUE)
 

--- a/R/read_table.R
+++ b/R/read_table.R
@@ -36,7 +36,7 @@ read_table <- function(file, col_names = TRUE, col_types = NULL,
                        locale = default_locale(), na = "NA", skip = 0,
                        n_max = Inf, guess_max = min(n_max, 1000),
                        progress = show_progress(), comment = "") {
-  ds <- datasource(file, skip = skip)
+  ds <- datasource(file, skip = skip, encoding = locale$encoding)
   columns <- fwf_empty(ds, skip = skip, n = guess_max, comment = comment)
   skip <- skip + columns$skip
 
@@ -48,7 +48,7 @@ read_table <- function(file, col_names = TRUE, col_types = NULL,
     locale = locale, tokenizer = tokenizer
   )
 
-  ds <- datasource(file = ds, skip = skip + isTRUE(col_names))
+  ds <- datasource(file = ds, skip = skip + isTRUE(col_names), encoding = locale$encoding)
   if (is.null(col_types) && !inherits(ds, "source_string")) {
     show_cols_spec(spec)
   }

--- a/R/source.R
+++ b/R/source.R
@@ -16,6 +16,7 @@
 #'    Using a value of [clipboard()] will read from the system clipboard.
 #'
 #' @param skip Number of lines to skip before reading data.
+#' @param encoding The text encoding of the data given in `file`. "UTF-8" as default.
 #' @keywords internal
 #' @export
 #' @examples
@@ -35,7 +36,7 @@
 #' con <- rawConnection(charToRaw("abc\n123"))
 #' datasource(con)
 #' close(con)
-datasource <- function(file, skip = 0, comment = "") {
+datasource <- function(file, skip = 0, comment = "", encoding = "UTF-8") {
   if (inherits(file, "source")) {
 
     # If `skip` and `comment` arguments are expliictly passed, we want to use
@@ -48,22 +49,26 @@ datasource <- function(file, skip = 0, comment = "") {
       file$comment <- comment
     }
 
+    if (!missing(encoding)) {
+      file$encoding <- encoding
+    }
+
     file
   } else if (is.connection(file)) {
-    datasource_connection(file, skip, comment)
+    datasource_connection(file, skip, comment, encoding)
   } else if (is.raw(file)) {
-    datasource_raw(file, skip, comment)
+    datasource_raw(file, skip, comment, encoding)
   } else if (is.character(file)) {
     if (length(file) > 1) {
-      datasource_string(paste(file, collapse = "\n"), skip, comment)
+      datasource_string(paste(file, collapse = "\n"), skip, comment, encoding)
     } else if (grepl("\n", file)) {
-      datasource_string(file, skip, comment)
+      datasource_string(file, skip, comment, encoding)
     } else {
       file <- standardise_path(file)
       if (is.connection(file)) {
-        datasource_connection(file, skip, comment)
+        datasource_connection(file, skip, comment, encoding)
       } else {
-        datasource_file(file, skip, comment)
+        datasource_file(file, skip, comment, encoding)
       }
     }
   } else {
@@ -73,26 +78,26 @@ datasource <- function(file, skip = 0, comment = "") {
 
 # Constructors -----------------------------------------------------------------
 
-new_datasource <- function(type, x, skip, comment = "", ...) {
-  structure(list(x, skip = skip, comment = comment, ...),
+new_datasource <- function(type, x, skip, comment = "", encoding = "UTF-8", ...) {
+  structure(list(x, skip = skip, comment = comment, encoding = encoding, ...),
     class = c(paste0("source_", type), "source"))
 }
 
-datasource_string <- function(text, skip, comment = "") {
-  new_datasource("string", text, skip = skip, comment = comment)
+datasource_string <- function(text, skip, comment = "", encoding = "UTF-8") {
+  new_datasource("string", text, skip = skip, comment = comment, encoding = encoding)
 }
 
-datasource_file <- function(path, skip, comment = "") {
+datasource_file <- function(path, skip, comment = "", encoding = "UTF-8") {
   path <- check_path(path)
-  new_datasource("file", path, skip = skip, comment = comment)
+  new_datasource("file", path, skip = skip, comment = comment, encoding = encoding)
 }
 
-datasource_connection <- function(path, skip, comment = "") {
-  datasource_raw(read_connection(path), skip, comment = comment)
+datasource_connection <- function(path, skip, comment = "", encoding = "UTF-8") {
+  datasource_raw(read_connection(path), skip, comment = comment, encoding = encoding)
 }
 
-datasource_raw <- function(text, skip, comment) {
-  new_datasource("raw", text, skip = skip, comment = comment)
+datasource_raw <- function(text, skip, comment, encoding = "UTF-8") {
+  new_datasource("raw", text, skip = skip, comment = comment, encoding = encoding)
 }
 
 # Helpers ----------------------------------------------------------------------

--- a/R/tokenizer.R
+++ b/R/tokenizer.R
@@ -16,8 +16,8 @@
 #'
 #' # Only tokenize first two lines
 #' tokenize("1,2\n3,4,5\n\n6", n = 2)
-tokenize <- function(file, tokenizer = tokenizer_csv(), skip = 0, n_max = -1L) {
-  ds <- datasource(file, skip = skip)
+tokenize <- function(file, tokenizer = tokenizer_csv(), skip = 0, n_max = -1L, encoding = "UTF-8") {
+  ds <- datasource(file, skip = skip, encoding = encoding)
   tokenize_(ds, tokenizer, n_max)
 }
 

--- a/man/count_fields.Rd
+++ b/man/count_fields.Rd
@@ -4,7 +4,7 @@
 \alias{count_fields}
 \title{Count the number of fields in each line of a file}
 \usage{
-count_fields(file, tokenizer, skip = 0, n_max = -1L)
+count_fields(file, tokenizer, skip = 0, n_max = -1L, encoding = "UTF-8")
 }
 \arguments{
 \item{file}{Either a path to a file, a connection, or literal data
@@ -29,6 +29,8 @@ up into fields, e.g., \code{\link[=tokenizer_csv]{tokenizer_csv()}},
 \item{skip}{Number of lines to skip before reading data.}
 
 \item{n_max}{Optionally, maximum number of rows to count fields for.}
+
+\item{encoding}{The text encoding of the data given in \code{file}. "UTF-8" as default.}
 }
 \description{
 This is useful for diagnosing problems with functions that fail

--- a/man/datasource.Rd
+++ b/man/datasource.Rd
@@ -4,7 +4,7 @@
 \alias{datasource}
 \title{Create a source object.}
 \usage{
-datasource(file, skip = 0, comment = "")
+datasource(file, skip = 0, comment = "", encoding = "UTF-8")
 }
 \arguments{
 \item{file}{Either a path to a file, a connection, or literal data
@@ -23,6 +23,8 @@ vector of greater than length 1.
 Using a value of \code{\link[=clipboard]{clipboard()}} will read from the system clipboard.}
 
 \item{skip}{Number of lines to skip before reading data.}
+
+\item{encoding}{The text encoding of the data given in \code{file}. "UTF-8" as default.}
 }
 \description{
 Create a source object.

--- a/man/read_file.Rd
+++ b/man/read_file.Rd
@@ -8,7 +8,7 @@
 \usage{
 read_file(file, locale = default_locale())
 
-read_file_raw(file)
+read_file_raw(file, encoding = "UTF-8")
 
 write_file(x, path, append = FALSE)
 }
@@ -33,6 +33,8 @@ The default locale is US-centric (like R), but you can use
 \code{\link[=locale]{locale()}} to create your own locale that controls things like
 the default time zone, encoding, decimal mark, big mark, and day/month
 names.}
+
+\item{encoding}{The text encoding of the data given in \code{file}. "UTF-8" as default.}
 
 \item{x}{A data frame to write to disk}
 

--- a/man/read_fwf.Rd
+++ b/man/read_fwf.Rd
@@ -12,7 +12,8 @@ read_fwf(file, col_positions, col_types = NULL, locale = default_locale(),
   na = c("", "NA"), comment = "", trim_ws = TRUE, skip = 0,
   n_max = Inf, guess_max = min(n_max, 1000), progress = show_progress())
 
-fwf_empty(file, skip = 0, col_names = NULL, comment = "", n = 100L)
+fwf_empty(file, skip = 0, col_names = NULL, comment = "", n = 100L,
+  encoding = "UTF-8")
 
 fwf_widths(widths, col_names = NULL)
 
@@ -89,6 +90,8 @@ setting option \code{readr.show_progress} to \code{FALSE}.}
 
 \item{n}{Number of lines the tokenizer will read to determine file structure. By default
 it is set to 100.}
+
+\item{encoding}{The text encoding of the data given in \code{file}. "UTF-8" as default.}
 
 \item{widths}{Width of each field. Use NA as width of last field when
 reading a ragged fwf file.}

--- a/man/read_lines.Rd
+++ b/man/read_lines.Rd
@@ -9,7 +9,8 @@
 read_lines(file, skip = 0, n_max = -1L, locale = default_locale(),
   na = character(), progress = show_progress())
 
-read_lines_raw(file, skip = 0, n_max = -1L, progress = show_progress())
+read_lines_raw(file, skip = 0, n_max = -1L, progress = show_progress(),
+  encoding = "UTF-8")
 
 write_lines(x, path, sep = "\\n", na = "NA", append = FALSE)
 }
@@ -48,6 +49,8 @@ in an interactive session and not while knitting a document. The display
 is updated every 50,000 values and will only display if estimated reading
 time is 5 seconds or more. The automatic progress bar can be disabled by
 setting option \code{readr.show_progress} to \code{FALSE}.}
+
+\item{encoding}{The text encoding of the data given in \code{file}. "UTF-8" as default.}
 
 \item{x}{A data frame to write to disk}
 

--- a/man/tokenize.Rd
+++ b/man/tokenize.Rd
@@ -4,7 +4,8 @@
 \alias{tokenize}
 \title{Tokenize a file/string.}
 \usage{
-tokenize(file, tokenizer = tokenizer_csv(), skip = 0, n_max = -1L)
+tokenize(file, tokenizer = tokenizer_csv(), skip = 0, n_max = -1L,
+  encoding = "UTF-8")
 }
 \arguments{
 \item{file}{Either a path to a file, a connection, or literal data
@@ -27,6 +28,8 @@ Using a value of \code{\link[=clipboard]{clipboard()}} will read from the system
 \item{skip}{Number of lines to skip before reading data.}
 
 \item{n_max}{Optionally, maximum number of rows to tokenize.}
+
+\item{encoding}{The text encoding of the data given in \code{file}. "UTF-8" as default.}
 }
 \description{
 Turns input into a character vector. Usually the tokenization is done purely

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -17,6 +17,30 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// source_encoding
+CharacterVector source_encoding(List spec);
+RcppExport SEXP _readr_source_encoding(SEXP specSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< List >::type spec(specSEXP);
+    rcpp_result_gen = Rcpp::wrap(source_encoding(spec));
+    return rcpp_result_gen;
+END_RCPP
+}
+// whitespaceColumns
+List whitespaceColumns(List sourceSpec, int n, std::string comment);
+RcppExport SEXP _readr_whitespaceColumns(SEXP sourceSpecSEXP, SEXP nSEXP, SEXP commentSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< List >::type sourceSpec(sourceSpecSEXP);
+    Rcpp::traits::input_parameter< int >::type n(nSEXP);
+    Rcpp::traits::input_parameter< std::string >::type comment(commentSEXP);
+    rcpp_result_gen = Rcpp::wrap(whitespaceColumns(sourceSpec, n, comment));
+    return rcpp_result_gen;
+END_RCPP
+}
 // read_connection_
 RawVector read_connection_(RObject con, int chunk_size);
 RcppExport SEXP _readr_read_connection_(SEXP conSEXP, SEXP chunk_sizeSEXP) {
@@ -226,19 +250,6 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// whitespaceColumns
-List whitespaceColumns(List sourceSpec, int n, std::string comment);
-RcppExport SEXP _readr_whitespaceColumns(SEXP sourceSpecSEXP, SEXP nSEXP, SEXP commentSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< List >::type sourceSpec(sourceSpecSEXP);
-    Rcpp::traits::input_parameter< int >::type n(nSEXP);
-    Rcpp::traits::input_parameter< std::string >::type comment(commentSEXP);
-    rcpp_result_gen = Rcpp::wrap(whitespaceColumns(sourceSpec, n, comment));
-    return rcpp_result_gen;
-END_RCPP
-}
 // type_convert_col
 RObject type_convert_col(CharacterVector x, List spec, List locale_, int col, const std::vector<std::string>& na, bool trim_ws);
 RcppExport SEXP _readr_type_convert_col(SEXP xSEXP, SEXP specSEXP, SEXP locale_SEXP, SEXP colSEXP, SEXP naSEXP, SEXP trim_wsSEXP) {
@@ -252,22 +263,6 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const std::vector<std::string>& >::type na(naSEXP);
     Rcpp::traits::input_parameter< bool >::type trim_ws(trim_wsSEXP);
     rcpp_result_gen = Rcpp::wrap(type_convert_col(x, spec, locale_, col, na, trim_ws));
-    return rcpp_result_gen;
-END_RCPP
-}
-// stream_delim_
-std::string stream_delim_(const List& df, RObject connection, char delim, const std::string& na, bool col_names, bool bom);
-RcppExport SEXP _readr_stream_delim_(SEXP dfSEXP, SEXP connectionSEXP, SEXP delimSEXP, SEXP naSEXP, SEXP col_namesSEXP, SEXP bomSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const List& >::type df(dfSEXP);
-    Rcpp::traits::input_parameter< RObject >::type connection(connectionSEXP);
-    Rcpp::traits::input_parameter< char >::type delim(delimSEXP);
-    Rcpp::traits::input_parameter< const std::string& >::type na(naSEXP);
-    Rcpp::traits::input_parameter< bool >::type col_names(col_namesSEXP);
-    Rcpp::traits::input_parameter< bool >::type bom(bomSEXP);
-    rcpp_result_gen = Rcpp::wrap(stream_delim_(df, connection, delim, na, col_names, bom));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -318,9 +313,27 @@ BEGIN_RCPP
     return R_NilValue;
 END_RCPP
 }
+// stream_delim_
+std::string stream_delim_(const List& df, RObject connection, char delim, const std::string& na, bool col_names, bool bom);
+RcppExport SEXP _readr_stream_delim_(SEXP dfSEXP, SEXP connectionSEXP, SEXP delimSEXP, SEXP naSEXP, SEXP col_namesSEXP, SEXP bomSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const List& >::type df(dfSEXP);
+    Rcpp::traits::input_parameter< RObject >::type connection(connectionSEXP);
+    Rcpp::traits::input_parameter< char >::type delim(delimSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type na(naSEXP);
+    Rcpp::traits::input_parameter< bool >::type col_names(col_namesSEXP);
+    Rcpp::traits::input_parameter< bool >::type bom(bomSEXP);
+    rcpp_result_gen = Rcpp::wrap(stream_delim_(df, connection, delim, na, col_names, bom));
+    return rcpp_result_gen;
+END_RCPP
+}
 
 static const R_CallMethodDef CallEntries[] = {
     {"_readr_collectorGuess", (DL_FUNC) &_readr_collectorGuess, 2},
+    {"_readr_source_encoding", (DL_FUNC) &_readr_source_encoding, 1},
+    {"_readr_whitespaceColumns", (DL_FUNC) &_readr_whitespaceColumns, 3},
     {"_readr_read_connection_", (DL_FUNC) &_readr_read_connection_, 2},
     {"_readr_utctime", (DL_FUNC) &_readr_utctime, 7},
     {"_readr_dim_tokens_", (DL_FUNC) &_readr_dim_tokens_, 2},
@@ -336,13 +349,12 @@ static const R_CallMethodDef CallEntries[] = {
     {"_readr_read_tokens_", (DL_FUNC) &_readr_read_tokens_, 7},
     {"_readr_read_tokens_chunked_", (DL_FUNC) &_readr_read_tokens_chunked_, 8},
     {"_readr_guess_types_", (DL_FUNC) &_readr_guess_types_, 4},
-    {"_readr_whitespaceColumns", (DL_FUNC) &_readr_whitespaceColumns, 3},
     {"_readr_type_convert_col", (DL_FUNC) &_readr_type_convert_col, 6},
-    {"_readr_stream_delim_", (DL_FUNC) &_readr_stream_delim_, 6},
     {"_readr_write_lines_", (DL_FUNC) &_readr_write_lines_, 4},
     {"_readr_write_lines_raw_", (DL_FUNC) &_readr_write_lines_raw_, 3},
     {"_readr_write_file_", (DL_FUNC) &_readr_write_file_, 2},
     {"_readr_write_file_raw_", (DL_FUNC) &_readr_write_file_raw_, 2},
+    {"_readr_stream_delim_", (DL_FUNC) &_readr_stream_delim_, 6},
     {NULL, NULL, 0}
 };
 

--- a/src/Source.cpp
+++ b/src/Source.cpp
@@ -12,16 +12,26 @@ SourcePtr Source::create(List spec) {
   int skip = as<int>(spec["skip"]);
   std::string comment = as<std::string>(spec["comment"]);
 
+  std::string encoding = as<std::string>(spec["encoding"]);
+
   if (subclass == "source_raw") {
-    return SourcePtr(new SourceRaw(as<RawVector>(spec[0]), skip, comment));
-  } else if (subclass == "source_string") {
     return SourcePtr(
-        new SourceString(as<CharacterVector>(spec[0]), skip, comment));
+        new SourceRaw(as<RawVector>(spec[0]), skip, comment, encoding));
+  } else if (subclass == "source_string") {
+    return SourcePtr(new SourceString(
+        as<CharacterVector>(spec[0]), skip, comment, encoding));
   } else if (subclass == "source_file") {
     std::string path(as<CharacterVector>(spec[0])[0]);
-    return SourcePtr(new SourceFile(path, skip, comment));
+    return SourcePtr(new SourceFile(path, skip, comment, encoding));
   }
 
   Rcpp::stop("Unknown source type");
   return SourcePtr();
+}
+
+// This function is used to test the encoding detection based on the BOM
+// [[Rcpp::export]]
+CharacterVector source_encoding(List spec) {
+  SourcePtr source = Source::create(spec);
+  return source->encoding();
 }

--- a/src/SourceFile.h
+++ b/src/SourceFile.h
@@ -14,7 +14,11 @@ class SourceFile : public Source {
 
 public:
   SourceFile(
-      const std::string& path, int skip = 0, const std::string& comment = "") {
+      const std::string& path,
+      int skip,
+      const std::string& comment,
+      const std::string encoding)
+      : Source(encoding) {
     try {
       fm_ = boost::interprocess::file_mapping(
           path.c_str(), boost::interprocess::read_only);

--- a/src/SourceRaw.h
+++ b/src/SourceRaw.h
@@ -10,8 +10,12 @@ class SourceRaw : public Source {
   const char* end_;
 
 public:
-  SourceRaw(Rcpp::RawVector x, int skip = 0, const std::string& comment = "")
-      : x_(x) {
+  SourceRaw(
+      Rcpp::RawVector x,
+      int skip,
+      const std::string& comment,
+      const std::string encoding)
+      : Source(encoding), x_(x) {
     begin_ = (const char*)RAW(x);
     end_ = (const char*)RAW(x) + Rf_xlength(x);
 

--- a/src/SourceString.h
+++ b/src/SourceString.h
@@ -12,7 +12,11 @@ class SourceString : public Source {
 
 public:
   SourceString(
-      Rcpp::CharacterVector x, int skip = 0, const std::string& comment = "") {
+      Rcpp::CharacterVector x,
+      int skip,
+      const std::string& comment,
+      const std::string encoding)
+      : Source(encoding) {
     string_ = x[0];
 
     begin_ = CHAR(string_);

--- a/src/TokenizerFwf.cpp
+++ b/src/TokenizerFwf.cpp
@@ -103,7 +103,8 @@ List whitespaceColumns(List sourceSpec, int n = 100, std::string comment = "") {
   return List::create(_["begin"] = begin, _["end"] = end, _["skip"] = s.lines);
 }
 
-// TokenizerFwf ---------------------------------------------------------------
+  // TokenizerFwf
+  // ---------------------------------------------------------------
 
 #include "TokenizerFwf.h"
 #include <Rcpp.h>

--- a/tests/testthat/test-source.R
+++ b/tests/testthat/test-source.R
@@ -1,0 +1,23 @@
+context("Source")
+# Tests the Source class
+
+test_that("Encoding is trivially retreived", {
+  ds <- datasource("a b\n1 2", encoding = "UTF-8")
+  expect_equal(source_encoding(ds), "UTF-8")
+})
+
+test_that("UTF-16 is identified as UTF-16LE or UTF-16BE", {
+  bom_le <- as.raw(c(0xFF, 0xFE))
+  # Convert text to UTF-16LE (without BOM) and append BOM manually so it becomes
+  # UTF-16 (with BOM). The Source class should skip the BOM automatically and
+  # report UTF-16LE
+  text <- iconv("a b\n1 2", from = "UTF-8", to = "UTF-16LE", toRaw = TRUE)[[1]]
+  ds <- datasource(c(bom_le, text), encoding = "UTF-16")
+  expect_equal(source_encoding(ds), "UTF-16LE")
+
+  # Do the same with UTF-16
+  bom_be <- as.raw(c(0xFE, 0xFF))
+  text <- iconv("a b\n1 2", from = "UTF-8", to = "UTF-16BE", toRaw = TRUE)[[1]]
+  ds <- datasource(c(bom_be, text), encoding = "UTF-16")
+  expect_equal(source_encoding(ds), "UTF-16BE")
+})


### PR DESCRIPTION
This pull request is the first of a series to provide multibyte encoding support to readr on the tokenizers. I made a first attempt in #673, but that PR was too big to be easily reviewed.

With this pull request, the datasource() R function and the associated C++ Source class now will require an encoding. If this encoding is ambiguous in endianness (like UTF-16 or UTF-32, which mandate a Byte Order Mark) the BOM is detected and skipped (as happened before) and the encoding is updated to reflect the endianness (UTF-16LE, UTF16-BE...).

Future pull requests will use this encoding for proper source parsing.

As this PR is not a new feature (not yet at least) and it is not a bug fix, I have not added a NEWS entry. Feel free to ask for it if you feel it is better to have it.