### PR TITLE
Add write_csv2 and format_csv2

### DIFF
--- a/R/write.R
+++ b/R/write.R
@@ -14,7 +14,8 @@
 #' \href{https://en.wikipedia.org/wiki/Byte_order_mark}{UTF-8 Byte order mark}
 #' which indicates to Excel the csv is UTF-8 encoded.
 #'
-#' `write_excel_csv2()` was created to allow users with different locale settings save csv files with their default settings
+#' `write_csv()` and `write_excel_csv2()` enable users with
+#' different locale settings save csv files with their default settings
 #' `;` as column separator and `,` as decimal separator.
 #'
 #' Values are only quoted if needed: if they contain a comma, quote or newline.
@@ -73,7 +74,16 @@ write_delim <- function(x, path, delim = " ", na = "NA", append = FALSE,
 #' @rdname write_delim
 #' @export
 write_csv <- function(x, path, na = "NA", append = FALSE, col_names = !append) {
-  write_delim(x, path, delim = ",", na = na,append = append, col_names = col_names)
+  write_delim(x, path, delim = ",", na = na, append = append, col_names = col_names)
+}
+
+#' @rdname write_delim
+#' @export
+write_csv2 <- function(x, path, na = "NA", append = FALSE, col_names = !append) {
+  numeric_cols <- vapply(x, is.numeric, logical(1))
+  x[numeric_cols] <- lapply(x[numeric_cols], format, decimal.mark = ",")
+  x[] <- lapply(x, output_column)
+  write_delim(x, path, delim = ";", na = na, append = append, col_names = col_names)
 }
 
 #' @rdname write_delim
@@ -93,7 +103,7 @@ write_excel_csv <- function(x, path, na = "NA", append = FALSE, col_names = !app
 
 #' @rdname write_delim
 #' @export
-write_excel_csv2 <- function(x, path, na = "NA", append = FALSE, col_names = !append, delim = ";") {
+write_excel_csv2 <- function(x, path, na = "NA", append = FALSE, col_names = !append) {
   stopifnot(is.data.frame(x))
 
   numeric_cols <- vapply(x, is.numeric, logical(1))
@@ -103,7 +113,7 @@ write_excel_csv2 <- function(x, path, na = "NA", append = FALSE, col_names = !ap
   x[datetime_cols] <- lapply(x[datetime_cols], format, "%Y/%m/%d %H:%M:%S")
 
   x[] <- lapply(x, output_column)
-  write_excel_csv(x, path, na, append, col_names, delim)
+  write_excel_csv(x, path, na, append, col_names, delim = ";")
 }
 
 #' @rdname write_delim
@@ -133,6 +143,14 @@ format_delim <- function(x, delim, na = "NA", append = FALSE, col_names = !appen
 #' @rdname format_delim
 format_csv <- function(x, na = "NA", append = FALSE, col_names = !append) {
   format_delim(x, delim = ",", na = na, append = append, col_names = col_names)
+}
+
+#' @export
+#' @rdname format_delim
+format_csv2 <- function(x, na = "NA", append = FALSE, col_names = !append){
+  numeric_cols <- vapply(x, is.numeric, logical(1))
+  x[numeric_cols] <- lapply(x[numeric_cols], format, decimal.mark = ",")
+  format_delim(x, delim = ";", na = na, append = append, col_names = col_names)
 }
 
 #' @export


### PR DESCRIPTION
Semicolon separated csv files are pretty common in europe, so I added `write_csv2()` and `format_csv2()` for consistency. 