### PR TITLE
Correct reference to date_names_langs

### DIFF
--- a/R/date-symbols.R
+++ b/R/date-symbols.R
@@ -35,7 +35,7 @@ date_names <- function(mon, mon_ab = mon, day, day_ab = day,
 #' @export
 #' @rdname date_names
 #' @param language A BCP 47 locale, made up of a languge and a region,
-#'   e.g. `"en_US"` for American English. See `date_names_locales()`
+#'   e.g. `"en_US"` for American English. See `date_names_langs()`
 #'   for a complete list of available locales.
 date_names_lang <- function(language) {
   stopifnot(is.character(language), length(language) == 1)


### PR DESCRIPTION
`date_names_locales` has been replace by `date_names_langs` for some time now. 

I believe it is the last reference to it in the documentation. 