### PR TITLE
Support multiple comment symbols

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -31,6 +31,12 @@
 * Allow files to be read via FTP over SSH by recognising `sftp` as a URL protocol (#707, @jdeboer).
 * `read_*()` now converts string `file`s to UTF-8 before parsing, which is convenient for non-UTF-8 platforms
   in most cases (#730, @yutannihilation).
+
+* Comments are now handled by the `datasource` instead of by the `tokenizer` (@zeehio, #766)
+
+* Allow a character vector of comments. Using `comment = c("//", "#")` will
+  skip all the lines starting with either `//` or `#`. (@zeehio, #766)
+
 # readr 1.1.1
 
 * Point release for test compatibility with tibble v1.3.1.

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -5,14 +5,6 @@ collectorGuess <- function(input, locale_) {
     .Call(`_readr_collectorGuess`, input, locale_)
 }
 
-source_encoding <- function(spec) {
-    .Call(`_readr_source_encoding`, spec)
-}
-
-whitespaceColumns <- function(sourceSpec, n = 100L, comment = "") {
-    .Call(`_readr_whitespaceColumns`, sourceSpec, n, comment)
-}
-
 read_connection_ <- function(con, chunk_size = 64 * 1024L) {
     .Call(`_readr_read_connection_`, con, chunk_size)
 }
@@ -71,6 +63,14 @@ read_tokens_chunked_ <- function(sourceSpec, callback, chunkSize, tokenizerSpec,
 
 guess_types_ <- function(sourceSpec, tokenizerSpec, locale_, n = 100L) {
     .Call(`_readr_guess_types_`, sourceSpec, tokenizerSpec, locale_, n)
+}
+
+source_encoding <- function(spec) {
+    .Call(`_readr_source_encoding`, spec)
+}
+
+whitespaceColumns <- function(sourceSpec, n = 100L) {
+    .Call(`_readr_whitespaceColumns`, sourceSpec, n)
 }
 
 type_convert_col <- function(x, spec, locale_, col, na, trim_ws) {

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -5,6 +5,14 @@ collectorGuess <- function(input, locale_) {
     .Call(`_readr_collectorGuess`, input, locale_)
 }
 
+source_encoding <- function(spec) {
+    .Call(`_readr_source_encoding`, spec)
+}
+
+whitespaceColumns <- function(sourceSpec, n = 100L, comment = "") {
+    .Call(`_readr_whitespaceColumns`, sourceSpec, n, comment)
+}
+
 read_connection_ <- function(con, chunk_size = 64 * 1024L) {
     .Call(`_readr_read_connection_`, con, chunk_size)
 }
@@ -65,16 +73,8 @@ guess_types_ <- function(sourceSpec, tokenizerSpec, locale_, n = 100L) {
     .Call(`_readr_guess_types_`, sourceSpec, tokenizerSpec, locale_, n)
 }
 
-whitespaceColumns <- function(sourceSpec, n = 100L, comment = "") {
-    .Call(`_readr_whitespaceColumns`, sourceSpec, n, comment)
-}
-
 type_convert_col <- function(x, spec, locale_, col, na, trim_ws) {
     .Call(`_readr_type_convert_col`, x, spec, locale_, col, na, trim_ws)
-}
-
-stream_delim_ <- function(df, connection, delim, na, col_names = TRUE, bom = FALSE) {
-    .Call(`_readr_stream_delim_`, df, connection, delim, na, col_names, bom)
 }
 
 write_lines_ <- function(lines, connection, na, sep = "\n") {
@@ -91,5 +91,9 @@ write_file_ <- function(x, connection) {
 
 write_file_raw_ <- function(x, connection) {
     invisible(.Call(`_readr_write_file_raw_`, x, connection))
+}
+
+stream_delim_ <- function(df, connection, delim, na, col_names = TRUE, bom = FALSE) {
+    .Call(`_readr_stream_delim_`, df, connection, delim, na, col_names, bom)
 }
 

--- a/R/col_types.R
+++ b/R/col_types.R
@@ -240,7 +240,7 @@ col_spec_standardise <- function(file, col_names = TRUE, col_types = NULL,
 
   # Figure out the column names -----------------------------------------------
   if (is.logical(col_names) && length(col_names) == 1) {
-    ds_header <- datasource(file, skip = skip, comment = comment)
+    ds_header <- datasource(file, skip = skip, comment = comment, encoding = locale$encoding)
     if (col_names) {
       col_names <- guess_header(ds_header, tokenizer, locale)
       skip <- skip + 1
@@ -367,7 +367,7 @@ col_spec_standardise <- function(file, col_names = TRUE, col_types = NULL,
   is_guess <- vapply(spec$cols, function(x) inherits(x, "collector_guess"), logical(1))
   if (any(is_guess)) {
     if (is.null(guessed_types)) {
-      ds <- datasource(file, skip = skip, comment = comment)
+      ds <- datasource(file, skip = skip, comment = comment, encoding = locale$encoding)
       guessed_types <- guess_types(ds, tokenizer, locale, guess_max = guess_max)
     }
 

--- a/R/count_fields.R
+++ b/R/count_fields.R
@@ -11,7 +11,7 @@
 #' @export
 #' @examples
 #' count_fields(readr_example("mtcars.csv"), tokenizer_csv())
-count_fields <- function(file, tokenizer, skip = 0, n_max = -1L) {
-  ds <- datasource(file, skip = skip)
+count_fields <- function(file, tokenizer, skip = 0, n_max = -1L, encoding = "UTF-8") {
+  ds <- datasource(file, skip = skip, encoding = encoding)
   count_fields_(ds, tokenizer, n_max)
 }

--- a/R/file.R
+++ b/R/file.R
@@ -28,18 +28,18 @@ read_file <- function(file, locale = default_locale()) {
     return("")
   }
 
-  ds <- datasource(file)
+  ds <- datasource(file, encoding = locale$encoding)
   read_file_(ds, locale)
 }
 
 #' @export
 #' @rdname read_file
-read_file_raw <- function(file) {
+read_file_raw <- function(file, encoding = "UTF-8") {
   if (empty_file(file)) {
     return(raw())
   }
 
-  ds <- datasource(file)
+  ds <- datasource(file, encoding = encoding)
   read_file_raw_(ds)
 }
 

--- a/R/lines.R
+++ b/R/lines.R
@@ -35,17 +35,17 @@ read_lines <- function(file, skip = 0, n_max = -1L,
   if (empty_file(file)) {
     return(character())
   }
-  ds <- datasource(file, skip = skip)
+  ds <- datasource(file, skip = skip, encoding = locale$encoding)
   read_lines_(ds, locale_ = locale, na = na, n_max = n_max, progress = progress)
 }
 
 #' @export
 #' @rdname read_lines
-read_lines_raw <- function(file, skip = 0, n_max = -1L, progress = show_progress()) {
+read_lines_raw <- function(file, skip = 0, n_max = -1L, progress = show_progress(), encoding = "UTF-8") {
   if (empty_file(file)) {
     return(list())
   }
-  ds <- datasource(file, skip = skip)
+  ds <- datasource(file, skip = skip, encoding = encoding)
   read_lines_raw_(ds, n_max = n_max, progress = progress)
 }
 

--- a/R/read_delim.R
+++ b/R/read_delim.R
@@ -101,7 +101,7 @@ read_delim <- function(file, delim, quote = '"',
   }
   tokenizer <- tokenizer_delim(delim, quote = quote,
     escape_backslash = escape_backslash, escape_double = escape_double,
-    na = na, quoted_na = quoted_na, comment = comment, trim_ws = trim_ws)
+    na = na, quoted_na = quoted_na, trim_ws = trim_ws)
   read_delimited(file, tokenizer, col_names = col_names, col_types = col_types,
     locale = locale, skip = skip, comment = comment, n_max = n_max, guess_max =
       guess_max, progress = progress)
@@ -115,7 +115,7 @@ read_csv <- function(file, col_names = TRUE, col_types = NULL,
                      skip = 0, n_max = Inf, guess_max = min(1000, n_max),
                      progress = show_progress()) {
   tokenizer <- tokenizer_csv(na = na, quoted_na = quoted_na, quote = quote,
-    comment = comment, trim_ws = trim_ws)
+    trim_ws = trim_ws)
   read_delimited(file, tokenizer, col_names = col_names, col_types = col_types,
     locale = locale, skip = skip, comment = comment, n_max = n_max, guess_max =
       guess_max, progress = progress)
@@ -135,7 +135,7 @@ read_csv2 <- function(file, col_names = TRUE, col_types = NULL,
     locale$grouping_mark <- "."
   }
   tokenizer <- tokenizer_delim(delim = ";", na = na, quoted_na = quoted_na,
-    quote = quote, comment = comment, trim_ws = trim_ws)
+    quote = quote, trim_ws = trim_ws)
   read_delimited(file, tokenizer, col_names = col_names, col_types = col_types,
     locale = locale, skip = skip, comment = comment, n_max = n_max,
     guess_max = guess_max, progress = progress)
@@ -150,7 +150,7 @@ read_tsv <- function(file, col_names = TRUE, col_types = NULL,
                      comment = "", trim_ws = TRUE, skip = 0, n_max = Inf,
                      guess_max = min(1000, n_max), progress = show_progress()) {
   tokenizer <- tokenizer_tsv(na = na, quoted_na = quoted_na, quote = quote,
-    comment = comment, trim_ws = trim_ws)
+    trim_ws = trim_ws)
   read_delimited(file, tokenizer, col_names = col_names, col_types = col_types,
     locale = locale, skip = skip, comment = comment, n_max = n_max,
     guess_max = guess_max, progress = progress)

--- a/R/read_delim.R
+++ b/R/read_delim.R
@@ -190,7 +190,7 @@ read_delimited <- function(file, tokenizer, col_names = TRUE, col_types = NULL,
     col_names = col_names, col_types = col_types, tokenizer = tokenizer,
     locale = locale)
 
-  ds <- datasource(data, skip = skip + isTRUE(col_names), comment = comment)
+  ds <- datasource(data, skip = skip + isTRUE(col_names), comment = comment, encoding = locale$encoding)
 
   if (is.null(col_types) && !inherits(ds, "source_string")) {
     show_cols_spec(spec)

--- a/R/read_fwf.R
+++ b/R/read_fwf.R
@@ -37,7 +37,7 @@ read_fwf <- function(file, col_positions, col_types = NULL,
                      locale = default_locale(), na = c("", "NA"),
                      comment = "", trim_ws = TRUE, skip = 0, n_max = Inf,
                      guess_max = min(n_max, 1000), progress = show_progress()) {
-  ds <- datasource(file, skip = skip)
+  ds <- datasource(file, skip = skip, encoding = locale$encoding)
   if (inherits(ds, "source_file") && empty_file(file)) {
     return(tibble::tibble())
   }
@@ -72,8 +72,8 @@ read_fwf <- function(file, col_positions, col_types = NULL,
 #' @export
 #' @param n Number of lines the tokenizer will read to determine file structure. By default
 #'      it is set to 100.
-fwf_empty <- function(file, skip = 0, col_names = NULL, comment = "", n = 100L) {
-  ds <- datasource(file, skip = skip)
+fwf_empty <- function(file, skip = 0, col_names = NULL, comment = "", n = 100L, encoding = "UTF-8") {
+  ds <- datasource(file, skip = skip, encoding = encoding)
 
   out <- whitespaceColumns(ds, comment = comment, n = n)
   out$end[length(out$end)] <- NA

--- a/R/read_fwf.R
+++ b/R/read_fwf.R
@@ -37,12 +37,12 @@ read_fwf <- function(file, col_positions, col_types = NULL,
                      locale = default_locale(), na = c("", "NA"),
                      comment = "", trim_ws = TRUE, skip = 0, n_max = Inf,
                      guess_max = min(n_max, 1000), progress = show_progress()) {
-  ds <- datasource(file, skip = skip, encoding = locale$encoding)
+  ds <- datasource(file, skip = skip, comment = comment, encoding = locale$encoding)
   if (inherits(ds, "source_file") && empty_file(file)) {
     return(tibble::tibble())
   }
 
-  tokenizer <- tokenizer_fwf(col_positions$begin, col_positions$end, na = na, comment = comment, trim_ws = trim_ws)
+  tokenizer <- tokenizer_fwf(col_positions$begin, col_positions$end, na = na, trim_ws = trim_ws)
 
   spec <- col_spec_standardise(
     file,
@@ -73,9 +73,9 @@ read_fwf <- function(file, col_positions, col_types = NULL,
 #' @param n Number of lines the tokenizer will read to determine file structure. By default
 #'      it is set to 100.
 fwf_empty <- function(file, skip = 0, col_names = NULL, comment = "", n = 100L, encoding = "UTF-8") {
-  ds <- datasource(file, skip = skip, encoding = encoding)
+  ds <- datasource(file, skip = skip, comment = comment, encoding = encoding)
 
-  out <- whitespaceColumns(ds, comment = comment, n = n)
+  out <- whitespaceColumns(ds, n = n)
   out$end[length(out$end)] <- NA
 
   col_names <- fwf_col_names(col_names, length(out$begin))

--- a/R/read_lines_chunked.R
+++ b/R/read_lines_chunked.R
@@ -10,7 +10,7 @@ read_lines_chunked <- function(file, callback, chunk_size = 10000, skip = 0,
   if (empty_file(file)) {
     return(character())
   }
-  ds <- datasource(file, skip = skip)
+  ds <- datasource(file, skip = skip, encoding = locale$encoding)
   callback <- as_chunk_callback(callback)
   on.exit(callback$finally(), add = TRUE)
 

--- a/R/read_table.R
+++ b/R/read_table.R
@@ -36,7 +36,7 @@ read_table <- function(file, col_names = TRUE, col_types = NULL,
                        locale = default_locale(), na = "NA", skip = 0,
                        n_max = Inf, guess_max = min(n_max, 1000),
                        progress = show_progress(), comment = "") {
-  ds <- datasource(file, skip = skip)
+  ds <- datasource(file, skip = skip, encoding = locale$encoding)
   columns <- fwf_empty(ds, skip = skip, n = guess_max, comment = comment)
   skip <- skip + columns$skip
 
@@ -48,7 +48,7 @@ read_table <- function(file, col_names = TRUE, col_types = NULL,
     locale = locale, tokenizer = tokenizer
   )
 
-  ds <- datasource(file = ds, skip = skip + isTRUE(col_names))
+  ds <- datasource(file = ds, skip = skip + isTRUE(col_names), encoding = locale$encoding)
   if (is.null(col_types) && !inherits(ds, "source_string")) {
     show_cols_spec(spec)
   }

--- a/R/read_table.R
+++ b/R/read_table.R
@@ -36,19 +36,20 @@ read_table <- function(file, col_names = TRUE, col_types = NULL,
                        locale = default_locale(), na = "NA", skip = 0,
                        n_max = Inf, guess_max = min(n_max, 1000),
                        progress = show_progress(), comment = "") {
-  ds <- datasource(file, skip = skip, encoding = locale$encoding)
+  ds <- datasource(file, skip = skip, comment = comment, encoding = locale$encoding)
   columns <- fwf_empty(ds, skip = skip, n = guess_max, comment = comment)
-  skip <- skip + columns$skip
 
-  tokenizer <- tokenizer_fwf(columns$begin, columns$end, na = na, comment = comment)
+  tokenizer <- tokenizer_fwf(columns$begin, columns$end, na = na)
 
   spec <- col_spec_standardise(
     file = ds, skip = skip, guess_max = guess_max,
     col_names = col_names, col_types = col_types,
+    comment = comment,
     locale = locale, tokenizer = tokenizer
   )
 
-  ds <- datasource(file = ds, skip = skip + isTRUE(col_names), encoding = locale$encoding)
+  ds <- datasource(file = ds, skip = skip + isTRUE(col_names), comment = comment,
+                   encoding = locale$encoding)
   if (is.null(col_types) && !inherits(ds, "source_string")) {
     show_cols_spec(spec)
   }
@@ -67,7 +68,7 @@ read_table2 <- function(file, col_names = TRUE, col_types = NULL,
                        n_max = Inf, guess_max = min(n_max, 1000),
                        progress = show_progress(), comment = "") {
 
-  tokenizer <- tokenizer_ws(na = na, comment = comment)
+  tokenizer <- tokenizer_ws(na = na)
   read_delimited(file, tokenizer, col_names = col_names, col_types = col_types,
     locale = locale, skip = skip, comment = comment, n_max = n_max, guess_max =
       guess_max, progress = progress)

--- a/R/source.R
+++ b/R/source.R
@@ -16,6 +16,7 @@
 #'    Using a value of [clipboard()] will read from the system clipboard.
 #'
 #' @param skip Number of lines to skip before reading data.
+#' @param encoding The text encoding of the data given in `file`. "UTF-8" as default.
 #' @keywords internal
 #' @export
 #' @examples
@@ -35,7 +36,7 @@
 #' con <- rawConnection(charToRaw("abc\n123"))
 #' datasource(con)
 #' close(con)
-datasource <- function(file, skip = 0, comment = "") {
+datasource <- function(file, skip = 0, comment = "", encoding = "UTF-8") {
   if (inherits(file, "source")) {
 
     # If `skip` and `comment` arguments are expliictly passed, we want to use
@@ -48,22 +49,26 @@ datasource <- function(file, skip = 0, comment = "") {
       file$comment <- comment
     }
 
+    if (!missing(encoding)) {
+      file$encoding <- encoding
+    }
+
     file
   } else if (is.connection(file)) {
-    datasource_connection(file, skip, comment)
+    datasource_connection(file, skip, comment, encoding)
   } else if (is.raw(file)) {
-    datasource_raw(file, skip, comment)
+    datasource_raw(file, skip, comment, encoding)
   } else if (is.character(file)) {
     if (length(file) > 1) {
-      datasource_string(paste(file, collapse = "\n"), skip, comment)
+      datasource_string(paste(file, collapse = "\n"), skip, comment, encoding)
     } else if (grepl("\n", file)) {
-      datasource_string(file, skip, comment)
+      datasource_string(file, skip, comment, encoding)
     } else {
       file <- standardise_path(file)
       if (is.connection(file)) {
-        datasource_connection(file, skip, comment)
+        datasource_connection(file, skip, comment, encoding)
       } else {
-        datasource_file(file, skip, comment)
+        datasource_file(file, skip, comment, encoding)
       }
     }
   } else {
@@ -73,26 +78,26 @@ datasource <- function(file, skip = 0, comment = "") {
 
 # Constructors -----------------------------------------------------------------
 
-new_datasource <- function(type, x, skip, comment = "", ...) {
-  structure(list(x, skip = skip, comment = comment, ...),
+new_datasource <- function(type, x, skip, comment = "", encoding = "UTF-8", ...) {
+  structure(list(x, skip = skip, comment = comment, encoding = encoding, ...),
     class = c(paste0("source_", type), "source"))
 }
 
-datasource_string <- function(text, skip, comment = "") {
-  new_datasource("string", text, skip = skip, comment = comment)
+datasource_string <- function(text, skip, comment = "", encoding = "UTF-8") {
+  new_datasource("string", text, skip = skip, comment = comment, encoding = encoding)
 }
 
-datasource_file <- function(path, skip, comment = "") {
+datasource_file <- function(path, skip, comment = "", encoding = "UTF-8") {
   path <- check_path(path)
-  new_datasource("file", path, skip = skip, comment = comment)
+  new_datasource("file", path, skip = skip, comment = comment, encoding = encoding)
 }
 
-datasource_connection <- function(path, skip, comment = "") {
-  datasource_raw(read_connection(path), skip, comment = comment)
+datasource_connection <- function(path, skip, comment = "", encoding = "UTF-8") {
+  datasource_raw(read_connection(path), skip, comment = comment, encoding = encoding)
 }
 
-datasource_raw <- function(text, skip, comment) {
-  new_datasource("raw", text, skip = skip, comment = comment)
+datasource_raw <- function(text, skip, comment, encoding = "UTF-8") {
+  new_datasource("raw", text, skip = skip, comment = comment, encoding = encoding)
 }
 
 # Helpers ----------------------------------------------------------------------

--- a/R/source.R
+++ b/R/source.R
@@ -16,6 +16,9 @@
 #'    Using a value of [clipboard()] will read from the system clipboard.
 #'
 #' @param skip Number of lines to skip before reading data.
+#' @param comment A string used to identify comments. Any text after the
+#'   comment characters will be silently ignored. Multiple comments can be given
+#'   using a character vector.
 #' @param encoding The text encoding of the data given in `file`. "UTF-8" as default.
 #' @keywords internal
 #' @export

--- a/R/tokenizer.R
+++ b/R/tokenizer.R
@@ -16,8 +16,8 @@
 #'
 #' # Only tokenize first two lines
 #' tokenize("1,2\n3,4,5\n\n6", n = 2)
-tokenize <- function(file, tokenizer = tokenizer_csv(), skip = 0, n_max = -1L) {
-  ds <- datasource(file, skip = skip)
+tokenize <- function(file, tokenizer = tokenizer_csv(), skip = 0, n_max = -1L, encoding = "UTF-8") {
+  ds <- datasource(file, skip = skip, encoding = encoding)
   tokenize_(ds, tokenizer, n_max)
 }
 

--- a/R/tokenizer.R
+++ b/R/tokenizer.R
@@ -35,8 +35,8 @@ NULL
 
 #' @export
 #' @rdname Tokenizers
-#' @param comment A string used to identify comments. Any text after the
-#'   comment characters will be silently ignored.
+#' @param comment This argument is deprecated and will be ignored. Comments are
+#'   now handled by [datasource()].
 #' @param na Character vector of strings to use for missing values. Set this
 #'   option to `character()` to indicate no missing values.
 #' @param quoted_na Should missing values inside quotes be treated as missing
@@ -56,13 +56,15 @@ tokenizer_delim <- function(delim, quote = '"', na = "NA", quoted_na = TRUE, com
                             trim_ws = TRUE,
                             escape_double = TRUE,
                             escape_backslash = FALSE) {
+  if (!missing(comment)) {
+    warning("comment argument in tokenizer is deprecated and will be ignored. Give it to the datasource instead.")
+  }
   structure(
     list(
       delim = delim,
       quote = quote,
       na = na,
       quoted_na = quoted_na,
-      comment = comment,
       trim_ws = trim_ws,
       escape_double = escape_double,
       escape_backslash = escape_backslash
@@ -75,12 +77,14 @@ tokenizer_delim <- function(delim, quote = '"', na = "NA", quoted_na = TRUE, com
 #' @rdname Tokenizers
 tokenizer_csv <- function(na = "NA", quoted_na = TRUE, quote = "\"",
                           comment = "", trim_ws = TRUE) {
+  if (!missing(comment)) {
+    warning("comment argument in tokenizer is deprecated and will be ignored. Give it to the datasource instead.")
+  }
   tokenizer_delim(
     delim = ",",
     na = na,
     quoted_na = quoted_na,
     quote = quote,
-    comment = comment,
     trim_ws = trim_ws,
     escape_double = TRUE,
     escape_backslash = FALSE
@@ -91,12 +95,14 @@ tokenizer_csv <- function(na = "NA", quoted_na = TRUE, quote = "\"",
 #' @rdname Tokenizers
 tokenizer_tsv <- function(na = "NA", quoted_na = TRUE, quote = "\"",
                           comment = "", trim_ws = TRUE) {
+  if (!missing(comment)) {
+    warning("comment argument in tokenizer is deprecated and will be ignored. Give it to the datasource instead.")
+  }
   tokenizer_delim(
     delim = "\t",
     na = na,
     quoted_na = quoted_na,
     quote = quote,
-    comment = comment,
     trim_ws = trim_ws,
     escape_double = TRUE,
     escape_backslash = FALSE
@@ -122,11 +128,17 @@ tokenizer_log <- function() {
 #'   offsets so the first column is column zero, and the ranges are
 #'   [begin, end) (i.e inclusive-exclusive).
 tokenizer_fwf <- function(begin, end, na = "NA", comment = "", trim_ws = TRUE) {
-  structure(list(begin = begin, end = end, na = na, comment = comment, trim_ws = trim_ws), class = "tokenizer_fwf")
+  if (!missing(comment)) {
+    warning("comment argument in tokenizer is deprecated and will be ignored. Give it to the datasource instead.")
+  }
+  structure(list(begin = begin, end = end, na = na, trim_ws = trim_ws), class = "tokenizer_fwf")
 }
 
 #' @export
 #' @rdname Tokenizers
 tokenizer_ws <- function(na = "NA", comment = "") {
-  structure(list(na = na, comment = comment), class = "tokenizer_ws")
+  if (!missing(comment)) {
+    warning("comment argument in tokenizer is deprecated and will be ignored. Give it to the datasource instead.")
+  }
+  structure(list(na = na), class = "tokenizer_ws")
 }

--- a/man/Tokenizers.Rd
+++ b/man/Tokenizers.Rd
@@ -40,8 +40,8 @@ option to \code{character()} to indicate no missing values.}
 \item{quoted_na}{Should missing values inside quotes be treated as missing
 values (the default) or strings.}
 
-\item{comment}{A string used to identify comments. Any text after the
-comment characters will be silently ignored.}
+\item{comment}{This argument is deprecated and will be ignored. Comments are
+now handled by \code{\link[=datasource]{datasource()}}.}
 
 \item{trim_ws}{Should leading and trailing whitespace be trimmed from
 each field before parsing it?}

--- a/man/count_fields.Rd
+++ b/man/count_fields.Rd
@@ -4,7 +4,7 @@
 \alias{count_fields}
 \title{Count the number of fields in each line of a file}
 \usage{
-count_fields(file, tokenizer, skip = 0, n_max = -1L)
+count_fields(file, tokenizer, skip = 0, n_max = -1L, encoding = "UTF-8")
 }
 \arguments{
 \item{file}{Either a path to a file, a connection, or literal data
@@ -29,6 +29,8 @@ up into fields, e.g., \code{\link[=tokenizer_csv]{tokenizer_csv()}},
 \item{skip}{Number of lines to skip before reading data.}
 
 \item{n_max}{Optionally, maximum number of rows to count fields for.}
+
+\item{encoding}{The text encoding of the data given in \code{file}. "UTF-8" as default.}
 }
 \description{
 This is useful for diagnosing problems with functions that fail

--- a/man/datasource.Rd
+++ b/man/datasource.Rd
@@ -4,7 +4,7 @@
 \alias{datasource}
 \title{Create a source object.}
 \usage{
-datasource(file, skip = 0, comment = "")
+datasource(file, skip = 0, comment = "", encoding = "UTF-8")
 }
 \arguments{
 \item{file}{Either a path to a file, a connection, or literal data
@@ -23,6 +23,8 @@ vector of greater than length 1.
 Using a value of \code{\link[=clipboard]{clipboard()}} will read from the system clipboard.}
 
 \item{skip}{Number of lines to skip before reading data.}
+
+\item{encoding}{The text encoding of the data given in \code{file}. "UTF-8" as default.}
 }
 \description{
 Create a source object.

--- a/man/datasource.Rd
+++ b/man/datasource.Rd
@@ -24,6 +24,10 @@ Using a value of \code{\link[=clipboard]{clipboard()}} will read from the system
 
 \item{skip}{Number of lines to skip before reading data.}
 
+\item{comment}{A string used to identify comments. Any text after the
+comment characters will be silently ignored. Multiple comments can be given
+using a character vector.}
+
 \item{encoding}{The text encoding of the data given in \code{file}. "UTF-8" as default.}
 }
 \description{

--- a/man/read_delim.Rd
+++ b/man/read_delim.Rd
@@ -102,7 +102,8 @@ option to \code{character()} to indicate no missing values.}
 values (the default) or strings.}
 
 \item{comment}{A string used to identify comments. Any text after the
-comment characters will be silently ignored.}
+comment characters will be silently ignored. Multiple comments can be given
+using a character vector.}
 
 \item{trim_ws}{Should leading and trailing whitespace be trimmed from
 each field before parsing it?}

--- a/man/read_delim_chunked.Rd
+++ b/man/read_delim_chunked.Rd
@@ -106,7 +106,8 @@ option to \code{character()} to indicate no missing values.}
 values (the default) or strings.}
 
 \item{comment}{A string used to identify comments. Any text after the
-comment characters will be silently ignored.}
+comment characters will be silently ignored. Multiple comments can be given
+using a character vector.}
 
 \item{trim_ws}{Should leading and trailing whitespace be trimmed from
 each field before parsing it?}

--- a/man/read_file.Rd
+++ b/man/read_file.Rd
@@ -8,7 +8,7 @@
 \usage{
 read_file(file, locale = default_locale())
 
-read_file_raw(file)
+read_file_raw(file, encoding = "UTF-8")
 
 write_file(x, path, append = FALSE)
 }
@@ -33,6 +33,8 @@ The default locale is US-centric (like R), but you can use
 \code{\link[=locale]{locale()}} to create your own locale that controls things like
 the default time zone, encoding, decimal mark, big mark, and day/month
 names.}
+
+\item{encoding}{The text encoding of the data given in \code{file}. "UTF-8" as default.}
 
 \item{x}{A data frame to write to disk}
 

--- a/man/read_fwf.Rd
+++ b/man/read_fwf.Rd
@@ -69,7 +69,8 @@ names.}
 option to \code{character()} to indicate no missing values.}
 
 \item{comment}{A string used to identify comments. Any text after the
-comment characters will be silently ignored.}
+comment characters will be silently ignored. Multiple comments can be given
+using a character vector.}
 
 \item{trim_ws}{Should leading and trailing whitespace be trimmed from
 each field before parsing it?}

--- a/man/read_fwf.Rd
+++ b/man/read_fwf.Rd
@@ -12,7 +12,8 @@ read_fwf(file, col_positions, col_types = NULL, locale = default_locale(),
   na = c("", "NA"), comment = "", trim_ws = TRUE, skip = 0,
   n_max = Inf, guess_max = min(n_max, 1000), progress = show_progress())
 
-fwf_empty(file, skip = 0, col_names = NULL, comment = "", n = 100L)
+fwf_empty(file, skip = 0, col_names = NULL, comment = "", n = 100L,
+  encoding = "UTF-8")
 
 fwf_widths(widths, col_names = NULL)
 
@@ -89,6 +90,8 @@ setting option \code{readr.show_progress} to \code{FALSE}.}
 
 \item{n}{Number of lines the tokenizer will read to determine file structure. By default
 it is set to 100.}
+
+\item{encoding}{The text encoding of the data given in \code{file}. "UTF-8" as default.}
 
 \item{widths}{Width of each field. Use NA as width of last field when
 reading a ragged fwf file.}

--- a/man/read_lines.Rd
+++ b/man/read_lines.Rd
@@ -9,7 +9,8 @@
 read_lines(file, skip = 0, n_max = -1L, locale = default_locale(),
   na = character(), progress = show_progress())
 
-read_lines_raw(file, skip = 0, n_max = -1L, progress = show_progress())
+read_lines_raw(file, skip = 0, n_max = -1L, progress = show_progress(),
+  encoding = "UTF-8")
 
 write_lines(x, path, sep = "\\n", na = "NA", append = FALSE)
 }
@@ -48,6 +49,8 @@ in an interactive session and not while knitting a document. The display
 is updated every 50,000 values and will only display if estimated reading
 time is 5 seconds or more. The automatic progress bar can be disabled by
 setting option \code{readr.show_progress} to \code{FALSE}.}
+
+\item{encoding}{The text encoding of the data given in \code{file}. "UTF-8" as default.}
 
 \item{x}{A data frame to write to disk}
 

--- a/man/read_table.Rd
+++ b/man/read_table.Rd
@@ -83,7 +83,8 @@ time is 5 seconds or more. The automatic progress bar can be disabled by
 setting option \code{readr.show_progress} to \code{FALSE}.}
 
 \item{comment}{A string used to identify comments. Any text after the
-comment characters will be silently ignored.}
+comment characters will be silently ignored. Multiple comments can be given
+using a character vector.}
 }
 \description{
 \code{read_table()} and \code{read_table2()} are designed to read the type of textual

--- a/man/spec_delim.Rd
+++ b/man/spec_delim.Rd
@@ -107,7 +107,8 @@ option to \code{character()} to indicate no missing values.}
 values (the default) or strings.}
 
 \item{comment}{A string used to identify comments. Any text after the
-comment characters will be silently ignored.}
+comment characters will be silently ignored. Multiple comments can be given
+using a character vector.}
 
 \item{trim_ws}{Should leading and trailing whitespace be trimmed from
 each field before parsing it?}

--- a/man/tokenize.Rd
+++ b/man/tokenize.Rd
@@ -4,7 +4,8 @@
 \alias{tokenize}
 \title{Tokenize a file/string.}
 \usage{
-tokenize(file, tokenizer = tokenizer_csv(), skip = 0, n_max = -1L)
+tokenize(file, tokenizer = tokenizer_csv(), skip = 0, n_max = -1L,
+  encoding = "UTF-8")
 }
 \arguments{
 \item{file}{Either a path to a file, a connection, or literal data
@@ -27,6 +28,8 @@ Using a value of \code{\link[=clipboard]{clipboard()}} will read from the system
 \item{skip}{Number of lines to skip before reading data.}
 
 \item{n_max}{Optionally, maximum number of rows to tokenize.}
+
+\item{encoding}{The text encoding of the data given in \code{file}. "UTF-8" as default.}
 }
 \description{
 Turns input into a character vector. Usually the tokenization is done purely

--- a/notes/design.Rmd
+++ b/notes/design.Rmd
@@ -99,7 +99,7 @@ The tokenizer (`Tokenizer.h`) turns a source (a stream of characters) into a str
 TokenizerPtr tokenizer = Tokenizer::create(tokenizerSpec);
 
 # Initialise it with a source
-tokenizer->tokenize(source->begin(), source->end());
+tokenizer->tokenize(source);
 
 # Call nextToken until there are no tokens left 
 for (Token t = tokenizer->nextToken(); t.type() != TOKEN_EOF; t = tokenizer->nextToken());

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -17,6 +17,30 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// source_encoding
+CharacterVector source_encoding(List spec);
+RcppExport SEXP _readr_source_encoding(SEXP specSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< List >::type spec(specSEXP);
+    rcpp_result_gen = Rcpp::wrap(source_encoding(spec));
+    return rcpp_result_gen;
+END_RCPP
+}
+// whitespaceColumns
+List whitespaceColumns(List sourceSpec, int n, std::string comment);
+RcppExport SEXP _readr_whitespaceColumns(SEXP sourceSpecSEXP, SEXP nSEXP, SEXP commentSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< List >::type sourceSpec(sourceSpecSEXP);
+    Rcpp::traits::input_parameter< int >::type n(nSEXP);
+    Rcpp::traits::input_parameter< std::string >::type comment(commentSEXP);
+    rcpp_result_gen = Rcpp::wrap(whitespaceColumns(sourceSpec, n, comment));
+    return rcpp_result_gen;
+END_RCPP
+}
 // read_connection_
 RawVector read_connection_(RObject con, int chunk_size);
 RcppExport SEXP _readr_read_connection_(SEXP conSEXP, SEXP chunk_sizeSEXP) {
@@ -226,19 +250,6 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// whitespaceColumns
-List whitespaceColumns(List sourceSpec, int n, std::string comment);
-RcppExport SEXP _readr_whitespaceColumns(SEXP sourceSpecSEXP, SEXP nSEXP, SEXP commentSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< List >::type sourceSpec(sourceSpecSEXP);
-    Rcpp::traits::input_parameter< int >::type n(nSEXP);
-    Rcpp::traits::input_parameter< std::string >::type comment(commentSEXP);
-    rcpp_result_gen = Rcpp::wrap(whitespaceColumns(sourceSpec, n, comment));
-    return rcpp_result_gen;
-END_RCPP
-}
 // type_convert_col
 RObject type_convert_col(CharacterVector x, List spec, List locale_, int col, const std::vector<std::string>& na, bool trim_ws);
 RcppExport SEXP _readr_type_convert_col(SEXP xSEXP, SEXP specSEXP, SEXP locale_SEXP, SEXP colSEXP, SEXP naSEXP, SEXP trim_wsSEXP) {
@@ -252,22 +263,6 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const std::vector<std::string>& >::type na(naSEXP);
     Rcpp::traits::input_parameter< bool >::type trim_ws(trim_wsSEXP);
     rcpp_result_gen = Rcpp::wrap(type_convert_col(x, spec, locale_, col, na, trim_ws));
-    return rcpp_result_gen;
-END_RCPP
-}
-// stream_delim_
-std::string stream_delim_(const List& df, RObject connection, char delim, const std::string& na, bool col_names, bool bom);
-RcppExport SEXP _readr_stream_delim_(SEXP dfSEXP, SEXP connectionSEXP, SEXP delimSEXP, SEXP naSEXP, SEXP col_namesSEXP, SEXP bomSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const List& >::type df(dfSEXP);
-    Rcpp::traits::input_parameter< RObject >::type connection(connectionSEXP);
-    Rcpp::traits::input_parameter< char >::type delim(delimSEXP);
-    Rcpp::traits::input_parameter< const std::string& >::type na(naSEXP);
-    Rcpp::traits::input_parameter< bool >::type col_names(col_namesSEXP);
-    Rcpp::traits::input_parameter< bool >::type bom(bomSEXP);
-    rcpp_result_gen = Rcpp::wrap(stream_delim_(df, connection, delim, na, col_names, bom));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -318,9 +313,27 @@ BEGIN_RCPP
     return R_NilValue;
 END_RCPP
 }
+// stream_delim_
+std::string stream_delim_(const List& df, RObject connection, char delim, const std::string& na, bool col_names, bool bom);
+RcppExport SEXP _readr_stream_delim_(SEXP dfSEXP, SEXP connectionSEXP, SEXP delimSEXP, SEXP naSEXP, SEXP col_namesSEXP, SEXP bomSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const List& >::type df(dfSEXP);
+    Rcpp::traits::input_parameter< RObject >::type connection(connectionSEXP);
+    Rcpp::traits::input_parameter< char >::type delim(delimSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type na(naSEXP);
+    Rcpp::traits::input_parameter< bool >::type col_names(col_namesSEXP);
+    Rcpp::traits::input_parameter< bool >::type bom(bomSEXP);
+    rcpp_result_gen = Rcpp::wrap(stream_delim_(df, connection, delim, na, col_names, bom));
+    return rcpp_result_gen;
+END_RCPP
+}
 
 static const R_CallMethodDef CallEntries[] = {
     {"_readr_collectorGuess", (DL_FUNC) &_readr_collectorGuess, 2},
+    {"_readr_source_encoding", (DL_FUNC) &_readr_source_encoding, 1},
+    {"_readr_whitespaceColumns", (DL_FUNC) &_readr_whitespaceColumns, 3},
     {"_readr_read_connection_", (DL_FUNC) &_readr_read_connection_, 2},
     {"_readr_utctime", (DL_FUNC) &_readr_utctime, 7},
     {"_readr_dim_tokens_", (DL_FUNC) &_readr_dim_tokens_, 2},
@@ -336,13 +349,12 @@ static const R_CallMethodDef CallEntries[] = {
     {"_readr_read_tokens_", (DL_FUNC) &_readr_read_tokens_, 7},
     {"_readr_read_tokens_chunked_", (DL_FUNC) &_readr_read_tokens_chunked_, 8},
     {"_readr_guess_types_", (DL_FUNC) &_readr_guess_types_, 4},
-    {"_readr_whitespaceColumns", (DL_FUNC) &_readr_whitespaceColumns, 3},
     {"_readr_type_convert_col", (DL_FUNC) &_readr_type_convert_col, 6},
-    {"_readr_stream_delim_", (DL_FUNC) &_readr_stream_delim_, 6},
     {"_readr_write_lines_", (DL_FUNC) &_readr_write_lines_, 4},
     {"_readr_write_lines_raw_", (DL_FUNC) &_readr_write_lines_raw_, 3},
     {"_readr_write_file_", (DL_FUNC) &_readr_write_file_, 2},
     {"_readr_write_file_raw_", (DL_FUNC) &_readr_write_file_raw_, 2},
+    {"_readr_stream_delim_", (DL_FUNC) &_readr_stream_delim_, 6},
     {NULL, NULL, 0}
 };
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -17,30 +17,6 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// source_encoding
-CharacterVector source_encoding(List spec);
-RcppExport SEXP _readr_source_encoding(SEXP specSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< List >::type spec(specSEXP);
-    rcpp_result_gen = Rcpp::wrap(source_encoding(spec));
-    return rcpp_result_gen;
-END_RCPP
-}
-// whitespaceColumns
-List whitespaceColumns(List sourceSpec, int n, std::string comment);
-RcppExport SEXP _readr_whitespaceColumns(SEXP sourceSpecSEXP, SEXP nSEXP, SEXP commentSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< List >::type sourceSpec(sourceSpecSEXP);
-    Rcpp::traits::input_parameter< int >::type n(nSEXP);
-    Rcpp::traits::input_parameter< std::string >::type comment(commentSEXP);
-    rcpp_result_gen = Rcpp::wrap(whitespaceColumns(sourceSpec, n, comment));
-    return rcpp_result_gen;
-END_RCPP
-}
 // read_connection_
 RawVector read_connection_(RObject con, int chunk_size);
 RcppExport SEXP _readr_read_connection_(SEXP conSEXP, SEXP chunk_sizeSEXP) {
@@ -250,6 +226,29 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// source_encoding
+CharacterVector source_encoding(List spec);
+RcppExport SEXP _readr_source_encoding(SEXP specSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< List >::type spec(specSEXP);
+    rcpp_result_gen = Rcpp::wrap(source_encoding(spec));
+    return rcpp_result_gen;
+END_RCPP
+}
+// whitespaceColumns
+List whitespaceColumns(List sourceSpec, int n);
+RcppExport SEXP _readr_whitespaceColumns(SEXP sourceSpecSEXP, SEXP nSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< List >::type sourceSpec(sourceSpecSEXP);
+    Rcpp::traits::input_parameter< int >::type n(nSEXP);
+    rcpp_result_gen = Rcpp::wrap(whitespaceColumns(sourceSpec, n));
+    return rcpp_result_gen;
+END_RCPP
+}
 // type_convert_col
 RObject type_convert_col(CharacterVector x, List spec, List locale_, int col, const std::vector<std::string>& na, bool trim_ws);
 RcppExport SEXP _readr_type_convert_col(SEXP xSEXP, SEXP specSEXP, SEXP locale_SEXP, SEXP colSEXP, SEXP naSEXP, SEXP trim_wsSEXP) {
@@ -332,8 +331,6 @@ END_RCPP
 
 static const R_CallMethodDef CallEntries[] = {
     {"_readr_collectorGuess", (DL_FUNC) &_readr_collectorGuess, 2},
-    {"_readr_source_encoding", (DL_FUNC) &_readr_source_encoding, 1},
-    {"_readr_whitespaceColumns", (DL_FUNC) &_readr_whitespaceColumns, 3},
     {"_readr_read_connection_", (DL_FUNC) &_readr_read_connection_, 2},
     {"_readr_utctime", (DL_FUNC) &_readr_utctime, 7},
     {"_readr_dim_tokens_", (DL_FUNC) &_readr_dim_tokens_, 2},
@@ -349,6 +346,8 @@ static const R_CallMethodDef CallEntries[] = {
     {"_readr_read_tokens_", (DL_FUNC) &_readr_read_tokens_, 7},
     {"_readr_read_tokens_chunked_", (DL_FUNC) &_readr_read_tokens_chunked_, 8},
     {"_readr_guess_types_", (DL_FUNC) &_readr_guess_types_, 4},
+    {"_readr_source_encoding", (DL_FUNC) &_readr_source_encoding, 1},
+    {"_readr_whitespaceColumns", (DL_FUNC) &_readr_whitespaceColumns, 2},
     {"_readr_type_convert_col", (DL_FUNC) &_readr_type_convert_col, 6},
     {"_readr_write_lines_", (DL_FUNC) &_readr_write_lines_, 4},
     {"_readr_write_lines_raw_", (DL_FUNC) &_readr_write_lines_raw_, 3},

--- a/src/Reader.cpp
+++ b/src/Reader.cpp
@@ -30,7 +30,7 @@ Reader::Reader(
 }
 
 void Reader::init(CharacterVector colNames) {
-  tokenizer_->tokenize(source_->begin(), source_->end());
+  tokenizer_->tokenize(source_);
   tokenizer_->setWarnings(&warnings_);
 
   // Work out which output columns we are keeping and set warnings for each

--- a/src/Source.cpp
+++ b/src/Source.cpp
@@ -12,16 +12,26 @@ SourcePtr Source::create(List spec) {
   int skip = as<int>(spec["skip"]);
   std::string comment = as<std::string>(spec["comment"]);
 
+  std::string encoding = as<std::string>(spec["encoding"]);
+
   if (subclass == "source_raw") {
-    return SourcePtr(new SourceRaw(as<RawVector>(spec[0]), skip, comment));
-  } else if (subclass == "source_string") {
     return SourcePtr(
-        new SourceString(as<CharacterVector>(spec[0]), skip, comment));
+        new SourceRaw(as<RawVector>(spec[0]), skip, comment, encoding));
+  } else if (subclass == "source_string") {
+    return SourcePtr(new SourceString(
+        as<CharacterVector>(spec[0]), skip, comment, encoding));
   } else if (subclass == "source_file") {
     std::string path(as<CharacterVector>(spec[0])[0]);
-    return SourcePtr(new SourceFile(path, skip, comment));
+    return SourcePtr(new SourceFile(path, skip, comment, encoding));
   }
 
   Rcpp::stop("Unknown source type");
   return SourcePtr();
+}
+
+// This function is used to test the encoding detection based on the BOM
+// [[Rcpp::export]]
+CharacterVector source_encoding(List spec) {
+  SourcePtr source = Source::create(spec);
+  return source->encoding();
 }

--- a/src/Source.cpp
+++ b/src/Source.cpp
@@ -10,19 +10,27 @@ SourcePtr Source::create(List spec) {
   std::string subclass(as<CharacterVector>(spec.attr("class"))[0]);
 
   int skip = as<int>(spec["skip"]);
-  std::string comment = as<std::string>(spec["comment"]);
+
+  std::vector<std::string> comments;
+  CharacterVector givenComments(as<CharacterVector>(spec["comment"]));
+  for (R_xlen_t i = 0; i < givenComments.length(); ++i) {
+    std::string comm = as<std::string>(givenComments[i]);
+    if (comm != "") {
+      comments.push_back(comm);
+    }
+  }
 
   std::string encoding = as<std::string>(spec["encoding"]);
 
   if (subclass == "source_raw") {
     return SourcePtr(
-        new SourceRaw(as<RawVector>(spec[0]), skip, comment, encoding));
+        new SourceRaw(as<RawVector>(spec[0]), skip, comments, encoding));
   } else if (subclass == "source_string") {
     return SourcePtr(new SourceString(
-        as<CharacterVector>(spec[0]), skip, comment, encoding));
+        as<CharacterVector>(spec[0]), skip, comments, encoding));
   } else if (subclass == "source_file") {
     std::string path(as<CharacterVector>(spec[0])[0]);
-    return SourcePtr(new SourceFile(path, skip, comment, encoding));
+    return SourcePtr(new SourceFile(path, skip, comments, encoding));
   }
 
   Rcpp::stop("Unknown source type");

--- a/src/SourceFile.h
+++ b/src/SourceFile.h
@@ -14,7 +14,11 @@ class SourceFile : public Source {
 
 public:
   SourceFile(
-      const std::string& path, int skip = 0, const std::string& comment = "") {
+      const std::string& path,
+      int skip,
+      const std::string& comment,
+      const std::string encoding)
+      : Source(encoding) {
     try {
       fm_ = boost::interprocess::file_mapping(
           path.c_str(), boost::interprocess::read_only);

--- a/src/SourceFile.h
+++ b/src/SourceFile.h
@@ -16,9 +16,9 @@ public:
   SourceFile(
       const std::string& path,
       int skip,
-      const std::string& comment,
+      const std::vector<std::string>& comments,
       const std::string encoding)
-      : Source(encoding) {
+      : Source(comments, encoding) {
     try {
       fm_ = boost::interprocess::file_mapping(
           path.c_str(), boost::interprocess::read_only);
@@ -35,12 +35,12 @@ public:
     begin_ = skipBom(begin_, end_);
 
     // Skip lines, if needed
-    begin_ = skipLines(begin_, end_, skip, comment);
+    begin_ = skipLines(skip);
   }
 
-  const char* begin() { return begin_; }
+  const char* begin() const { return begin_; }
 
-  const char* end() { return end_; }
+  const char* end() const { return end_; }
 };
 
 #endif

--- a/src/SourceRaw.h
+++ b/src/SourceRaw.h
@@ -10,8 +10,12 @@ class SourceRaw : public Source {
   const char* end_;
 
 public:
-  SourceRaw(Rcpp::RawVector x, int skip = 0, const std::string& comment = "")
-      : x_(x) {
+  SourceRaw(
+      Rcpp::RawVector x,
+      int skip,
+      const std::string& comment,
+      const std::string encoding)
+      : Source(encoding), x_(x) {
     begin_ = (const char*)RAW(x);
     end_ = (const char*)RAW(x) + Rf_xlength(x);
 

--- a/src/SourceRaw.h
+++ b/src/SourceRaw.h
@@ -13,9 +13,9 @@ public:
   SourceRaw(
       Rcpp::RawVector x,
       int skip,
-      const std::string& comment,
+      const std::vector<std::string>& comments,
       const std::string encoding)
-      : Source(encoding), x_(x) {
+      : Source(comments, encoding), x_(x) {
     begin_ = (const char*)RAW(x);
     end_ = (const char*)RAW(x) + Rf_xlength(x);
 
@@ -23,12 +23,12 @@ public:
     begin_ = skipBom(begin_, end_);
 
     // Skip lines, if needed
-    begin_ = skipLines(begin_, end_, skip, comment);
+    begin_ = skipLines(skip);
   }
 
-  const char* begin() { return begin_; }
+  const char* begin() const { return begin_; }
 
-  const char* end() { return end_; }
+  const char* end() const { return end_; }
 };
 
 #endif

--- a/src/SourceString.h
+++ b/src/SourceString.h
@@ -14,9 +14,9 @@ public:
   SourceString(
       Rcpp::CharacterVector x,
       int skip,
-      const std::string& comment,
+      const std::vector<std::string>& comments,
       const std::string encoding)
-      : Source(encoding) {
+      : Source(comments, encoding) {
     string_ = x[0];
 
     begin_ = CHAR(string_);
@@ -26,12 +26,12 @@ public:
     begin_ = skipBom(begin_, end_);
 
     // Skip lines, if needed
-    begin_ = skipLines(begin_, end_, skip, comment);
+    begin_ = skipLines(skip);
   }
 
-  const char* begin() { return begin_; }
+  const char* begin() const { return begin_; }
 
-  const char* end() { return end_; }
+  const char* end() const { return end_; }
 };
 
 #endif

--- a/src/SourceString.h
+++ b/src/SourceString.h
@@ -12,7 +12,11 @@ class SourceString : public Source {
 
 public:
   SourceString(
-      Rcpp::CharacterVector x, int skip = 0, const std::string& comment = "") {
+      Rcpp::CharacterVector x,
+      int skip,
+      const std::string& comment,
+      const std::string encoding)
+      : Source(encoding) {
     string_ = x[0];
 
     begin_ = CHAR(string_);

--- a/src/Tokenizer.cpp
+++ b/src/Tokenizer.cpp
@@ -15,29 +15,20 @@ TokenizerPtr Tokenizer::create(List spec) {
     char delim = as<char>(spec["delim"]);
     char quote = as<char>(spec["quote"]);
     std::vector<std::string> na = as<std::vector<std::string> >(spec["na"]);
-    std::string comment = as<std::string>(spec["comment"]);
     bool trimWs = as<bool>(spec["trim_ws"]);
     bool escapeDouble = as<bool>(spec["escape_double"]);
     bool escapeBackslash = as<bool>(spec["escape_backslash"]);
     bool quotedNA = as<bool>(spec["quoted_na"]);
 
     return TokenizerPtr(new TokenizerDelim(
-        delim,
-        quote,
-        na,
-        comment,
-        trimWs,
-        escapeBackslash,
-        escapeDouble,
-        quotedNA));
+        delim, quote, na, trimWs, escapeBackslash, escapeDouble, quotedNA));
   } else if (subclass == "tokenizer_fwf") {
     std::vector<int> begin = as<std::vector<int> >(spec["begin"]),
                      end = as<std::vector<int> >(spec["end"]);
     std::vector<std::string> na = as<std::vector<std::string> >(spec["na"]);
-    std::string comment = as<std::string>(spec["comment"]);
     bool trimWs = as<bool>(spec["trim_ws"]);
 
-    return TokenizerPtr(new TokenizerFwf(begin, end, na, comment, trimWs));
+    return TokenizerPtr(new TokenizerFwf(begin, end, na, trimWs));
   } else if (subclass == "tokenizer_line") {
     std::vector<std::string> na = as<std::vector<std::string> >(spec["na"]);
     return TokenizerPtr(new TokenizerLine(na));
@@ -45,8 +36,7 @@ TokenizerPtr Tokenizer::create(List spec) {
     return TokenizerPtr(new TokenizerLog());
   } else if (subclass == "tokenizer_ws") {
     std::vector<std::string> na = as<std::vector<std::string> >(spec["na"]);
-    std::string comment = as<std::string>(spec["comment"]);
-    return TokenizerPtr(new TokenizerWs(na, comment));
+    return TokenizerPtr(new TokenizerWs(na));
   }
 
   Rcpp::stop("Unknown tokenizer type");

--- a/src/Tokenizer.h
+++ b/src/Tokenizer.h
@@ -1,6 +1,7 @@
 #ifndef FASTREAD_TOKENIZER_H_
 #define FASTREAD_TOKENIZER_H_
 
+#include "Source.h"
 #include "Warnings.h"
 #include "boost.h"
 #include <Rcpp.h>
@@ -21,7 +22,7 @@ public:
   Tokenizer() : pWarnings_(NULL) {}
   virtual ~Tokenizer() {}
 
-  virtual void tokenize(SourceIterator begin, SourceIterator end) = 0;
+  virtual void tokenize(SourcePtr source) = 0;
   virtual Token nextToken() = 0;
   // Percentage & bytes
   virtual std::pair<double, size_t> progress() = 0;

--- a/src/TokenizerDelim.h
+++ b/src/TokenizerDelim.h
@@ -20,12 +20,11 @@ enum DelimState {
 class TokenizerDelim : public Tokenizer {
   char delim_, quote_;
   std::vector<std::string> NA_;
-  std::string comment_;
 
-  bool hasComment_, trimWS_, escapeBackslash_, escapeDouble_, quotedNA_,
-      hasEmptyNA_;
+  bool trimWS_, escapeBackslash_, escapeDouble_, quotedNA_, hasEmptyNA_;
 
   SourceIterator begin_, cur_, end_;
+  SourcePtr source_;
   DelimState state_;
   int row_, col_;
   bool moreTokens_;
@@ -35,13 +34,12 @@ public:
       char delim = ',',
       char quote = '"',
       std::vector<std::string> NA = std::vector<std::string>(1, "NA"),
-      std::string comment = "",
       bool trimWS = true,
       bool escapeBackslash = false,
       bool escapeDouble = true,
       bool quotedNA = true);
 
-  void tokenize(SourceIterator begin, SourceIterator end);
+  void tokenize(SourcePtr source);
 
   std::pair<double, size_t> progress();
 
@@ -51,8 +49,6 @@ public:
       SourceIterator begin, SourceIterator end, boost::container::string* pOut);
 
 private:
-  bool isComment(const char* cur) const;
-
   void newField();
 
   void newRecord();

--- a/src/TokenizerFwf.cpp
+++ b/src/TokenizerFwf.cpp
@@ -103,7 +103,8 @@ List whitespaceColumns(List sourceSpec, int n = 100, std::string comment = "") {
   return List::create(_["begin"] = begin, _["end"] = end, _["skip"] = s.lines);
 }
 
-// TokenizerFwf ---------------------------------------------------------------
+  // TokenizerFwf
+  // ---------------------------------------------------------------
 
 #include "TokenizerFwf.h"
 #include <Rcpp.h>

--- a/src/TokenizerFwf.h
+++ b/src/TokenizerFwf.h
@@ -11,19 +11,18 @@ class TokenizerFwf : public Tokenizer {
   std::vector<std::string> NA_;
 
   SourceIterator begin_, cur_, curLine_, end_;
+  SourcePtr source_;
   int row_, col_, cols_, max_;
-  std::string comment_;
-  bool moreTokens_, isRagged_, hasComment_, trimWS_;
+  bool moreTokens_, isRagged_, trimWS_;
 
 public:
   TokenizerFwf(
       const std::vector<int>& beginOffset,
       const std::vector<int>& endOffset,
       std::vector<std::string> NA = std::vector<std::string>(1, "NA"),
-      std::string comment = "",
       bool trimWS = true);
 
-  void tokenize(SourceIterator begin, SourceIterator end);
+  void tokenize(SourcePtr source);
 
   std::pair<double, size_t> progress();
 
@@ -31,9 +30,6 @@ public:
 
 private:
   Token fieldToken(SourceIterator begin, SourceIterator end, bool hasNull);
-
-  bool isComment(const char* cur) const;
-  bool isEmpty() const;
 };
 
 #endif

--- a/src/TokenizerLine.h
+++ b/src/TokenizerLine.h
@@ -17,10 +17,10 @@ public:
 
   TokenizerLine() : moreTokens_(false) {}
 
-  void tokenize(SourceIterator begin, SourceIterator end) {
-    begin_ = begin;
-    cur_ = begin;
-    end_ = end;
+  void tokenize(SourcePtr source) {
+    begin_ = source->begin();
+    cur_ = source->begin();
+    end_ = source->end();
     line_ = 0;
     moreTokens_ = true;
   }

--- a/src/TokenizerLog.h
+++ b/src/TokenizerLog.h
@@ -24,10 +24,10 @@ class TokenizerLog : public Tokenizer {
 public:
   TokenizerLog() {}
 
-  void tokenize(SourceIterator begin, SourceIterator end) {
-    cur_ = begin;
-    begin_ = begin;
-    end_ = end;
+  void tokenize(SourcePtr source) {
+    cur_ = source->begin();
+    begin_ = source->begin();
+    end_ = source->end();
 
     row_ = 0;
     col_ = 0;

--- a/src/TokenizerWs.h
+++ b/src/TokenizerWs.h
@@ -10,6 +10,7 @@ class TokenizerWs : public Tokenizer {
   std::vector<std::string> NA_;
 
   SourceIterator begin_, cur_, curLine_, end_;
+  SourcePtr source_;
   int row_, col_;
   std::string comment_;
   bool moreTokens_, hasComment_;
@@ -19,7 +20,7 @@ public:
       std::vector<std::string> NA = std::vector<std::string>(1, "NA"),
       std::string comment = "");
 
-  void tokenize(SourceIterator begin, SourceIterator end);
+  void tokenize(SourcePtr source);
 
   std::pair<double, size_t> progress();
 
@@ -27,9 +28,6 @@ public:
 
 private:
   Token fieldToken(SourceIterator begin, SourceIterator end, bool hasNull);
-
-  bool isComment(const char* cur) const;
-  bool isEmpty() const;
 };
 
 #endif

--- a/src/read.cpp
+++ b/src/read.cpp
@@ -160,7 +160,7 @@ std::vector<std::string> guess_types_(
   Warnings warnings;
   SourcePtr source = Source::create(sourceSpec);
   TokenizerPtr tokenizer = Tokenizer::create(tokenizerSpec);
-  tokenizer->tokenize(source->begin(), source->end());
+  tokenizer->tokenize(source);
   tokenizer->setWarnings(&warnings); // silence warnings
 
   LocaleInfo locale(locale_);

--- a/tests/testthat/test-source.R
+++ b/tests/testthat/test-source.R
@@ -1,0 +1,23 @@
+context("Source")
+# Tests the Source class
+
+test_that("Encoding is trivially retreived", {
+  ds <- datasource("a b\n1 2", encoding = "UTF-8")
+  expect_equal(source_encoding(ds), "UTF-8")
+})
+
+test_that("UTF-16 is identified as UTF-16LE or UTF-16BE", {
+  bom_le <- as.raw(c(0xFF, 0xFE))
+  # Convert text to UTF-16LE (without BOM) and append BOM manually so it becomes
+  # UTF-16 (with BOM). The Source class should skip the BOM automatically and
+  # report UTF-16LE
+  text <- iconv("a b\n1 2", from = "UTF-8", to = "UTF-16LE", toRaw = TRUE)[[1]]
+  ds <- datasource(c(bom_le, text), encoding = "UTF-16")
+  expect_equal(source_encoding(ds), "UTF-16LE")
+
+  # Do the same with UTF-16
+  bom_be <- as.raw(c(0xFE, 0xFF))
+  text <- iconv("a b\n1 2", from = "UTF-8", to = "UTF-16BE", toRaw = TRUE)[[1]]
+  ds <- datasource(c(bom_be, text), encoding = "UTF-16")
+  expect_equal(source_encoding(ds), "UTF-16BE")
+})

--- a/tests/testthat/test-source.R
+++ b/tests/testthat/test-source.R
@@ -21,3 +21,16 @@ test_that("UTF-16 is identified as UTF-16LE or UTF-16BE", {
   ds <- datasource(c(bom_be, text), encoding = "UTF-16")
   expect_equal(source_encoding(ds), "UTF-16BE")
 })
+
+test_that("Support multiple comments in header", {
+  a <- read_table("COMMENT\n#TEST\na b\n1 2", comment = c("COMMENT", "#"))
+  b <- read_table("a b\n1 2")
+  expect_equal(a, b)
+
+})
+
+test_that("Support multiple comments in body", {
+  a <- read_table("a b\n1 2\nCOMMENT potato\n#another\n3 4\n#onemore\n5 6\n#endcomm", comment = c("COMMENT", "#"))
+  b <- read_table("a b\n1 2\n3 4\n5 6")
+  expect_equal(a, b)
+})


### PR DESCRIPTION
This pull request allows to provide more than one comment pattern to `readr`. Example:

```
readr::read_delim(c(
  "# A comment",
  "x,y",
  "1,2",
  "// another comment",
  "3,4"), delim = ",", comment = c("#", "//"))
```

It is applied on top of this other PR https://github.com/tidyverse/readr/pull/677, so merging this will be easier once that PR is reviewed.