### PR TITLE
Adds much more robust empty line and comment skipping

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,12 +1,26 @@
 # readr 1.2.1.9000
 
-* `hms` objects with NA values are now written without whitespace padding (#930).
+## Breaking Changes
 
-* `write_csv2()` now properly respects the `na` argument (#928).
+### Blank line skipping
+
+readr's blank line skipping has been modified to be more consistent and to
+avoid edge cases that affected the behavior in 1.2.0. The skip parameter now
+behaves more similar to how it worked previous to readr 1.2.0, but in addition
+the parameter `skip_blank_rows` can be used to control if fully blank lines are
+skipped in the output. (#923)
+
+## Bugfixes
+
+* `write_csv2()` now properly respects the `na` argument (#928)
 
 * Fixes compilation with multiple architectures on linux (#922).
 
 * Fixes compilation with R < 3.3.0
+
+* `hms` objects with NA values are now written without whitespace padding (#930).
+
+* `write_csv2()` now properly respects the `na` argument (#928).
 
 # readr 1.2.1
 

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -45,12 +45,12 @@ read_file_raw_ <- function(sourceSpec) {
     .Call(`_readr_read_file_raw_`, sourceSpec)
 }
 
-read_lines_ <- function(sourceSpec, locale_, na, n_max = -1L, progress = TRUE) {
-    .Call(`_readr_read_lines_`, sourceSpec, locale_, na, n_max, progress)
+read_lines_ <- function(sourceSpec, locale_, na, n_max = -1L, skip_empty_rows = FALSE, progress = TRUE) {
+    .Call(`_readr_read_lines_`, sourceSpec, locale_, na, n_max, skip_empty_rows, progress)
 }
 
-read_lines_chunked_ <- function(sourceSpec, locale_, na, chunkSize, callback, progress = TRUE) {
-    invisible(.Call(`_readr_read_lines_chunked_`, sourceSpec, locale_, na, chunkSize, callback, progress))
+read_lines_chunked_ <- function(sourceSpec, locale_, na, chunkSize, callback, skip_empty_rows = FALSE, progress = TRUE) {
+    invisible(.Call(`_readr_read_lines_chunked_`, sourceSpec, locale_, na, chunkSize, callback, skip_empty_rows, progress))
 }
 
 read_lines_raw_ <- function(sourceSpec, n_max = -1L, progress = FALSE) {

--- a/R/col_types.R
+++ b/R/col_types.R
@@ -278,19 +278,22 @@ col_concise <- function(x) {
 
 col_spec_standardise <- function(file, col_names = TRUE, col_types = NULL,
                                  guessed_types = NULL,
-                                 comment = "", skip = 0, guess_max = 1000,
+                                 comment = "",
+                                 skip = 0, skip_empty_rows = TRUE,
+                                 guess_max = 1000,
                                  tokenizer = tokenizer_csv(),
                                  locale = default_locale(),
                                  drop_skipped_names = FALSE) {
 
   # Figure out the column names -----------------------------------------------
   if (is.logical(col_names) && length(col_names) == 1) {
-    ds_header <- datasource(file, skip = skip, comment = comment)
+    ds_header <- datasource(file, skip = skip, skip_empty_rows = skip_empty_rows, comment = comment)
     if (col_names) {
-      col_names <- guess_header(ds_header, tokenizer, locale)
-      skip <- skip + 1
+      res <- guess_header(ds_header, tokenizer, locale)
+      col_names <- res$header
+      skip <- res$skip
     } else {
-      n <- length(guess_header(ds_header, tokenizer, locale))
+      n <- length(guess_header(ds_header, tokenizer, locale)$header)
       col_names <- paste0("X", seq_len(n))
     }
     guessed_names <- TRUE
@@ -336,6 +339,8 @@ col_spec_standardise <- function(file, col_names = TRUE, col_types = NULL,
 
   spec <- as.col_spec(col_types)
   type_names <- names(spec$cols)
+
+  spec$skip <- skip
 
   if (length(spec$cols) == 0) {
     # no types specified so use defaults
@@ -412,7 +417,7 @@ col_spec_standardise <- function(file, col_names = TRUE, col_types = NULL,
   is_guess <- vapply(spec$cols, function(x) inherits(x, "collector_guess"), logical(1))
   if (any(is_guess)) {
     if (is.null(guessed_types)) {
-      ds <- datasource(file, skip = skip, comment = comment)
+      ds <- datasource(file, skip = spec$skip, skip_empty_rows = skip_empty_rows, comment = comment)
       guessed_types <- guess_types(ds, tokenizer, locale, guess_max = guess_max)
     }
 

--- a/R/lines.R
+++ b/R/lines.R
@@ -28,20 +28,21 @@
 #'
 #' write_lines(airquality$Ozone, tmp, na = "-1")
 #' read_lines(tmp)
-read_lines <- function(file, skip = 0, n_max = -1L,
+read_lines <- function(file, skip = 0, skip_empty_rows = FALSE, n_max = -1L,
                        locale = default_locale(),
                        na = character(),
                        progress = show_progress()) {
   if (empty_file(file)) {
     return(character())
   }
-  ds <- datasource(file, skip = skip)
-  read_lines_(ds, locale_ = locale, na = na, n_max = n_max, progress = progress)
+  ds <- datasource(file, skip = skip, skip_empty_rows = skip_empty_rows)
+  read_lines_(ds, skip_empty_rows = skip_empty_rows, locale_ = locale, na = na, n_max = n_max, progress = progress)
 }
 
 #' @export
 #' @rdname read_lines
-read_lines_raw <- function(file, skip = 0, n_max = -1L, progress = show_progress()) {
+read_lines_raw <- function(file, skip = 0,
+                           n_max = -1L, progress = show_progress()) {
   if (empty_file(file)) {
     return(list())
   }

--- a/R/melt_delim.R
+++ b/R/melt_delim.R
@@ -61,7 +61,8 @@ melt_delim <- function(file, delim, quote = '"',
     na = na, quoted_na = quoted_na, comment = comment, trim_ws = trim_ws,
     skip_empty_rows = skip_empty_rows)
   melt_delimited(file, tokenizer, locale = locale, skip = skip,
-                 comment = comment, n_max = n_max, progress = progress)
+    skip_empty_rows = skip_empty_rows, comment = comment,
+    n_max = n_max, progress = progress)
 }
 
 #' @rdname melt_delim
@@ -74,7 +75,8 @@ melt_csv <- function(file, locale = default_locale(), na = c("", "NA"),
   tokenizer <- tokenizer_csv(na = na, quoted_na = quoted_na, quote = quote,
     comment = comment, trim_ws = trim_ws, skip_empty_rows = skip_empty_rows)
   melt_delimited(file, tokenizer, locale = locale, skip = skip,
-                 comment = comment, n_max = n_max, progress = progress)
+    skip_empty_rows = skip_empty_rows, comment = comment, n_max = n_max,
+    progress = progress)
 }
 
 #' @rdname melt_delim
@@ -94,7 +96,8 @@ melt_csv2 <- function(file, locale = default_locale(), na = c("", "NA"),
     quote = quote, comment = comment, trim_ws = trim_ws,
     skip_empty_rows = skip_empty_rows)
   melt_delimited(file, tokenizer, locale = locale, skip = skip,
-                 comment = comment, n_max = n_max, progress = progress)
+    skip_empty_rows = skip_empty_rows, comment = comment, n_max = n_max,
+    progress = progress)
 }
 
 
@@ -108,7 +111,8 @@ melt_tsv <- function(file, locale = default_locale(), na = c("", "NA"),
   tokenizer <- tokenizer_tsv(na = na, quoted_na = quoted_na, quote = quote,
     comment = comment, trim_ws = trim_ws, skip_empty_rows = skip_empty_rows)
   melt_delimited(file, tokenizer, locale = locale, skip = skip,
-                 comment = comment, n_max = n_max, progress = progress)
+    skip_empty_rows = skip_empty_rows, comment = comment, n_max = n_max,
+    progress = progress)
 }
 
 # Helper functions for reading from delimited files ----------------------------
@@ -135,13 +139,13 @@ melt_tokens <- function(data, tokenizer, locale_, n_max, progress) {
 }
 
 melt_delimited <- function(file, tokenizer, locale = default_locale(),
-                           skip = 0, comment = "", n_max = Inf,
+                           skip = 0, skip_empty_rows = FALSE, comment = "", n_max = Inf,
                            progress = show_progress()) {
   name <- source_name(file)
   # If connection needed, read once.
   file <- standardise_path(file)
   if (is.connection(file)) {
-    data <- datasource_connection(file, skip, comment)
+    data <- datasource_connection(file, skip, skip_empty_rows = skip_empty_rows, comment)
   } else {
     if (empty_file(file)) {
        return(tibble::data_frame(row = double(), col = double(),
@@ -155,7 +159,7 @@ melt_delimited <- function(file, tokenizer, locale = default_locale(),
       data <- file
     }
   }
-  ds <- datasource(data, skip = skip, comment = comment)
+  ds <- datasource(data, skip = skip, skip_empty_rows = skip_empty_rows, comment = comment)
   out <- melt_tokens(ds, tokenizer, locale_ = locale, n_max = n_max,
               progress = progress)
   warn_problems(out)

--- a/R/read_delim.R
+++ b/R/read_delim.R
@@ -109,8 +109,8 @@ read_delim <- function(file, delim, quote = '"',
     na = na, quoted_na = quoted_na, comment = comment, trim_ws = trim_ws,
     skip_empty_rows = skip_empty_rows)
   read_delimited(file, tokenizer, col_names = col_names, col_types = col_types,
-    locale = locale, skip = skip, comment = comment, n_max = n_max, guess_max =
-      guess_max, progress = progress)
+    locale = locale, skip = skip, skip_empty_rows = skip_empty_rows,
+    comment = comment, n_max = n_max, guess_max = guess_max, progress = progress)
 }
 
 #' @rdname read_delim
@@ -123,8 +123,8 @@ read_csv <- function(file, col_names = TRUE, col_types = NULL,
   tokenizer <- tokenizer_csv(na = na, quoted_na = quoted_na, quote = quote,
     comment = comment, trim_ws = trim_ws, skip_empty_rows = skip_empty_rows)
   read_delimited(file, tokenizer, col_names = col_names, col_types = col_types,
-    locale = locale, skip = skip, comment = comment, n_max = n_max, guess_max =
-      guess_max, progress = progress)
+    locale = locale, skip = skip, skip_empty_rows = skip_empty_rows,
+    comment = comment, n_max = n_max, guess_max = guess_max, progress = progress)
 }
 
 #' @rdname read_delim
@@ -145,8 +145,8 @@ read_csv2 <- function(file, col_names = TRUE, col_types = NULL,
     quote = quote, comment = comment, trim_ws = trim_ws,
     skip_empty_rows = skip_empty_rows)
   read_delimited(file, tokenizer, col_names = col_names, col_types = col_types,
-    locale = locale, skip = skip, comment = comment, n_max = n_max,
-    guess_max = guess_max, progress = progress)
+    locale = locale, skip = skip, skip_empty_rows = skip_empty_rows,
+    comment = comment, n_max = n_max, guess_max = guess_max, progress = progress)
 }
 
 
@@ -161,8 +161,8 @@ read_tsv <- function(file, col_names = TRUE, col_types = NULL,
   tokenizer <- tokenizer_tsv(na = na, quoted_na = quoted_na, quote = quote,
     comment = comment, trim_ws = trim_ws, skip_empty_rows = skip_empty_rows)
   read_delimited(file, tokenizer, col_names = col_names, col_types = col_types,
-    locale = locale, skip = skip, comment = comment, n_max = n_max,
-    guess_max = guess_max, progress = progress)
+    locale = locale, skip = skip, skip_empty_rows = skip_empty_rows,
+    comment = comment, n_max = n_max, guess_max = guess_max, progress = progress)
 }
 
 # Helper functions for reading from delimited files ----------------------------
@@ -174,13 +174,13 @@ read_tokens <- function(data, tokenizer, col_specs, col_names, locale_, n_max, p
 }
 
 read_delimited <- function(file, tokenizer, col_names = TRUE, col_types = NULL,
-                           locale = default_locale(), skip = 0, comment = "",
+                           locale = default_locale(), skip = 0, skip_empty_rows = TRUE, comment = "",
                            n_max = Inf, guess_max = min(1000, n_max), progress = show_progress()) {
   name <- source_name(file)
   # If connection needed, read once.
   file <- standardise_path(file)
   if (is.connection(file)) {
-    data <- datasource_connection(file, skip, comment)
+    data <- datasource_connection(file, skip, skip_empty_rows, comment)
   } else {
     if (empty_file(file)) {
        return(tibble::data_frame())
@@ -195,11 +195,11 @@ read_delimited <- function(file, tokenizer, col_names = TRUE, col_types = NULL,
   }
 
   spec <- col_spec_standardise(
-    data, skip = skip, comment = comment, guess_max = guess_max,
-    col_names = col_names, col_types = col_types, tokenizer = tokenizer,
-    locale = locale)
+    data, skip = skip, skip_empty_rows = skip_empty_rows,
+    comment = comment, guess_max = guess_max, col_names = col_names,
+    col_types = col_types, tokenizer = tokenizer, locale = locale)
 
-  ds <- datasource(data, skip = skip + isTRUE(col_names), comment = comment)
+  ds <- datasource(data, skip = spec$skip, skip_empty_rows = skip_empty_rows, comment = comment)
 
   if (is.null(col_types) && !inherits(ds, "source_string")) {
     show_cols_spec(spec)

--- a/R/read_fwf.R
+++ b/R/read_fwf.R
@@ -60,7 +60,7 @@ read_fwf <- function(file, col_positions, col_types = NULL,
     show_cols_spec(spec)
   }
 
-  out <- read_tokens(ds, tokenizer, spec$cols, names(spec$cols),
+  out <- read_tokens(datasource(file, skip = spec$skip), tokenizer, spec$cols, names(spec$cols),
     locale_ = locale, n_max = if (n_max == Inf) -1 else n_max,
     progress = progress)
 

--- a/R/read_table.R
+++ b/R/read_table.R
@@ -37,7 +37,7 @@ read_table <- function(file, col_names = TRUE, col_types = NULL,
                        n_max = Inf, guess_max = min(n_max, 1000),
                        progress = show_progress(), comment = "",
                        skip_empty_rows = TRUE) {
-  ds <- datasource(file, skip = skip)
+  ds <- datasource(file, skip = skip, skip_empty_rows = skip_empty_rows)
   columns <- fwf_empty(ds, skip = skip, n = guess_max, comment = comment)
   skip <- skip + columns$skip
 
@@ -46,12 +46,12 @@ read_table <- function(file, col_names = TRUE, col_types = NULL,
                              skip_empty_rows = skip_empty_rows)
 
   spec <- col_spec_standardise(
-    file = ds, skip = skip, guess_max = guess_max,
-    col_names = col_names, col_types = col_types,
+    file = ds, skip = skip, skip_empty_rows = skip_empty_rows,
+    guess_max = guess_max, col_names = col_names, col_types = col_types,
     locale = locale, tokenizer = tokenizer
   )
 
-  ds <- datasource(file = ds, skip = skip + isTRUE(col_names))
+  ds <- datasource(file = ds, skip = spec$skip, skip_empty_rows = skip_empty_rows)
   if (is.null(col_types) && !inherits(ds, "source_string")) {
     show_cols_spec(spec)
   }
@@ -74,8 +74,8 @@ read_table2 <- function(file, col_names = TRUE, col_types = NULL,
   tokenizer <- tokenizer_ws(na = na, comment = comment,
                             skip_empty_rows = skip_empty_rows)
   read_delimited(file, tokenizer, col_names = col_names, col_types = col_types,
-    locale = locale, skip = skip, comment = comment, n_max = n_max, guess_max =
-      guess_max, progress = progress)
+    locale = locale, skip = skip, skip_empty_rows = skip_empty_rows,
+    comment = comment, n_max = n_max, guess_max = guess_max, progress = progress)
 }
 
 #' @rdname spec_delim

--- a/R/source.R
+++ b/R/source.R
@@ -35,7 +35,7 @@
 #' con <- rawConnection(charToRaw("abc\n123"))
 #' datasource(con)
 #' close(con)
-datasource <- function(file, skip = 0, comment = "") {
+datasource <- function(file, skip = 0, skip_empty_rows = TRUE, comment = "") {
   if (inherits(file, "source")) {
 
     # If `skip` and `comment` arguments are expliictly passed, we want to use
@@ -50,20 +50,20 @@ datasource <- function(file, skip = 0, comment = "") {
 
     file
   } else if (is.connection(file)) {
-    datasource_connection(file, skip, comment)
+    datasource_connection(file, skip, skip_empty_rows, comment)
   } else if (is.raw(file)) {
-    datasource_raw(file, skip, comment)
+    datasource_raw(file, skip, skip_empty_rows, comment)
   } else if (is.character(file)) {
     if (length(file) > 1) {
       datasource_string(paste(file, collapse = "\n"), skip, comment)
     } else if (grepl("\n", file)) {
-      datasource_string(file, skip, comment)
+      datasource_string(file, skip, skip_empty_rows, comment)
     } else {
       file <- standardise_path(file)
       if (is.connection(file)) {
-        datasource_connection(file, skip, comment)
+        datasource_connection(file, skip, skip_empty_rows, comment)
       } else {
-        datasource_file(file, skip, comment)
+        datasource_file(file, skip, skip_empty_rows, comment)
       }
     }
   } else {
@@ -73,32 +73,32 @@ datasource <- function(file, skip = 0, comment = "") {
 
 # Constructors -----------------------------------------------------------------
 
-new_datasource <- function(type, x, skip, comment = "", ...) {
-  structure(list(x, skip = skip, comment = comment, ...),
+new_datasource <- function(type, x, skip, skip_empty_rows = TRUE, comment = "", ...) {
+  structure(list(x, skip = skip, skip_empty_rows = skip_empty_rows, comment = comment, ...),
     class = c(paste0("source_", type), "source"))
 }
 
-datasource_string <- function(text, skip, comment = "") {
-  new_datasource("string", text, skip = skip, comment = comment)
+datasource_string <- function(text, skip, skip_empty_rows = TRUE, comment = "") {
+  new_datasource("string", text, skip = skip, skip_empty_rows = skip_empty_rows, comment = comment)
 }
 
-datasource_file <- function(path, skip, comment = "", ...) {
+datasource_file <- function(path, skip, skip_empty_rows = TRUE, comment = "", ...) {
   path <- check_path(path)
-  new_datasource("file", path, skip = skip, comment = comment, ...)
+  new_datasource("file", path, skip = skip, skip_empty_rows = skip_empty_rows, comment = comment, ...)
 }
 
-datasource_connection <- function(path, skip, comment = "") {
+datasource_connection <- function(path, skip, skip_empty_rows = TRUE, comment = "") {
   # We read the connection to a temporary file, then register a finalizer to
   # cleanup the temp file after the datasource object is removed.
 
   file <- read_connection(path)
   env <- new.env(parent = emptyenv())
   reg.finalizer(env, function(env) unlink(file))
-  datasource_file(file, skip, comment = comment, env = env)
+  datasource_file(file, skip, skip_empty_rows = skip_empty_rows, comment = comment, env = env)
 }
 
-datasource_raw <- function(text, skip, comment) {
-  new_datasource("raw", text, skip = skip, comment = comment)
+datasource_raw <- function(text, skip, skip_empty_rows, comment) {
+  new_datasource("raw", text, skip = skip, skip_empty_rows = skip_empty_rows, comment = comment)
 }
 
 # Helpers ----------------------------------------------------------------------

--- a/R/utils.R
+++ b/R/utils.R
@@ -24,3 +24,19 @@ deparse2 <- function(expr, ..., sep = "\n") {
 is_integerish <- function(x) {
   floor(x) == x
 }
+
+# @export
+compare.tbl_df <- function(x, y, ...) {
+  attr(x, "spec") <- NULL
+  attr(y, "spec") <- NULL
+
+  NextMethod("compare")
+}
+
+# @export
+compare.col_spec <- function(x, y, ...) {
+  x[["skip"]] <- NULL
+  y[["skip"]] <- NULL
+
+  NextMethod("compare")
+}

--- a/man/datasource.Rd
+++ b/man/datasource.Rd
@@ -4,7 +4,7 @@
 \alias{datasource}
 \title{Create a source object.}
 \usage{
-datasource(file, skip = 0, comment = "")
+datasource(file, skip = 0, skip_empty_rows = TRUE, comment = "")
 }
 \arguments{
 \item{file}{Either a path to a file, a connection, or literal data

--- a/man/read_lines.Rd
+++ b/man/read_lines.Rd
@@ -6,8 +6,9 @@
 \alias{write_lines}
 \title{Read/write lines to/from a file}
 \usage{
-read_lines(file, skip = 0, n_max = -1L, locale = default_locale(),
-  na = character(), progress = show_progress())
+read_lines(file, skip = 0, skip_empty_rows = FALSE, n_max = -1L,
+  locale = default_locale(), na = character(),
+  progress = show_progress())
 
 read_lines_raw(file, skip = 0, n_max = -1L,
   progress = show_progress())
@@ -31,6 +32,10 @@ vector of greater than length 1.
 Using a value of \code{\link[=clipboard]{clipboard()}} will read from the system clipboard.}
 
 \item{skip}{Number of lines to skip before reading data.}
+
+\item{skip_empty_rows}{Should blank rows be ignored altogether? i.e. If this
+option is \code{TRUE} then blank rows will not be represented at all.  If it is
+\code{FALSE} then they will be represented by \code{NA} values in all the columns.}
 
 \item{n_max}{Number of lines to read. If \code{n_max} is -1, all lines in
 file will be read.}

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -151,8 +151,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // read_lines_
-CharacterVector read_lines_(List sourceSpec, List locale_, std::vector<std::string> na, int n_max, bool progress);
-RcppExport SEXP _readr_read_lines_(SEXP sourceSpecSEXP, SEXP locale_SEXP, SEXP naSEXP, SEXP n_maxSEXP, SEXP progressSEXP) {
+CharacterVector read_lines_(List sourceSpec, List locale_, std::vector<std::string> na, int n_max, bool skip_empty_rows, bool progress);
+RcppExport SEXP _readr_read_lines_(SEXP sourceSpecSEXP, SEXP locale_SEXP, SEXP naSEXP, SEXP n_maxSEXP, SEXP skip_empty_rowsSEXP, SEXP progressSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -160,14 +160,15 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< List >::type locale_(locale_SEXP);
     Rcpp::traits::input_parameter< std::vector<std::string> >::type na(naSEXP);
     Rcpp::traits::input_parameter< int >::type n_max(n_maxSEXP);
+    Rcpp::traits::input_parameter< bool >::type skip_empty_rows(skip_empty_rowsSEXP);
     Rcpp::traits::input_parameter< bool >::type progress(progressSEXP);
-    rcpp_result_gen = Rcpp::wrap(read_lines_(sourceSpec, locale_, na, n_max, progress));
+    rcpp_result_gen = Rcpp::wrap(read_lines_(sourceSpec, locale_, na, n_max, skip_empty_rows, progress));
     return rcpp_result_gen;
 END_RCPP
 }
 // read_lines_chunked_
-void read_lines_chunked_(List sourceSpec, List locale_, std::vector<std::string> na, int chunkSize, Environment callback, bool progress);
-RcppExport SEXP _readr_read_lines_chunked_(SEXP sourceSpecSEXP, SEXP locale_SEXP, SEXP naSEXP, SEXP chunkSizeSEXP, SEXP callbackSEXP, SEXP progressSEXP) {
+void read_lines_chunked_(List sourceSpec, List locale_, std::vector<std::string> na, int chunkSize, Environment callback, bool skip_empty_rows, bool progress);
+RcppExport SEXP _readr_read_lines_chunked_(SEXP sourceSpecSEXP, SEXP locale_SEXP, SEXP naSEXP, SEXP chunkSizeSEXP, SEXP callbackSEXP, SEXP skip_empty_rowsSEXP, SEXP progressSEXP) {
 BEGIN_RCPP
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< List >::type sourceSpec(sourceSpecSEXP);
@@ -175,8 +176,9 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< std::vector<std::string> >::type na(naSEXP);
     Rcpp::traits::input_parameter< int >::type chunkSize(chunkSizeSEXP);
     Rcpp::traits::input_parameter< Environment >::type callback(callbackSEXP);
+    Rcpp::traits::input_parameter< bool >::type skip_empty_rows(skip_empty_rowsSEXP);
     Rcpp::traits::input_parameter< bool >::type progress(progressSEXP);
-    read_lines_chunked_(sourceSpec, locale_, na, chunkSize, callback, progress);
+    read_lines_chunked_(sourceSpec, locale_, na, chunkSize, callback, skip_empty_rows, progress);
     return R_NilValue;
 END_RCPP
 }
@@ -379,8 +381,8 @@ static const R_CallMethodDef CallEntries[] = {
     {"_readr_parse_vector_", (DL_FUNC) &_readr_parse_vector_, 5},
     {"_readr_read_file_", (DL_FUNC) &_readr_read_file_, 2},
     {"_readr_read_file_raw_", (DL_FUNC) &_readr_read_file_raw_, 1},
-    {"_readr_read_lines_", (DL_FUNC) &_readr_read_lines_, 5},
-    {"_readr_read_lines_chunked_", (DL_FUNC) &_readr_read_lines_chunked_, 6},
+    {"_readr_read_lines_", (DL_FUNC) &_readr_read_lines_, 6},
+    {"_readr_read_lines_chunked_", (DL_FUNC) &_readr_read_lines_chunked_, 7},
     {"_readr_read_lines_raw_", (DL_FUNC) &_readr_read_lines_raw_, 3},
     {"_readr_read_lines_raw_chunked_", (DL_FUNC) &_readr_read_lines_raw_chunked_, 4},
     {"_readr_read_tokens_", (DL_FUNC) &_readr_read_tokens_, 7},

--- a/src/Source.cpp
+++ b/src/Source.cpp
@@ -10,16 +10,19 @@ SourcePtr Source::create(List spec) {
   std::string subclass(as<CharacterVector>(spec.attr("class"))[0]);
 
   int skip = as<int>(spec["skip"]);
+  bool skipEmptyRows = as<int>(spec["skip_empty_rows"]);
   std::string comment = as<std::string>(spec["comment"]);
 
   if (subclass == "source_raw") {
-    return SourcePtr(new SourceRaw(as<RawVector>(spec[0]), skip, comment));
-  } else if (subclass == "source_string") {
     return SourcePtr(
-        new SourceString(as<CharacterVector>(spec[0]), skip, comment));
+        new SourceRaw(as<RawVector>(spec[0]), skip, skipEmptyRows, comment));
+  } else if (subclass == "source_string") {
+    return SourcePtr(new SourceString(
+        as<CharacterVector>(spec[0]), skip, skipEmptyRows, comment));
   } else if (subclass == "source_file") {
     CharacterVector path(spec[0]);
-    return SourcePtr(new SourceFile(Rf_translateChar(path[0]), skip, comment));
+    return SourcePtr(new SourceFile(
+        Rf_translateChar(path[0]), skip, skipEmptyRows, comment));
   }
 
   Rcpp::stop("Unknown source type");

--- a/src/Source.h
+++ b/src/Source.h
@@ -2,6 +2,7 @@
 #define FASTREAD_SOURCE_H_
 
 #include "boost.h"
+#include "utils.h"
 #include <Rcpp.h>
 
 class Source;
@@ -14,10 +15,11 @@ public:
   virtual const char* begin() = 0;
   virtual const char* end() = 0;
 
-  static const char* skipLines(
+  const char* skipLines(
       const char* begin,
       const char* end,
       int n,
+      bool skipEmptyRows = true,
       const std::string& comment = "") {
     bool hasComment = comment != "";
     bool isComment = false, lineStart = true;
@@ -25,45 +27,51 @@ public:
 
     const char* cur = begin;
 
-    while (n > 0 && cur != end) {
+    for (; n > 0 && cur != end; ++cur) {
       if (lineStart) {
         isComment = hasComment && inComment(cur, end, comment);
       }
 
       // This doesn't handle escaped quotes or more sophisticated things, but
       // will work for simple cases.
-      if (*cur == '"') {
+      if (*cur == '"' || *cur == '\'') {
         isQuote = !isQuote;
-        cur++;
         lineStart = false;
         continue;
       }
 
-      if (isQuote) {
-        cur++;
+      if (isComment || isQuote) {
         continue;
       }
 
-      if (*cur == '\r') {
-        if (cur + 1 != end && *(cur + 1) == '\n') {
-          cur++;
-        }
-        if (!(isComment || lineStart))
-          n--;
-        lineStart = true;
-      } else if (*cur == '\n') {
-        if (!(isComment || lineStart))
-          n--;
+      if (*cur == '\n' || *cur == '\r') {
+        --n;
+        advanceForLF(&cur, end);
+        ++skippedRows_;
         lineStart = true;
       } else if (lineStart) {
         lineStart = false;
       }
+    }
 
-      cur++;
+    // Skip any more trailing empty rows or comments
+    while ((skipEmptyRows && (*cur == '\n' || *cur == '\r')) ||
+           (isComment = hasComment && inComment(cur, end, comment))) {
+      if (isComment) {
+        // skip the rest of the line until the newline
+        while (cur <= end && !(*cur == '\n' || *cur == '\r')) {
+          ++cur;
+        }
+      }
+      advanceForLF(&cur, end);
+      ++cur;
+      ++skippedRows_;
     }
 
     return cur;
   }
+
+  size_t skippedRows() { return skippedRows_; }
 
   static const char* skipBom(const char* begin, const char* end) {
 
@@ -124,6 +132,8 @@ private:
     boost::iterator_range<const char*> haystack(cur, end);
     return boost::starts_with(haystack, comment);
   }
+
+  size_t skippedRows_ = 0;
 };
 
 #endif

--- a/src/SourceFile.h
+++ b/src/SourceFile.h
@@ -14,7 +14,10 @@ class SourceFile : public Source {
 
 public:
   SourceFile(
-      const std::string& path, int skip = 0, const std::string& comment = "") {
+      const std::string& path,
+      int skip = 0,
+      bool skipEmptyRows = true,
+      const std::string& comment = "") {
     try {
       fm_ = boost::interprocess::file_mapping(
           path.c_str(), boost::interprocess::read_only);
@@ -31,7 +34,7 @@ public:
     begin_ = skipBom(begin_, end_);
 
     // Skip lines, if needed
-    begin_ = skipLines(begin_, end_, skip, comment);
+    begin_ = skipLines(begin_, end_, skip, skipEmptyRows, comment);
   }
 
   const char* begin() { return begin_; }

--- a/src/SourceRaw.h
+++ b/src/SourceRaw.h
@@ -10,7 +10,11 @@ class SourceRaw : public Source {
   const char* end_;
 
 public:
-  SourceRaw(Rcpp::RawVector x, int skip = 0, const std::string& comment = "")
+  SourceRaw(
+      Rcpp::RawVector x,
+      int skip = 0,
+      bool skipEmptyRows = true,
+      const std::string& comment = "")
       : x_(x) {
     begin_ = (const char*)RAW(x);
     end_ = (const char*)RAW(x) + Rf_xlength(x);
@@ -19,7 +23,7 @@ public:
     begin_ = skipBom(begin_, end_);
 
     // Skip lines, if needed
-    begin_ = skipLines(begin_, end_, skip, comment);
+    begin_ = skipLines(begin_, end_, skip, skipEmptyRows, comment);
   }
 
   const char* begin() { return begin_; }

--- a/src/SourceString.h
+++ b/src/SourceString.h
@@ -12,7 +12,10 @@ class SourceString : public Source {
 
 public:
   SourceString(
-      Rcpp::CharacterVector x, int skip = 0, const std::string& comment = "") {
+      Rcpp::CharacterVector x,
+      int skip = 0,
+      bool skipEmptyRows = true,
+      const std::string& comment = "") {
     string_ = x[0];
 
     begin_ = CHAR(string_);
@@ -22,7 +25,7 @@ public:
     begin_ = skipBom(begin_, end_);
 
     // Skip lines, if needed
-    begin_ = skipLines(begin_, end_, skip, comment);
+    begin_ = skipLines(begin_, end_, skip, skipEmptyRows, comment);
   }
 
   const char* begin() { return begin_; }

--- a/src/Tokenizer.cpp
+++ b/src/Tokenizer.cpp
@@ -44,7 +44,8 @@ TokenizerPtr Tokenizer::create(List spec) {
         new TokenizerFwf(begin, end, na, comment, trimWs, skipEmptyRows));
   } else if (subclass == "tokenizer_line") {
     std::vector<std::string> na = as<std::vector<std::string> >(spec["na"]);
-    return TokenizerPtr(new TokenizerLine(na));
+    bool skipEmptyRows = as<bool>(spec["skip_empty_rows"]);
+    return TokenizerPtr(new TokenizerLine(na, skipEmptyRows));
   } else if (subclass == "tokenizer_log") {
     return TokenizerPtr(new TokenizerLog());
   } else if (subclass == "tokenizer_ws") {

--- a/src/TokenizerDelim.cpp
+++ b/src/TokenizerDelim.cpp
@@ -35,8 +35,9 @@ TokenizerDelim::TokenizerDelim(
 
 void TokenizerDelim::tokenize(SourceIterator begin, SourceIterator end) {
   cur_ = begin;
-  begin_ = begin;
+
   end_ = end;
+  begin_ = begin;
 
   row_ = 0;
   col_ = 0;

--- a/src/parse.cpp
+++ b/src/parse.cpp
@@ -61,12 +61,11 @@ RObject guess_header_(List sourceSpec, List tokenizerSpec, List locale_) {
 
   CollectorCharacter out(&locale.encoder_);
   out.setWarnings(&warnings);
+  Token t = tokenizer->nextToken();
+  int row_num = t.row();
 
-  for (Token t = tokenizer->nextToken(); t.type() != TOKEN_EOF;
+  for (; t.type() != TOKEN_EOF && t.row() == row_num;
        t = tokenizer->nextToken()) {
-    if (t.row() > (size_t)0) // only read one row
-      break;
-
     if (t.col() >= (size_t)out.size()) {
       out.resize(t.col() + 1);
     }
@@ -76,7 +75,8 @@ RObject guess_header_(List sourceSpec, List tokenizerSpec, List locale_) {
     }
   }
 
-  return out.vector();
+  return List::create(
+      _["header"] = out.vector(), _["skip"] = source->skippedRows() + 1);
 }
 
 // [[Rcpp::export]]

--- a/src/read.cpp
+++ b/src/read.cpp
@@ -34,12 +34,13 @@ CharacterVector read_lines_(
     List locale_,
     std::vector<std::string> na,
     int n_max = -1,
+    bool skip_empty_rows = false,
     bool progress = true) {
 
   LocaleInfo locale(locale_);
   Reader r(
       Source::create(sourceSpec),
-      TokenizerPtr(new TokenizerLine(na)),
+      TokenizerPtr(new TokenizerLine(na, skip_empty_rows)),
       CollectorPtr(new CollectorCharacter(&locale.encoder_)),
       progress);
 
@@ -63,12 +64,13 @@ void read_lines_chunked_(
     std::vector<std::string> na,
     int chunkSize,
     Environment callback,
+    bool skip_empty_rows = false,
     bool progress = true) {
 
   LocaleInfo locale(locale_);
   Reader r(
       Source::create(sourceSpec),
-      TokenizerPtr(new TokenizerLine(na)),
+      TokenizerPtr(new TokenizerLine(na, skip_empty_rows)),
       CollectorPtr(new CollectorCharacter(&locale.encoder_)),
       progress);
 

--- a/tests/testthat/test-melt-csv.R
+++ b/tests/testthat/test-melt-csv.R
@@ -12,7 +12,7 @@ test_that("read_tsv works on a simple file", {
 })
 
 test_that("melt_csv's 'NA' option genuinely changes the NA values", {
-  expect_equal(melt_csv("\nz", na = "z")$data_type[2], "missing")
+  expect_equal(melt_csv("z\n", na = "z")$data_type, "missing")
 })
 
 test_that("melt_csv's 'NA' option works with multiple NA values", {
@@ -21,7 +21,7 @@ test_that("melt_csv's 'NA' option works with multiple NA values", {
 })
 
 test_that('passing character() to melt_csv\'s "NA" option reads "" correctly', {
-  expect_equal(melt_csv("\nfoo", na = character())$value[2], "foo")
+  expect_equal(melt_csv("foo\n", na = character())$value, "foo")
 })
 
 test_that("passing \"\" to melt_csv's 'NA' option reads \"\" correctly", {
@@ -160,7 +160,7 @@ test_that("skip respects comments", {
   expect_equal(melt_x(), c("#a", "b", "c"))
   expect_equal(melt_x(skip = 1), c("b", "c"))
   expect_equal(melt_x(comment = "#"), c("b", "c"))
-  expect_equal(melt_x(comment = "#", skip = 1), c("c"))
+  expect_equal(melt_x(comment = "#", skip = 2), c("c"))
 })
 
 test_that("melt_csv returns a four-col zero-row data.frame on an empty file", {

--- a/tests/testthat/test-read-csv.R
+++ b/tests/testthat/test-read-csv.R
@@ -237,7 +237,24 @@ test_that("skip respects comments", {
   expect_equal(read_x(), c("#a", "b", "c"))
   expect_equal(read_x(skip = 1), c("b", "c"))
   expect_equal(read_x(comment = "#"), c("b", "c"))
-  expect_equal(read_x(comment = "#", skip = 1), c("c"))
+  expect_equal(read_x(comment = "#", skip = 2), c("c"))
+})
+
+test_that("skip respects newlines", {
+  read_x <- function(...) {
+    read_csv("1\n2\n3\n\na\nb\nc", col_names = FALSE, ..., progress = FALSE)[[1]]
+  }
+
+  expect_equal(read_x(), c("1", "2", "3", "a", "b", "c"))
+  expect_equal(read_x(skip = 3), c("a", "b", "c"))
+  expect_equal(read_x(skip = 4), c("a", "b", "c"))
+  expect_equal(read_x(skip = 5), c("b", "c"))
+
+  expect_equal(read_x(skip_empty_rows = FALSE), c("1", "2", "3", NA, "a", "b", "c"))
+
+  expect_equal(read_x(skip_empty_rows = TRUE, skip = 3), c("a", "b", "c"))
+  expect_equal(read_x(skip_empty_rows = FALSE, skip = 3), c(NA, "a", "b", "c"))
+  expect_equal(read_x(skip_empty_rows = FALSE, skip = 4), c("a", "b", "c"))
 })
 
 test_that("read_csv returns an empty data.frame on an empty file", {
@@ -250,7 +267,7 @@ test_that("read_delim errors on length 0 delimiter (557)", {
 })
 
 test_that("read_csv does not duplicate header rows for leading whitespace (747)", {
-  x <- read_csv("\nfoo,bar\n1,2")
+  x <- read_csv("\nfoo,bar\n1,2", skip = 1)
   expect_equal(nrow(x), 1)
   expect_equal(x$foo, 1)
 })

--- a/tests/testthat/test-read-lines.R
+++ b/tests/testthat/test-read-lines.R
@@ -29,6 +29,27 @@ test_that("blank lines are passed unchanged", {
   expect_equal(read_lines(tmp, na = ""), c("abc", NA_character_, "123"))
 })
 
+test_that("read_lines can skip blank lines (#923)", {
+  x <-
+"1
+2
+3
+
+foo
+bar
+baz
+"
+  expect_equal(read_lines(x), c("1", "2", "3", "", "foo", "bar", "baz"))
+  expect_equal(read_lines(x, skip_empty_rows = TRUE), c("1", "2", "3", "foo", "bar", "baz"))
+  expect_equal(read_lines(x, skip = 1), c("2", "3", "", "foo", "bar", "baz"))
+  expect_equal(read_lines(x, skip = 2), c("3", "", "foo", "bar", "baz"))
+  expect_equal(read_lines(x, skip = 3), c("", "foo", "bar", "baz"))
+  expect_equal(read_lines(x, skip = 4), c("foo", "bar", "baz"))
+  expect_equal(read_lines(x, skip = 5), c("bar", "baz"))
+  expect_equal(read_lines(x, skip = 6), c("baz"))
+  expect_equal(read_lines(x, skip = 7), character())
+})
+
 test_that("allocation works as expected", {
   tmp <- tempfile(fileext = ".gz")
   on.exit(unlink(tmp))

--- a/tests/testthat/test-write.R
+++ b/tests/testthat/test-write.R
@@ -161,5 +161,5 @@ test_that("Can change the escape behavior for quotes", {
 
 test_that("hms NAs are written without padding (#930)", {
   df <- data.frame(x = hms::as.hms(c(NA, 34.234)))
-  expect_equal(format_tsv(df), "x\nNA\n00:00:34.234")
+  expect_equal(format_tsv(df), "x\nNA\n00:00:34.234\n")
 })


### PR DESCRIPTION
We now always count empty lines and comments as part of the number of
skips, but also skip any remaining blank lines are comments after the
skips. This allows you to have consistent skip behavior but also makes
it easy to ignore blanks, which is useful with messy inputs.

Fixes #923

Fix test