### PR TITLE
Tweak language for na parameter

### DIFF
--- a/R/tokenizer.R
+++ b/R/tokenizer.R
@@ -37,7 +37,7 @@ NULL
 #' @rdname Tokenizers
 #' @param comment A string used to identify comments. Any text after the
 #'   comment characters will be silently ignored.
-#' @param na Character vector of strings to use for missing values. Set this
+#' @param na Character vector of strings to interpret as missing values. Set this
 #'   option to `character()` to indicate no missing values.
 #' @param quoted_na Should missing values inside quotes be treated as missing
 #'   values (the default) or strings.


### PR DESCRIPTION
Current wording says "Character vector of strings to use for missing values."  To me, this sounds like these will be INSERTED in place of missing values, so I changed the text to "to interpret as missing values". 

For what it's worth, read.csv uses 'na.strings', which is documented as "a character vector of strings which are to be interpreted as NA values".

Also, would it be worthwhile to caution the user that "NA" strings (North America, Sodium, etc) will be turned into missing values?