### PR TITLE
Documentation update to clarify column abbreviations and link parsing help pages

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,7 @@ License: GPL (>= 2) | file LICENSE
 BugReports: https://github.com/tidyverse/readr/issues
 URL: http://readr.tidyverse.org, https://github.com/tidyverse/readr
 VignetteBuilder: knitr
-RoxygenNote: 6.0.1
+RoxygenNote: 6.1.0
 Roxygen: list(markdown = TRUE)
 Remotes:
     tidyverse/hms

--- a/R/col_types.R
+++ b/R/col_types.R
@@ -4,10 +4,12 @@
 #' as the default. `cols_only()` includes only the columns you explicitly
 #' specify, skipping the rest.
 #'
-#' @param ... Either column objects created by `col_*()`, or their
-#'   abbreviated character names. If you're only overriding a few columns,
-#'   it's best to refer to columns by name. If not named, the column types
-#'   must match the column names exactly.
+#' @family parsers
+#' @param ... Either column objects created by `col_*()`, or their abbreviated
+#'   character names (as described in the \code{col_types} argument of
+#'   \code{\link{read_delim}}). If you're only overriding a few columns, it's
+#'   best to refer to columns by name. If not named, the column types must match
+#'   the column names exactly.
 #' @param .default Any named columns not explicitly overridden in `...`
 #'   will be read with this column type.
 #' @export
@@ -15,7 +17,7 @@
 #' cols(a = col_integer())
 #' cols_only(a = col_integer())
 #'
-#' # You can also use the standard abreviations
+#' # You can also use the standard abbreviations
 #' cols(a = "i")
 #' cols(a = "i", b = "d", c = "_")
 #'
@@ -219,6 +221,7 @@ str.col_spec <- function(object, ..., indent.str = "") {
 #' `spec()` extracts the full column specification from a tibble
 #' created by readr.
 #'
+#' @family parsers
 #' @param x The data frame object to extract from
 #' @return A col_spec object.
 #' @export

--- a/R/collectors.R
+++ b/R/collectors.R
@@ -19,6 +19,7 @@ collector_find <- function(name) {
 
 #' Parse a character vector.
 #'
+#' @family parsers
 #' @param x Character vector of elements to parse.
 #' @param collector Column specification.
 #' @inheritParams read_delim

--- a/man/col_skip.Rd
+++ b/man/col_skip.Rd
@@ -11,7 +11,10 @@ Use this function to ignore a column when reading in a file.
 To skip all columns not otherwise specified, use \code{\link{cols_only}()}.
 }
 \seealso{
-Other parsers: \code{\link{parse_datetime}},
+Other parsers: \code{\link{cols_condense}},
+  \code{\link{cols}}, \code{\link{parse_datetime}},
   \code{\link{parse_factor}}, \code{\link{parse_guess}},
-  \code{\link{parse_logical}}, \code{\link{parse_number}}
+  \code{\link{parse_logical}}, \code{\link{parse_number}},
+  \code{\link{parse_vector}}
 }
+\concept{parsers}

--- a/man/cols.Rd
+++ b/man/cols.Rd
@@ -10,10 +10,11 @@ cols(..., .default = col_guess())
 cols_only(...)
 }
 \arguments{
-\item{...}{Either column objects created by \code{col_*()}, or their
-abbreviated character names. If you're only overriding a few columns,
-it's best to refer to columns by name. If not named, the column types
-must match the column names exactly.}
+\item{...}{Either column objects created by \code{col_*()}, or their abbreviated
+character names (as described in the \code{col_types} argument of
+\code{\link{read_delim}}). If you're only overriding a few columns, it's
+best to refer to columns by name. If not named, the column types must match
+the column names exactly.}
 
 \item{.default}{Any named columns not explicitly overridden in \code{...}
 will be read with this column type.}
@@ -27,7 +28,7 @@ specify, skipping the rest.
 cols(a = col_integer())
 cols_only(a = col_integer())
 
-# You can also use the standard abreviations
+# You can also use the standard abbreviations
 cols(a = "i")
 cols(a = "i", b = "d", c = "_")
 
@@ -45,3 +46,11 @@ t3 <- t1
 t3$cols <- c(t1$cols, t2$cols)
 t3
 }
