### PR TITLE
Correct documentation for type_convert about guessing

### DIFF
--- a/R/type_convert.R
+++ b/R/type_convert.R
@@ -9,9 +9,7 @@
 #' @param col_types One of `NULL`, a [cols()] specification, or
 #'   a string. See `vignette("readr")` for more details.
 #'
-#'   If `NULL`, all column types will be imputed from the first 1000 rows
-#'   on the input. This is convenient (and fast), but not robust. If the
-#'   imputation fails, you'll need to supply the correct types yourself.
+#'   If `NULL`, column types will be imputed using all rows.
 #'
 #'   If a column specification created by [cols()], it must contain
 #'   one column specification for each column. If you only want to read a

--- a/man/type_convert.Rd
+++ b/man/type_convert.Rd
@@ -13,9 +13,7 @@ type_convert(df, col_types = NULL, na = c("", "NA"), trim_ws = TRUE,
 \item{col_types}{One of \code{NULL}, a \code{\link[=cols]{cols()}} specification, or
 a string. See \code{vignette("readr")} for more details.
 
-If \code{NULL}, all column types will be imputed from the first 1000 rows
-on the input. This is convenient (and fast), but not robust. If the
-imputation fails, you'll need to supply the correct types yourself.
+If \code{NULL}, column types will be imputed using all rows.
 
 If a column specification created by \code{\link[=cols]{cols()}}, it must contain
 one column specification for each column. If you only want to read a


### PR DESCRIPTION
Documentation assumes that the guessing in `type_convert()` relies on the first 1,000 rows as elsewhere. However, this does not appear to be true:

```r
library(readr)

test <- tibble::tibble(x = c(1:10000, "a"))
class(type_convert(test)$x)
#> Parsed with column specification:
#> cols(
#>   x = col_character()
#> )
#> [1] "character"
````