### PR TITLE
read_fwf .rd file name column ends at position 20, not 10

### DIFF
--- a/R/read_fwf.R
+++ b/R/read_fwf.R
@@ -28,9 +28,9 @@
 #' # 2. A vector of field widths
 #' read_fwf(fwf_sample, fwf_widths(c(20, 10, 12), c("name", "state", "ssn")))
 #' # 3. Paired vectors of start and end positions
-#' read_fwf(fwf_sample, fwf_positions(c(1, 30), c(10, 42), c("name", "ssn")))
+#' read_fwf(fwf_sample, fwf_positions(c(1, 30), c(20, 42), c("name", "ssn")))
 #' # 4. Named arguments with start and end positions
-#' read_fwf(fwf_sample, fwf_cols(name = c(1, 10), ssn = c(30, 42)))
+#' read_fwf(fwf_sample, fwf_cols(name = c(1, 20), ssn = c(30, 42)))
 #' # 5. Named arguments with column widths
 #' read_fwf(fwf_sample, fwf_cols(name = 20, state = 10, ssn = 12))
 read_fwf <- function(file, col_positions, col_types = NULL,


### PR DESCRIPTION
the example rd file currently cuts off the names..  thanks

	> # 3. Paired vectors of start and end positions
	> read_fwf(fwf_sample, fwf_positions(c(1, 30), c(10, 42), c("name", "ssn")))
	Parsed with column specification:
	cols(
	  name = col_character(),
	  ssn = col_character()
	)
	# A tibble: 3 x 2
	  name       ssn         
	  <chr>      <chr>       
	1 John Smith 418-Y11-4111
	2 Mary Hartf 319-Z19-4341
	3 Evan Nolan 219-532-c301
	> # 4. Named arguments with start and end positions
	> read_fwf(fwf_sample, fwf_cols(name = c(1, 10), ssn = c(30, 42)))
	Parsed with column specification:
	cols(
	  name = col_character(),
	  ssn = col_character()
	)
	# A tibble: 3 x 2
	  name       ssn         
	  <chr>      <chr>       
	1 John Smith 418-Y11-4111
	2 Mary Hartf 319-Z19-4341
	3 Evan Nolan 219-532-c301