### PR TITLE
Convert to a standard data frame before printing problems

### DIFF
--- a/R/problems.R
+++ b/R/problems.R
@@ -71,7 +71,7 @@ warn_problems <- function(x) {
   if (n == 0)
     return(x)
 
-  probs <- attr(x, "problems")
+  probs <- as.data.frame(attr(x, "problems"))
   many_problems <- nrow(probs) > 5
 
   probs_f <- format(utils::head(probs, 5), justify = "left")


### PR DESCRIPTION
Because tibble has a `format` method which behaves differently than
`format.data.frame` it broke the old printing code.

Fixes #685