### PR TITLE
Use levels = NULL as default in parse_factor() (#862)

### DIFF
--- a/R/col_types.R
+++ b/R/col_types.R
@@ -241,6 +241,7 @@ col_concise <- function(x) {
     c = col_character(),
     D = col_date(),
     d = col_double(),
+    f = col_factor(),
     i = col_integer(),
     l = col_logical(),
     n = col_number(),

--- a/R/collectors.R
+++ b/R/collectors.R
@@ -230,7 +230,7 @@ parse_factor <- function(x, levels, ordered = FALSE, na = c("", "NA"),
 
 #' @rdname parse_factor
 #' @export
-col_factor <- function(levels, ordered = FALSE, include_na = FALSE) {
+col_factor <- function(levels = NULL, ordered = FALSE, include_na = FALSE) {
   collector("factor", levels = levels, ordered = ordered, include_na = include_na)
 }
 

--- a/R/collectors.R
+++ b/R/collectors.R
@@ -223,7 +223,7 @@ guess_parser <- function(x, locale = default_locale()) {
 #'
 #' # Using an argument of `NULL` will generate levels based on values of `x`
 #' x2 <- parse_factor(x, levels = NULL)
-parse_factor <- function(x, levels, ordered = FALSE, na = c("", "NA"),
+parse_factor <- function(x, levels = NULL, ordered = FALSE, na = c("", "NA"),
                          locale = default_locale(), include_na = TRUE, trim_ws = TRUE) {
   parse_vector(x, col_factor(levels, ordered, include_na), na = na, locale = locale, trim_ws = trim_ws)
 }

--- a/man/Tokenizers.Rd
+++ b/man/Tokenizers.Rd
@@ -34,7 +34,7 @@ tokenizer_ws(na = "NA", comment = "")
 
 \item{quote}{Single character used to quote strings.}
 
-\item{na}{Character vector of strings to use for missing values. Set this
+\item{na}{Character vector of strings to interpret as missing values. Set this
 option to \code{character()} to indicate no missing values.}
 
 \item{quoted_na}{Should missing values inside quotes be treated as missing

--- a/man/parse_atomic.Rd
+++ b/man/parse_atomic.Rd
@@ -34,7 +34,7 @@ col_character()
 \arguments{
 \item{x}{Character vector of values to parse.}
 
-\item{na}{Character vector of strings to use for missing values. Set this
+\item{na}{Character vector of strings to interpret as missing values. Set this
 option to \code{character()} to indicate no missing values.}
 
 \item{locale}{The locale controls defaults that vary from place to place.

--- a/man/parse_datetime.Rd
+++ b/man/parse_datetime.Rd
@@ -34,7 +34,7 @@ time formats specified in the \code{\link[=locale]{locale()}}.
 Unlike \code{\link[=strptime]{strptime()}}, the format specification must match
 the complete string.}
 
-\item{na}{Character vector of strings to use for missing values. Set this
+\item{na}{Character vector of strings to interpret as missing values. Set this
 option to \code{character()} to indicate no missing values.}
 
 \item{locale}{The locale controls defaults that vary from place to place.
@@ -49,7 +49,7 @@ each field before parsing it?}
 \value{
 A \code{\link[=POSIXct]{POSIXct()}} vector with \code{tzone} attribute set to
 \code{tz}. Elements that could not be parsed (or did not generate valid
-dates) will bes set to \code{NA}, and a warning message will inform
+dates) will be set to \code{NA}, and a warning message will inform
 you of the total number of failures.
 }
 \description{

--- a/man/parse_factor.Rd
+++ b/man/parse_factor.Rd
@@ -5,10 +5,10 @@
 \alias{col_factor}
 \title{Parse factors}
 \usage{
-parse_factor(x, levels, ordered = FALSE, na = c("", "NA"),
+parse_factor(x, levels = NULL, ordered = FALSE, na = c("", "NA"),
   locale = default_locale(), include_na = TRUE, trim_ws = TRUE)
 
-col_factor(levels, ordered = FALSE, include_na = FALSE)
+col_factor(levels = NULL, ordered = FALSE, include_na = FALSE)
 }
 \arguments{
 \item{x}{Character vector of values to parse.}

--- a/man/parse_factor.Rd
+++ b/man/parse_factor.Rd
@@ -19,7 +19,7 @@ of appearance in \code{x}.}
 
 \item{ordered}{Is it an ordered factor?}
 
-\item{na}{Character vector of strings to use for missing values. Set this
+\item{na}{Character vector of strings to interpret as missing values. Set this
 option to \code{character()} to indicate no missing values.}
 
 \item{locale}{The locale controls defaults that vary from place to place.

--- a/man/parse_guess.Rd
+++ b/man/parse_guess.Rd
@@ -16,7 +16,7 @@ guess_parser(x, locale = default_locale())
 \arguments{
 \item{x}{Character vector of values to parse.}
 
-\item{na}{Character vector of strings to use for missing values. Set this
+\item{na}{Character vector of strings to interpret as missing values. Set this
 option to \code{character()} to indicate no missing values.}
 
 \item{locale}{The locale controls defaults that vary from place to place.

--- a/man/parse_number.Rd
+++ b/man/parse_number.Rd
@@ -13,7 +13,7 @@ col_number()
 \arguments{
 \item{x}{Character vector of values to parse.}
 
-\item{na}{Character vector of strings to use for missing values. Set this
+\item{na}{Character vector of strings to interpret as missing values. Set this
 option to \code{character()} to indicate no missing values.}
 
 \item{locale}{The locale controls defaults that vary from place to place.

--- a/man/parse_vector.Rd
+++ b/man/parse_vector.Rd
@@ -12,7 +12,7 @@ parse_vector(x, collector, na = c("", "NA"), locale = default_locale(),
 
 \item{collector}{Column specification.}
 
-\item{na}{Character vector of strings to use for missing values. Set this
+\item{na}{Character vector of strings to interpret as missing values. Set this
 option to \code{character()} to indicate no missing values.}
 
 \item{locale}{The locale controls defaults that vary from place to place.

--- a/man/read_delim.Rd
+++ b/man/read_delim.Rd
@@ -95,7 +95,7 @@ The default locale is US-centric (like R), but you can use
 the default time zone, encoding, decimal mark, big mark, and day/month
 names.}
 
-\item{na}{Character vector of strings to use for missing values. Set this
+\item{na}{Character vector of strings to interpret as missing values. Set this
 option to \code{character()} to indicate no missing values.}
 
 \item{quoted_na}{Should missing values inside quotes be treated as missing
@@ -142,7 +142,7 @@ read_csv("https://github.com/tidyverse/readr/raw/master/inst/extdata/mtcars.csv"
 read_csv("x,y\\n1,2\\n3,4")
 
 # Column types --------------------------------------------------------------
-# By default, readr guesses the columns types, looking at the first 100 rows.
+# By default, readr guesses the columns types, looking at the first 1000 rows.
 # You can override with a compact specification:
 read_csv("x,y\\n1,2\\n3,4", col_types = "dc")
 

--- a/man/read_delim_chunked.Rd
+++ b/man/read_delim_chunked.Rd
@@ -99,7 +99,7 @@ The default locale is US-centric (like R), but you can use
 the default time zone, encoding, decimal mark, big mark, and day/month
 names.}
 
-\item{na}{Character vector of strings to use for missing values. Set this
+\item{na}{Character vector of strings to interpret as missing values. Set this
 option to \code{character()} to indicate no missing values.}
 
 \item{quoted_na}{Should missing values inside quotes be treated as missing

--- a/man/read_fwf.Rd
+++ b/man/read_fwf.Rd
@@ -64,7 +64,7 @@ The default locale is US-centric (like R), but you can use
 the default time zone, encoding, decimal mark, big mark, and day/month
 names.}
 
-\item{na}{Character vector of strings to use for missing values. Set this
+\item{na}{Character vector of strings to interpret as missing values. Set this
 option to \code{character()} to indicate no missing values.}
 
 \item{comment}{A string used to identify comments. Any text after the
@@ -120,9 +120,9 @@ read_fwf(fwf_sample, fwf_empty(fwf_sample, col_names = c("first", "last", "state
 # 2. A vector of field widths
 read_fwf(fwf_sample, fwf_widths(c(20, 10, 12), c("name", "state", "ssn")))
 # 3. Paired vectors of start and end positions
-read_fwf(fwf_sample, fwf_positions(c(1, 30), c(10, 42), c("name", "ssn")))
+read_fwf(fwf_sample, fwf_positions(c(1, 30), c(20, 42), c("name", "ssn")))
 # 4. Named arguments with start and end positions
-read_fwf(fwf_sample, fwf_cols(name = c(1, 10), ssn = c(30, 42)))
+read_fwf(fwf_sample, fwf_cols(name = c(1, 20), ssn = c(30, 42)))
 # 5. Named arguments with column widths
 read_fwf(fwf_sample, fwf_cols(name = 20, state = 10, ssn = 12))
 }

--- a/man/read_lines.Rd
+++ b/man/read_lines.Rd
@@ -40,7 +40,7 @@ The default locale is US-centric (like R), but you can use
 the default time zone, encoding, decimal mark, big mark, and day/month
 names.}
 
-\item{na}{Character vector of strings to use for missing values. Set this
+\item{na}{Character vector of strings to interpret as missing values. Set this
 option to \code{character()} to indicate no missing values.}
 
 \item{progress}{Display a progress bar? By default it will only display

--- a/man/read_lines_chunked.Rd
+++ b/man/read_lines_chunked.Rd
@@ -35,7 +35,7 @@ The default locale is US-centric (like R), but you can use
 the default time zone, encoding, decimal mark, big mark, and day/month
 names.}
 
-\item{na}{Character vector of strings to use for missing values. Set this
+\item{na}{Character vector of strings to interpret as missing values. Set this
 option to \code{character()} to indicate no missing values.}
 
 \item{progress}{Display a progress bar? By default it will only display

--- a/man/read_table.Rd
+++ b/man/read_table.Rd
@@ -67,7 +67,7 @@ The default locale is US-centric (like R), but you can use
 the default time zone, encoding, decimal mark, big mark, and day/month
 names.}
 
-\item{na}{Character vector of strings to use for missing values. Set this
+\item{na}{Character vector of strings to interpret as missing values. Set this
 option to \code{character()} to indicate no missing values.}
 
 \item{skip}{Number of lines to skip before reading data.}

--- a/man/readr-package.Rd
+++ b/man/readr-package.Rd
@@ -21,7 +21,7 @@ Useful links:
 
 }
 \author{
-\strong{Maintainer}: Jim Hester \email{james.hester@rstudio.com}
+\strong{Maintainer}: Jim Hester \email{jim.hester@rstudio.com}
 
 Authors:
 \itemize{

--- a/man/spec_delim.Rd
+++ b/man/spec_delim.Rd
@@ -100,7 +100,7 @@ The default locale is US-centric (like R), but you can use
 the default time zone, encoding, decimal mark, big mark, and day/month
 names.}
 
-\item{na}{Character vector of strings to use for missing values. Set this
+\item{na}{Character vector of strings to interpret as missing values. Set this
 option to \code{character()} to indicate no missing values.}
 
 \item{quoted_na}{Should missing values inside quotes be treated as missing

--- a/man/type_convert.Rd
+++ b/man/type_convert.Rd
@@ -22,7 +22,7 @@ subset of the columns, use \code{\link[=cols_only]{cols_only()}}.
 Unlike other functions \code{type_convert()} does not allow character
 specifications of \code{col_types}.}
 
-\item{na}{Character vector of strings to use for missing values. Set this
+\item{na}{Character vector of strings to interpret as missing values. Set this
 option to \code{character()} to indicate no missing values.}
 
 \item{trim_ws}{Should leading and trailing whitespace be trimmed from

--- a/tests/testthat/test-collectors.R
+++ b/tests/testthat/test-collectors.R
@@ -40,7 +40,7 @@ test_that("? guesses column type", {
   expect_equal(out1$x, c(1L, 3L))
 })
 
-test_that("f parses factor", {
+test_that("f parses factor (#810)", {
   out <- read_csv("x,y\na,2\nb,4", col_types = "fi", progress = FALSE)
-  expect_equal(out$x, factor(c("a", "b")))
+  expect_s3_class(out$x, "factor")
 })

--- a/tests/testthat/test-collectors.R
+++ b/tests/testthat/test-collectors.R
@@ -39,3 +39,8 @@ test_that("? guesses column type", {
   out1 <- read_csv("x,y\n1,2\n3,4", col_types = "?i", progress = FALSE)
   expect_equal(out1$x, c(1L, 3L))
 })
+
+test_that("f parses factor", {
+  out <- read_csv("x,y\na,2\nb,4", col_types = "fi", progress = FALSE)
+  expect_equal(out$x, factor(c("a", "b")))
+})

--- a/tests/testthat/test-parsing-factors.R
+++ b/tests/testthat/test-parsing-factors.R
@@ -29,6 +29,11 @@ test_that("levels = NULL (497)", {
   expect_equal(x, factor(c("a", "b", "c", "b")))
 })
 
+test_that("levels = NULL orders by data", {
+  x <- parse_factor(c("b", "a", "c", "b"), levels = NULL)
+  expect_equal(levels(x), c("b", "a", "c"))
+})
+
 test_that("levels = NULL default (#862)", {
   x <- c("a", "b", "c", "b")
   expect_equal(parse_factor(x), parse_factor(x, levels = NULL))

--- a/tests/testthat/test-parsing-factors.R
+++ b/tests/testthat/test-parsing-factors.R
@@ -29,6 +29,11 @@ test_that("levels = NULL (497)", {
   expect_equal(x, factor(c("a", "b", "c", "b")))
 })
 
+test_that("levels = NULL default (#862)", {
+  x <- c("a", "b", "c", "b")
+  expect_equal(parse_factor(x), parse_factor(x, levels = NULL))
+})
+
 test_that("NAs included in levels if desired", {
   x <- parse_factor(c("NA", "b", "a"), levels = c("a", "b", NA))
   expect_equal(x, factor(c(NA, "b", "a"), levels = c("a", "b", NA), exclude = NULL))


### PR DESCRIPTION
Updated `parse_factor()` and `col_factor()` to use `levels = NULL` as default. Fixes #862.

This also fixes #810 by adding `"f"` as a shortcode for `col_factor()`, enabled by the default values.