+\seealso{
+Other parsers: \code{\link{col_skip}},
+  \code{\link{cols_condense}},
+  \code{\link{parse_datetime}}, \code{\link{parse_factor}},
+  \code{\link{parse_guess}}, \code{\link{parse_logical}},
+  \code{\link{parse_number}}, \code{\link{parse_vector}}
+}
+\concept{parsers}

--- a/man/parse_atomic.Rd
+++ b/man/parse_atomic.Rd
@@ -34,7 +34,7 @@ col_character()
 \arguments{
 \item{x}{Character vector of values to parse.}
 
-\item{na}{Character vector of strings to use for missing values. Set this
+\item{na}{Character vector of strings to interpret as missing values. Set this
 option to \code{character()} to indicate no missing values.}
 
 \item{locale}{The locale controls defaults that vary from place to place.
@@ -68,6 +68,9 @@ parse_double(x, na = "-")
 }
 \seealso{
 Other parsers: \code{\link{col_skip}},
+  \code{\link{cols_condense}}, \code{\link{cols}},
   \code{\link{parse_datetime}}, \code{\link{parse_factor}},
-  \code{\link{parse_guess}}, \code{\link{parse_number}}
+  \code{\link{parse_guess}}, \code{\link{parse_number}},
+  \code{\link{parse_vector}}
 }
+\concept{parsers}

--- a/man/parse_datetime.Rd
+++ b/man/parse_datetime.Rd
@@ -12,11 +12,11 @@
 parse_datetime(x, format = "", na = c("", "NA"),
   locale = default_locale(), trim_ws = TRUE)
 
-parse_date(x, format = "", na = c("", "NA"), locale = default_locale(),
-  trim_ws = TRUE)
+parse_date(x, format = "", na = c("", "NA"),
+  locale = default_locale(), trim_ws = TRUE)
 
-parse_time(x, format = "", na = c("", "NA"), locale = default_locale(),
-  trim_ws = TRUE)
+parse_time(x, format = "", na = c("", "NA"),
+  locale = default_locale(), trim_ws = TRUE)
 
 col_datetime(format = "")
 
@@ -34,7 +34,7 @@ time formats specified in the \code{\link[=locale]{locale()}}.
 Unlike \code{\link[=strptime]{strptime()}}, the format specification must match
 the complete string.}
 
-\item{na}{Character vector of strings to use for missing values. Set this
+\item{na}{Character vector of strings to interpret as missing values. Set this
 option to \code{character()} to indicate no missing values.}
 
 \item{locale}{The locale controls defaults that vary from place to place.
@@ -49,7 +49,7 @@ each field before parsing it?}
 \value{
 A \code{\link[=POSIXct]{POSIXct()}} vector with \code{tzone} attribute set to
 \code{tz}. Elements that could not be parsed (or did not generate valid
-dates) will bes set to \code{NA}, and a warning message will inform
+dates) will be set to \code{NA}, and a warning message will inform
 you of the total number of failures.
 }
 \description{
@@ -174,6 +174,9 @@ parse_datetime("1979-10-14T1010", locale = locale(tz = ""))
 }
 \seealso{
 Other parsers: \code{\link{col_skip}},
+  \code{\link{cols_condense}}, \code{\link{cols}},
   \code{\link{parse_factor}}, \code{\link{parse_guess}},
-  \code{\link{parse_logical}}, \code{\link{parse_number}}
+  \code{\link{parse_logical}}, \code{\link{parse_number}},
+  \code{\link{parse_vector}}
 }
+\concept{parsers}

--- a/man/parse_factor.Rd
+++ b/man/parse_factor.Rd
@@ -19,7 +19,7 @@ of appearance in \code{x}.}
 
 \item{ordered}{Is it an ordered factor?}
 
