### PR TITLE
Read connections to a temporary file rather than to a raw vector

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -53,6 +53,7 @@ implementation of the `melt_*()` functions!
 
 ## New features
 
+* Functions now read connections to a temporary file rather than to an in-memory object (#610, #76).
 * `melt_*()` functions added for reading ragged data (#760, @nacnudus).
 * `AccumulateCallback` R6 class added to provide an example of accumulating values in a single result (#689, @blakeboswell).
 * `read_fwf()` can now accept overlapping field specifications (#692, @gergness)

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -9,8 +9,8 @@ whitespaceColumns <- function(sourceSpec, n = 100L, comment = "") {
     .Call(`_readr_whitespaceColumns`, sourceSpec, n, comment)
 }
 
-read_connection_ <- function(con, chunk_size = 64 * 1024L) {
-    .Call(`_readr_read_connection_`, con, chunk_size)
+read_connection_ <- function(con, filename, chunk_size = 64 * 1024L) {
+    .Call(`_readr_read_connection_`, con, filename, chunk_size)
 }
 
 utctime <- function(year, month, day, hour, min, sec, psec) {

--- a/R/melt_delim.R
+++ b/R/melt_delim.R
@@ -139,7 +139,7 @@ melt_delimited <- function(file, tokenizer, locale = default_locale(),
   # If connection needed, read once.
   file <- standardise_path(file)
   if (is.connection(file)) {
-    data <- read_connection(file)
+    data <- datasource_connection(file, skip, comment)
   } else {
     if (empty_file(file)) {
        return(tibble::data_frame(row = double(), col = double(),

--- a/R/read_delim.R
+++ b/R/read_delim.R
@@ -176,7 +176,7 @@ read_delimited <- function(file, tokenizer, col_names = TRUE, col_types = NULL,
   # If connection needed, read once.
   file <- standardise_path(file)
   if (is.connection(file)) {
-    data <- read_connection(file)
+    data <- datasource_connection(file, skip, comment)
   } else {
     if (empty_file(file)) {
        return(tibble::data_frame())

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -32,14 +32,15 @@ BEGIN_RCPP
 END_RCPP
 }
 // read_connection_
-RawVector read_connection_(RObject con, int chunk_size);
-RcppExport SEXP _readr_read_connection_(SEXP conSEXP, SEXP chunk_sizeSEXP) {
+CharacterVector read_connection_(RObject con, std::string filename, int chunk_size);
+RcppExport SEXP _readr_read_connection_(SEXP conSEXP, SEXP filenameSEXP, SEXP chunk_sizeSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< RObject >::type con(conSEXP);
+    Rcpp::traits::input_parameter< std::string >::type filename(filenameSEXP);
     Rcpp::traits::input_parameter< int >::type chunk_size(chunk_sizeSEXP);
-    rcpp_result_gen = Rcpp::wrap(read_connection_(con, chunk_size));
+    rcpp_result_gen = Rcpp::wrap(read_connection_(con, filename, chunk_size));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -369,7 +370,7 @@ END_RCPP
 static const R_CallMethodDef CallEntries[] = {
     {"_readr_collectorGuess", (DL_FUNC) &_readr_collectorGuess, 3},
     {"_readr_whitespaceColumns", (DL_FUNC) &_readr_whitespaceColumns, 3},
-    {"_readr_read_connection_", (DL_FUNC) &_readr_read_connection_, 2},
+    {"_readr_read_connection_", (DL_FUNC) &_readr_read_connection_, 3},
     {"_readr_utctime", (DL_FUNC) &_readr_utctime, 7},
     {"_readr_dim_tokens_", (DL_FUNC) &_readr_dim_tokens_, 2},
     {"_readr_count_fields_", (DL_FUNC) &_readr_count_fields_, 3},


### PR DESCRIPTION
Because we previously read connections into an in-memory vector we would
frequently run into out of memory issues when reading from a
connection.

We automatically cleanup the temporary file using a finalizer when the datasource object is removed.