### PR TITLE
convert path to the native locale before passing to boost::interprocess::file_mapping()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -51,6 +51,7 @@ you would pass `skip = 3`, now you only need to pass `skip = 2`.
   in most cases (#730, @yutannihilation).
 * `read_*()` no longer throws a "length of NULL cannot be changed" warning when
   trying to resize a skipped column (#750, #833).
+* `read_*()` now handles non-ASCII paths properly with R >=3.5.0 on Windows (#838, @yutannihilation).
 
 # readr 1.1.1
 

--- a/src/Source.cpp
+++ b/src/Source.cpp
@@ -18,8 +18,8 @@ SourcePtr Source::create(List spec) {
     return SourcePtr(
         new SourceString(as<CharacterVector>(spec[0]), skip, comment));
   } else if (subclass == "source_file") {
-    SEXP path(as<CharacterVector>(spec[0])[0]);
-    return SourcePtr(new SourceFile(Rf_translateChar(path), skip, comment));
+    CharacterVector path(spec[0]);
+    return SourcePtr(new SourceFile(Rf_translateChar(path[0]), skip, comment));
   }
 
   Rcpp::stop("Unknown source type");

--- a/src/Source.cpp
+++ b/src/Source.cpp
@@ -18,8 +18,8 @@ SourcePtr Source::create(List spec) {
     return SourcePtr(
         new SourceString(as<CharacterVector>(spec[0]), skip, comment));
   } else if (subclass == "source_file") {
-    std::string path(as<CharacterVector>(spec[0])[0]);
-    return SourcePtr(new SourceFile(path, skip, comment));
+    SEXP path(as<CharacterVector>(spec[0])[0]);
+    return SourcePtr(new SourceFile(Rf_translateChar(path), skip, comment));
   }
 
   Rcpp::stop("Unknown source type");


### PR DESCRIPTION
fixes #834, fixes #837 

As described on #834, the behavior of `normalizePath()` (more precisely, `path.expand()`, which is used inside `normalizePath()`) has been changed to return the character encoded in UTF-8. I guess this happens only with Windows on non-UTF-8 locales.

R 3.4.4 on Windows 10:

``` r
Encoding(normalizePath("~/鬼"))
#> [1] "unknown"
```

R 3.5.0 on Windows 10:

``` r
Encoding(normalizePath("~/鬼"))
#> [1] "UTF-8"
```

This usually doesn't become a problem; on R codes, most R functions take care of the encoding automatically. But, on C++ codes, the encoding attribute is lost when the `String` is converted to `std::string`. So, we need to convert it to the proper encoding before passing it to the functions that take `std::string`, in this case, `boost::interprocess::file_mapping()` here:

https://github.com/tidyverse/readr/blob/6f0bb65296afa55709fd60cdc5d59a4c89623e36/src/SourceFile.h#L19-L20

It seems `boost::interprocess::file_mapping()` takes the path string encoded in the **native locale** (`CE_NATIVE`). So, we need to ensure the string is encoded properly, instead of blindly pass the one passed from R session.

IIUC, Rcpp doesn't have a function to do this, so `Rf_translateChar()` is the choice in this case. (I'm not an Rcpp expert, so please point out if I'm wrong at this point....)