### PR TITLE
Use private mapping (instead of shared) for SourceFile.

### DIFF
--- a/src/SourceFile.h
+++ b/src/SourceFile.h
@@ -19,7 +19,7 @@ public:
       fm_ = boost::interprocess::file_mapping(
           path.c_str(), boost::interprocess::read_only);
       mr_ = boost::interprocess::mapped_region(
-          fm_, boost::interprocess::read_only);
+          fm_, boost::interprocess::read_private);
     } catch (boost::interprocess::interprocess_exception& e) {
       Rcpp::stop("Cannot read file %s: %s", path, e.what());
     }


### PR DESCRIPTION
i.e. boost::interprocess::read_private instead of
boost::interprocess::read_only

Filesystems are much likely to support MAP_PRIVATE rather than
MAP_SHARED (e.g. FUSE).