### PR TITLE
Fix missing # in example causing check to fail

### DIFF
--- a/R/col_types.R
+++ b/R/col_types.R
@@ -16,7 +16,7 @@
 #' cols(a = "i", b = "d", c = "_")
 #'
 #' # You can also use multiple sets of column definitions by combining
-#' them like so:
+#' # them like so:
 #'
 #' t1 <- cols(
 #'   column_one = col_integer(),

--- a/man/cols.Rd
+++ b/man/cols.Rd
@@ -28,4 +28,18 @@ cols_only(a = col_integer())
 # You can also use the standard abreviations
 cols(a = "i")
 cols(a = "i", b = "d", c = "_")
+
+# You can also use multiple sets of column definitions by combining
+# them like so:
+
+t1 <- cols(
+  column_one = col_integer(),
+  column_two = col_number())
+
+t2 <- cols(
+ column_three = col_character())
+
+t3 <- t1
+t3$cols <- c(t1$cols, t2$cols)
+t3
 }


### PR DESCRIPTION
A missing # in the col_types example was causing "them like so:" to be executed as code and so the package checks to fail.