-\item{na}{Character vector of strings to use for missing values. Set this
+\item{na}{Character vector of strings to interpret as missing values. Set this
 option to \code{character()} to indicate no missing values.}
 
 \item{locale}{The locale controls defaults that vary from place to place.
@@ -54,6 +54,9 @@ x2 <- parse_factor(x, levels = NULL)
 }
 \seealso{
 Other parsers: \code{\link{col_skip}},
+  \code{\link{cols_condense}}, \code{\link{cols}},
   \code{\link{parse_datetime}}, \code{\link{parse_guess}},
-  \code{\link{parse_logical}}, \code{\link{parse_number}}
+  \code{\link{parse_logical}}, \code{\link{parse_number}},
+  \code{\link{parse_vector}}
 }
+\concept{parsers}

--- a/man/parse_guess.Rd
+++ b/man/parse_guess.Rd
@@ -16,7 +16,7 @@ guess_parser(x, locale = default_locale())
 \arguments{
 \item{x}{Character vector of values to parse.}
 
-\item{na}{Character vector of strings to use for missing values. Set this
+\item{na}{Character vector of strings to interpret as missing values. Set this
 option to \code{character()} to indicate no missing values.}
 
 \item{locale}{The locale controls defaults that vary from place to place.
@@ -53,6 +53,9 @@ parse_guess(c("2010-10-10"))
 }
 \seealso{
 Other parsers: \code{\link{col_skip}},
+  \code{\link{cols_condense}}, \code{\link{cols}},
   \code{\link{parse_datetime}}, \code{\link{parse_factor}},
-  \code{\link{parse_logical}}, \code{\link{parse_number}}
+  \code{\link{parse_logical}}, \code{\link{parse_number}},
+  \code{\link{parse_vector}}
 }
+\concept{parsers}

--- a/man/parse_number.Rd
+++ b/man/parse_number.Rd
@@ -13,7 +13,7 @@ col_number()
 \arguments{
 \item{x}{Character vector of values to parse.}
 
-\item{na}{Character vector of strings to use for missing values. Set this
+\item{na}{Character vector of strings to interpret as missing values. Set this
 option to \code{character()} to indicate no missing values.}
 
 \item{locale}{The locale controls defaults that vary from place to place.
@@ -35,6 +35,9 @@ parse_number("1,234,567.78")
 }
 \seealso{
 Other parsers: \code{\link{col_skip}},
+  \code{\link{cols_condense}}, \code{\link{cols}},
   \code{\link{parse_datetime}}, \code{\link{parse_factor}},
-  \code{\link{parse_guess}}, \code{\link{parse_logical}}
+  \code{\link{parse_guess}}, \code{\link{parse_logical}},
+  \code{\link{parse_vector}}
 }
+\concept{parsers}

--- a/man/parse_vector.Rd
+++ b/man/parse_vector.Rd
@@ -12,7 +12,7 @@ parse_vector(x, collector, na = c("", "NA"), locale = default_locale(),
 
 \item{collector}{Column specification.}
 
-\item{na}{Character vector of strings to use for missing values. Set this
+\item{na}{Character vector of strings to interpret as missing values. Set this
 option to \code{character()} to indicate no missing values.}
 
 \item{locale}{The locale controls defaults that vary from place to place.
@@ -32,4 +32,12 @@ x <- c("1", "2", "3", "NA")
 parse_vector(x, col_integer())
 parse_vector(x, col_double())
 }
+\seealso{
+Other parsers: \code{\link{col_skip}},
+  \code{\link{cols_condense}}, \code{\link{cols}},
+  \code{\link{parse_datetime}}, \code{\link{parse_factor}},
+  \code{\link{parse_guess}}, \code{\link{parse_logical}},
+  \code{\link{parse_number}}
+}
+\concept{parsers}
 \keyword{internal}

--- a/man/spec.Rd
+++ b/man/spec.Rd
@@ -30,3 +30,10 @@ s
 
 cols_condense(s)
 }
+\seealso{
+Other parsers: \code{\link{col_skip}}, \code{\link{cols}},
+  \code{\link{parse_datetime}}, \code{\link{parse_factor}},
+  \code{\link{parse_guess}}, \code{\link{parse_logical}},
+  \code{\link{parse_number}}, \code{\link{parse_vector}}
+}
+\concept{parsers}


### PR DESCRIPTION
Fix #888

Following this, a general documentation update should be performed to bring all the documentation up to roxygen2 version 6.1.0 formatting.