### PR TITLE
Add support for day of week in parse_datetime

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -32,6 +32,7 @@ you would pass `skip = 3`, now you only need to pass `skip = 2`.
 * `read_*()` files now support reading from the clipboard by using `clipboard()` (#656).
 * `write_file()` gains a `sep` argument, to specify the line separator (#665).
 * Allow files to be read via FTP over SSH by recognising `sftp` as a URL protocol (#707, @jdeboer).
+* `parse_date*() accepts `%a` for local day of week (#763, @tigertoes).
 
 ## Bug Fixes
 

--- a/R/collectors.R
+++ b/R/collectors.R
@@ -257,7 +257,8 @@ col_factor <- function(levels, ordered = FALSE, include_na = FALSE) {
 #'     70-99 -> 1970-1999.
 #'   \item Month: "\%m" (2 digits), "\%b" (abbreviated name in current
 #'     locale), "\%B" (full name in current locale).
-#'   \item Day: "\%d" (2 digits), "\%e" (optional leading space)
+#'   \item Day: "\%d" (2 digits), "\%e" (optional leading space),
+#'     "%a" (abbreviated name in current locale).
 #'   \item Hour: "\%H" or "\%I", use I (and not H) with AM/PM.
 #'   \item Minutes: "\%M"
 #'   \item Seconds: "\%S" (integer seconds), "\%OS" (partial seconds)

--- a/man/parse_datetime.Rd
+++ b/man/parse_datetime.Rd
@@ -75,7 +75,8 @@ month and "\%d" matches a 2 digit day. Month and day default to \code{1},
 70-99 -> 1970-1999.
 \item Month: "\%m" (2 digits), "\%b" (abbreviated name in current
 locale), "\%B" (full name in current locale).
-\item Day: "\%d" (2 digits), "\%e" (optional leading space)
+\item Day: "\%d" (2 digits), "\%e" (optional leading space),
+"%a" (abbreviated name in current locale).
 \item Hour: "\%H" or "\%I", use I (and not H) with AM/PM.
 \item Minutes: "\%M"
 \item Seconds: "\%S" (integer seconds), "\%OS" (partial seconds)

--- a/src/DateTimeParser.h
+++ b/src/DateTimeParser.h
@@ -173,6 +173,10 @@ public:
         if (!consumeInteger1(2, &day_, false))
           return false;
         break;
+      case 'a': // abbreviated day of week
+        if (!consumeString(pLocale_->dayAb_, &day_))
+          return false;
+        break;
       case 'e': // day with optional leading space
         if (!consumeInteger1WithSpace(2, &day_))
           return false;

--- a/tests/testthat/test-parsing-datetime.R
+++ b/tests/testthat/test-parsing-datetime.R
@@ -167,6 +167,16 @@ test_that("locale affects months", {
   expect_equal(parse_date("1 janvier 2010", "%d %B %Y", locale = fr), jan1)
 })
 
+test_that("locale affects day of week", {
+  a <- parse_datetime("2010-01-01")
+  b <- parse_date("2010-01-01")
+  fr <- locale("fr")
+  expect_equal(parse_datetime("Ven. 1 janv. 2010", "%a %d %b %Y", locale=fr), a)
+  expect_equal(parse_date("Ven. 1 janv. 2010", "%a %d %b %Y", locale=fr), b)
+  expect_warning(parse_datetime("Fri 1 janv. 1020", "%a %d %b %Y", locale=fr))
+  expect_warning(parse_date("Fri 1 janv. 2010", "%a %d %b %Y", locale=fr))
+})
+
 test_that("locale affects am/pm", {
   a <- parse_time("1:30 PM", "%H:%M %p")
   b <- parse_time("오후 1시 30분", "%p %H시 %M분", locale = locale("ko"))


### PR DESCRIPTION
To keep with other similar libraries, I've chosen `%a` as the designator. This might cause some issues when doing non-abbreviated day of week in future as `%A` is already reserved for other uses.

This PR updates the documentation, however none of the generated docs have been updated - is this something expected of contributors? If so, could you please tell me how to generate the documentation.