### PR TITLE
Updated documentation of col_types to include factors

### DIFF
--- a/R/read_delim.R
+++ b/R/read_delim.R
@@ -39,7 +39,7 @@ NULL
 #'   Alternatively, you can use a compact string representation where each
 #'   character represents one column:
 #'   c = character, i = integer, n = number, d = double,
-#'   l = logical, D = date, T = date time, t = time, ? = guess, or
+#'   l = logical, f = factor, D = date, T = date time, t = time, ? = guess, or
 #'   `_`/`-` to skip the column.
 #' @param locale The locale controls defaults that vary from place to place.
 #'   The default locale is US-centric (like R), but you can use

--- a/man/read_delim.Rd
+++ b/man/read_delim.Rd
@@ -90,7 +90,7 @@ subset of the columns, use \code{\link[=cols_only]{cols_only()}}.
 Alternatively, you can use a compact string representation where each
 character represents one column:
 c = character, i = integer, n = number, d = double,
-l = logical, D = date, T = date time, t = time, ? = guess, or
+l = logical, f = factor, D = date, T = date time, t = time, ? = guess, or
 \code{_}/\code{-} to skip the column.}
 
 \item{locale}{The locale controls defaults that vary from place to place.

--- a/man/read_delim_chunked.Rd
+++ b/man/read_delim_chunked.Rd
@@ -94,7 +94,7 @@ subset of the columns, use \code{\link[=cols_only]{cols_only()}}.
 Alternatively, you can use a compact string representation where each
 character represents one column:
 c = character, i = integer, n = number, d = double,
-l = logical, D = date, T = date time, t = time, ? = guess, or
+l = logical, f = factor, D = date, T = date time, t = time, ? = guess, or
 \code{_}/\code{-} to skip the column.}
 
 \item{locale}{The locale controls defaults that vary from place to place.

--- a/man/read_fwf.Rd
+++ b/man/read_fwf.Rd
@@ -56,7 +56,7 @@ subset of the columns, use \code{\link[=cols_only]{cols_only()}}.
 Alternatively, you can use a compact string representation where each
 character represents one column:
 c = character, i = integer, n = number, d = double,
-l = logical, D = date, T = date time, t = time, ? = guess, or
+l = logical, f = factor, D = date, T = date time, t = time, ? = guess, or
 \code{_}/\code{-} to skip the column.}
 
 \item{locale}{The locale controls defaults that vary from place to place.

--- a/man/read_log.Rd
+++ b/man/read_log.Rd
@@ -52,7 +52,7 @@ subset of the columns, use \code{\link[=cols_only]{cols_only()}}.
 Alternatively, you can use a compact string representation where each
 character represents one column:
 c = character, i = integer, n = number, d = double,
-l = logical, D = date, T = date time, t = time, ? = guess, or
+l = logical, f = factor, D = date, T = date time, t = time, ? = guess, or
 \code{_}/\code{-} to skip the column.}
 
 \item{skip}{Number of lines to skip before reading data.}

--- a/man/read_table.Rd
+++ b/man/read_table.Rd
@@ -60,7 +60,7 @@ subset of the columns, use \code{\link[=cols_only]{cols_only()}}.
 Alternatively, you can use a compact string representation where each
 character represents one column:
 c = character, i = integer, n = number, d = double,
-l = logical, D = date, T = date time, t = time, ? = guess, or
+l = logical, f = factor, D = date, T = date time, t = time, ? = guess, or
 \code{_}/\code{-} to skip the column.}
 
 \item{locale}{The locale controls defaults that vary from place to place.

--- a/man/spec_delim.Rd
+++ b/man/spec_delim.Rd
@@ -102,7 +102,7 @@ subset of the columns, use \code{\link[=cols_only]{cols_only()}}.
 Alternatively, you can use a compact string representation where each
 character represents one column:
 c = character, i = integer, n = number, d = double,
-l = logical, D = date, T = date time, t = time, ? = guess, or
+l = logical, f = factor, D = date, T = date time, t = time, ? = guess, or
 \code{_}/\code{-} to skip the column.}
 
 \item{locale}{The locale controls defaults that vary from place to place.


### PR DESCRIPTION
Noted that `factor` was not part of the documentation to the `col_types` argument of `read_delim`, despite the fact that setting `col_types = "f"` yields a factor column. Hence suggesting an update of the documentation.