### PR TITLE
Avoid warning in type_convert when providing non-character specs

### DIFF
--- a/R/col_types.R
+++ b/R/col_types.R
@@ -365,6 +365,11 @@ col_spec_standardise <- function(file, col_names = TRUE, col_types = NULL,
 }
 
 
+col_spec_limit_names <- function(col_spec, names_only) {
+  col_spec$cols <- col_spec$cols[names(col_spec$cols) %in% names_only]
+  col_spec
+}
+
 check_guess_max <- function(guess_max, max_limit = .Machine$integer.max %/% 100) {
 
   if (length(guess_max) != 1 || !is.numeric(guess_max) || !is_integerish(guess_max) ||

--- a/R/type_convert.R
+++ b/R/type_convert.R
@@ -55,7 +55,7 @@ type_convert <- function(df, col_types = NULL, na = c("", "NA"), trim_ws = TRUE,
   }
 
   specs <- col_spec_standardise(
-    col_types = col_types,
+    col_types = col_spec_limit_names(col_types, names(char_cols)),
     col_names = names(char_cols),
     guessed_types =  guesses
   )


### PR DESCRIPTION
Before this commit, if I use a col_spec with non-character variables in type_convert, I get a warning.

```r
library(readr)
test <- tibble::data_frame(x = 1:3, y = "3", z = "a")
type_convert(test, col_types = cols(x = col_number()))

#> # A tibble: 3 x 3
#>       x     y     z
#>   <int> <dbl> <chr>
#> 1     1     3     a
#> 2     2     3     a
#> 3     3     3     a
#> Warning message:
#> The following named parsers don't match the column names: x 
```