### PR TITLE
add labels parameter into parse_factor and col_factor

### DIFF
--- a/R/collectors.R
+++ b/R/collectors.R
@@ -202,6 +202,7 @@ guess_parser <- function(x, locale = default_locale()) {
 #' @param levels Character vector providing set of allowed levels. if `NULL`,
 #'   will generate levels based on the unique values of `x`, ordered by order
 #'   of appearance in `x`.
+#' @param labels Character vector of labels for the levels.
 #' @param ordered Is it an ordered factor?
 #' @param include_na If `NA` are present, include as an explicit factor to level?
 #' @inheritParams parse_atomic
@@ -223,15 +224,15 @@ guess_parser <- function(x, locale = default_locale()) {
 #'
 #' # Using an argument of `NULL` will generate levels based on values of `x`
 #' x2 <- parse_factor(x, levels = NULL)
-parse_factor <- function(x, levels, ordered = FALSE, na = c("", "NA"),
+parse_factor <- function(x, levels, labels = levels, ordered = FALSE, na = c("", "NA"),
                          locale = default_locale(), include_na = TRUE, trim_ws = TRUE) {
-  parse_vector(x, col_factor(levels, ordered, include_na), na = na, locale = locale, trim_ws = trim_ws)
+  parse_vector(x, col_factor(levels, labels, ordered, include_na), na = na, locale = locale, trim_ws = trim_ws)
 }
 
 #' @rdname parse_factor
 #' @export
-col_factor <- function(levels, ordered = FALSE, include_na = FALSE) {
-  collector("factor", levels = levels, ordered = ordered, include_na = include_na)
+col_factor <- function(levels, labels = levels, ordered = FALSE, include_na = FALSE) {
+  collector("factor", levels = levels, labels = labels, ordered = ordered, include_na = include_na)
 }
 
 # More complex ------------------------------------------------------------

--- a/src/Collector.cpp
+++ b/src/Collector.cpp
@@ -39,10 +39,12 @@ CollectorPtr Collector::create(List spec, LocaleInfo* pLocale) {
   if (subclass == "collector_factor") {
     Nullable<CharacterVector> levels =
         as<Nullable<CharacterVector> >(spec["levels"]);
+    Nullable<CharacterVector> labels =
+        as<Nullable<CharacterVector> >(spec["labels"]);
     bool ordered = as<bool>(spec["ordered"]);
     bool includeNa = as<bool>(spec["include_na"]);
     return CollectorPtr(
-        new CollectorFactor(&pLocale->encoder_, levels, ordered, includeNa));
+        new CollectorFactor(&pLocale->encoder_, levels, labels, ordered, includeNa));
   }
 
   Rcpp::stop("Unsupported column type");

--- a/tests/testthat/test-col-spec.R
+++ b/tests/testthat/test-col-spec.R
@@ -222,6 +222,7 @@ test_that("long expressions are wrapped (597)", {
   expect_equal(format(cols(a = col_factor(levels = c("apple", "pear", "banana", "peach", "apricot", "orange", "plum"), ordered = TRUE))),
 'cols(
   a = col_factor(levels = c("apple", "pear", "banana", "peach", "apricot", "orange", "plum"
+    ), labels = c("apple", "pear", "banana", "peach", "apricot", "orange", "plum"
     ), ordered = TRUE, include_na = FALSE)
 )
 ')

--- a/tests/testthat/test-parsing-factors.R
+++ b/tests/testthat/test-parsing-factors.R
@@ -74,3 +74,14 @@ test_that("factors parse like factor if trim_ws = FALSE (735)", {
       as.integer(parse_factor(c("a", "a "), levels = c("a ", "a"), trim_ws = FALSE)),
       as.integer(factor(c("a", "a "), levels = c("a ", "a"))))
 })
+
+test_that("factors set labels if it is properly set (#880)", {
+  x <- parse_factor(c("a", "b"), levels = c("a", "b"), labels = c("x", "y"))
+  expect_equal(x, factor(c("a", "b"), levels = c("a", "b"), labels = c("x", "y")))
+
+  x <- parse_factor(c("a", "b"), levels = c("a", "b", "c"), labels = c("x", "y"))
+  expect_equal(x, factor(c("a", "b"), levels = c("a", "b", "c"), labels = c("x", "y", NA_character_)))
+
+  x <- parse_factor(c("a", "b"), levels = c("a", "b"), labels = c("x", "y", "z"))
+  expect_equal(x, factor(c("a", "b"), levels = c("a", "b"), labels = c("x", "y")))
+})


### PR DESCRIPTION
solve #880 

To consider: this implementation does not respect the behavior of `base::factor`.

```r
# OK
factor(c("a", "b", "c"), levels = c("a", "b", "c"), labels = "x")
#> [1] x1 x2 x3
#> Levels: x1 x2 x3

# OK (with warning message)
parse_factor(c("a", "b", "c"), levels = c("a", "b", "c"), labels = "x")
#> [1] x    <NA> <NA>
#> Levels: x <NA> <NA>
```

```r
# NG (raises an error)
# factor(c("a", "b", "c"), levels = c("a", "b", "c"), labels = c("x", "y"))

# OK
parse_factor(c("a", "b", "c"), levels = c("a", "b", "c"), labels = c("x", "y"))
#> [1] x    y    <NA>
#> Levels: x y <NA>
```