### PR TITLE
Flexible scientific notation parsing with parse_number()

### DIFF
--- a/src/QiParsers.h
+++ b/src/QiParsers.h
@@ -111,9 +111,12 @@ inline bool parseNumber(
       }
       break;
     case STATE_EXP:
-      // negative sign only allowed immediately after 'e' or 'E'
+      // negative/positive sign only allowed immediately after 'e' or 'E'
       if (*cur == '-' && exp_init) {
         exp_sign = -1.0;
+        exp_init = false;
+      } else if (*cur == '+' && exp_init) {
+        // sign defaults to positive
         exp_init = false;
       } else if (*cur >= '0' && *cur <= '9') {
         exponent *= 10.0;

--- a/src/QiParsers.h
+++ b/src/QiParsers.h
@@ -4,7 +4,7 @@
 #include "boost.h"
 
 struct DecimalCommaPolicy
-  : public boost::spirit::qi::real_policies<long double> {
+    : public boost::spirit::qi::real_policies<long double> {
   template <typename Iterator>
   static bool parse_dot(Iterator& first, Iterator const& last) {
     if (first == last || *first != ',')
@@ -20,13 +20,13 @@ inline bool parseDouble(
 
   if (decimalMark == '.') {
     return boost::spirit::qi::parse(
-      first, last, boost::spirit::qi::long_double, res);
+        first, last, boost::spirit::qi::long_double, res);
   } else if (decimalMark == ',') {
     return boost::spirit::qi::parse(
-      first,
-      last,
-      boost::spirit::qi::real_parser<long double, DecimalCommaPolicy>(),
-      res);
+        first,
+        last,
+        boost::spirit::qi::real_parser<long double, DecimalCommaPolicy>(),
+        res);
   } else {
     return false;
   }
@@ -128,10 +128,10 @@ inline bool parseNumber(
     }
   }
 
-  end:
+end:
 
-    // Set last to point to final character used
-    last = cur;
+  // Set last to point to final character used
+  last = cur;
 
   res = sign * sum;
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -315,3 +315,35 @@ BEGIN_RCPP
     return R_NilValue;
 END_RCPP
 }
+
+static const R_CallMethodDef CallEntries[] = {
+    {"readr_collectorGuess", (DL_FUNC) &readr_collectorGuess, 2},
+    {"readr_read_connection_", (DL_FUNC) &readr_read_connection_, 2},
+    {"readr_utctime", (DL_FUNC) &readr_utctime, 7},
+    {"readr_dim_tokens_", (DL_FUNC) &readr_dim_tokens_, 2},
+    {"readr_count_fields_", (DL_FUNC) &readr_count_fields_, 3},
+    {"readr_guess_header_", (DL_FUNC) &readr_guess_header_, 3},
+    {"readr_tokenize_", (DL_FUNC) &readr_tokenize_, 3},
+    {"readr_parse_vector_", (DL_FUNC) &readr_parse_vector_, 4},
+    {"readr_read_file_", (DL_FUNC) &readr_read_file_, 2},
+    {"readr_read_file_raw_", (DL_FUNC) &readr_read_file_raw_, 1},
+    {"readr_read_lines_", (DL_FUNC) &readr_read_lines_, 5},
+    {"readr_read_lines_chunked_", (DL_FUNC) &readr_read_lines_chunked_, 6},
+    {"readr_read_lines_raw_", (DL_FUNC) &readr_read_lines_raw_, 3},
+    {"readr_read_tokens_", (DL_FUNC) &readr_read_tokens_, 7},
+    {"readr_read_tokens_chunked_", (DL_FUNC) &readr_read_tokens_chunked_, 8},
+    {"readr_guess_types_", (DL_FUNC) &readr_guess_types_, 4},
+    {"readr_whitespaceColumns", (DL_FUNC) &readr_whitespaceColumns, 3},
+    {"readr_type_convert_col", (DL_FUNC) &readr_type_convert_col, 6},
+    {"readr_stream_delim_", (DL_FUNC) &readr_stream_delim_, 6},
+    {"readr_write_lines_", (DL_FUNC) &readr_write_lines_, 3},
+    {"readr_write_lines_raw_", (DL_FUNC) &readr_write_lines_raw_, 2},
+    {"readr_write_file_", (DL_FUNC) &readr_write_file_, 2},
+    {"readr_write_file_raw_", (DL_FUNC) &readr_write_file_raw_, 2},
+    {NULL, NULL, 0}
+};
+
+RcppExport void R_init_readr(DllInfo *dll) {
+    R_registerRoutines(dll, NULL, CallEntries, NULL, NULL);
+    R_useDynamicSymbols(dll, FALSE);
+}

--- a/tests/testthat/test-parsing-numeric.R
+++ b/tests/testthat/test-parsing-numeric.R
@@ -115,6 +115,8 @@ test_that("large numbers are parsed properly", {
 test_that("scientific notation is parsed properly", {
   expect_equal(parse_number("1e20"), 1e20)
   expect_equal(parse_number("3e2"), 300)
+  expect_equal(parse_number("1e+20"), 1e20)
+  expect_equal(parse_number("3e+2"), 300)
   expect_equal(parse_number("3e0"), 3)
   expect_equal(parse_number("ignore17e4ignore"), 170000)
   expect_equal(parse_number("1.2345e4"), 12345)

--- a/tests/testthat/test-parsing-numeric.R
+++ b/tests/testthat/test-parsing-numeric.R
@@ -109,3 +109,20 @@ test_that("large numbers are parsed properly", {
 
   expect_equal(parse_double("1267650600228229401496703205376", locale = es_MX), 1.267650600228229401496703205376e+30)
 })
+
+# Scientific Notation -------------------------------------------------------
+
+test_that("scientific notation is parsed properly", {
+  expect_equal(parse_number("1e20"), 1e20)
+  expect_equal(parse_number("3e2"), 300)
+  expect_equal(parse_number("3e0"), 3)
+  expect_equal(parse_number("ignore17e4ignore"), 170000)
+  expect_equal(parse_number("1.2345e4"), 12345)
+  expect_equal(parse_number("-5.4e3"), -5400)
+  expect_equal(parse_number("0E12"), 0)
+  expect_equal(parse_number("17E-5"), 0.00017)
+  expect_equal(parse_number("-17E-5"), -0.00017)
+  expect_equal(parse_number("-17E-5-5"), -0.00017)
+  expect_equal(parse_number("1.2E-3"), 0.0012)
+})
+


### PR DESCRIPTION
This is inspired by (but doesn't exactly address) #654 
That issue is concerning **non-string** input of scientific notation, for example: `parse_number(2e5)`

This PR address **string** input of scientific notation, for example: `parse_number("2e5")`
Currently, `parse_number()` would parse `"2e5"` as simply `2` because it stops after the first non-numeric encountered in the middle of the number. The scientific notation parsing in this PR maintains much of the flexibility of the current `parse_number()` (ignoring leading and trailing non-numerics) but deals with the `e` and `E` characters specially. 

Standard use:
```
> parse_number("1e20")
[1] 1e+20
> parse_number("3e2")
[1] 300
> parse_number("1.2345e+4") # optional '+' at start of exponent
[1] 12345
> parse_number("-5.4e3")
[1] -5400
> parse_number("17E-5")
[1] 0.00017
```

Flexibility
```
> parse_number("ignore17e4ignore")
[1] 170000
> parse_number("-17E-5-5") # ignores characters after second '-', consistent with current use
[1] -0.00017
> parse_number("13e4e5") # ignores additional e's
[1] 130000
```