### PR TITLE
Colourise types of columns when printing specs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # readr (development version)
 
+* Column specifications are now coloured when printed. This makes it easy to
+  see at a glance when a column is input as a different type then the rest.
+  Colouring can be disabled by setting `options(crayon.enabled = FALSE)`.
+
 * `as.col_spec()` can now use named character vectors, which makes
   `read_csv("file.csv", col_types = c(xyz = "c"))` equivalent to
   `read_csv("file.csv", col_types = cols(xyz = col_character())`

--- a/tests/testthat/colour-test
+++ b/tests/testthat/colour-test
@@ -1,0 +1,11 @@
+cols(
+  a = [32mcol_double()[39m,
+  b = [32mcol_integer()[39m,
+  c = [33mcol_logical()[39m,
+  d = [31mcol_character()[39m,
+  e = [34mcol_date(format = "")[39m,
+  f = [34mcol_datetime(format = "")[39m,
+  g = [34mcol_time(format = "")[39m,
+  h = [31mcol_factor(levels = NULL, ordered = FALSE, include_na = FALSE)[39m,
+  i = col_skip()
+)

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -23,3 +23,15 @@ skip_if_no_clipboard <- function() {
   }
   return(invisible(TRUE))
 }
+
+with_crayon <- function(expr) {
+
+  old <- options(crayon.enabled = TRUE, crayon.colors = 16)
+  crayon::num_colors(forget = TRUE)
+  on.exit({
+    options(old)
+    crayon::num_colors(forget = TRUE)
+  })
+
+  force(expr)
+}

--- a/tests/testthat/test-col-spec.R
+++ b/tests/testthat/test-col-spec.R
@@ -198,7 +198,7 @@ test_that("print(col_spec) with no columns specified", {
 test_that("print(col_spec) and condense edge cases", {
   out <- cols(a = col_integer(), b = col_integer(), c = col_double())
 
-  expect_equal(format(out, n = 1, condense = TRUE),
+  expect_equal(format(out, n = 1, condense = TRUE, colour = FALSE),
 "cols(
   .default = col_integer(),
   c = col_double()
@@ -206,9 +206,20 @@ test_that("print(col_spec) and condense edge cases", {
 ")
 })
 
+test_that("print(col_spec) with colors", {
+  out <- col_spec_standardise(
+    "a,b,c,d,e,f,g,h,i\n1,2,F,a,2018-01-01,2018-01-01 12:01:01,12:01:01,foo,blah"
+    , col_types = c(b = "i", h = "f", i = "_")
+  )
+
+  with_crayon(
+    expect_known_output(out, "colour-test", print = TRUE)
+  )
+})
+
 test_that("non-syntatic names are escaped", {
   x <- read_csv("a b,_c,1,a`b\n1,2,3,4")
-  expect_equal(format(spec(x)),
+  expect_equal(format(spec(x), colour = FALSE),
 "cols(
   `a b` = col_double(),
   `_c` = col_double(),
@@ -219,7 +230,7 @@ test_that("non-syntatic names are escaped", {
 })
 
 test_that("long expressions are wrapped (597)", {
-  expect_equal(format(cols(a = col_factor(levels = c("apple", "pear", "banana", "peach", "apricot", "orange", "plum"), ordered = TRUE))),
+  expect_equal(format(cols(a = col_factor(levels = c("apple", "pear", "banana", "peach", "apricot", "orange", "plum"), ordered = TRUE)), colour = FALSE),
 'cols(
   a = col_factor(levels = c("apple", "pear", "banana", "peach", "apricot", "orange", "plum"
     ), ordered = TRUE, include_na = FALSE)


### PR DESCRIPTION
I think open questions are the colors to use and if we need a readr specific way to turn this off (right now it uses `crayon::has_color()`).

I used the following to test how it looks

```r
library(dplyr)
library(nycflights13)
library(readr)
set.seed(42)
flights %>%
  transmute(
    carrier, flight, tailnum, origin, dest,
    departure = lubridate::make_datetime(year, month, day, hour, minute),
    delayed = arr_delay > 15) %>%
  sample_n(25) %>%
  write_tsv("flights.tsv")

read_tsv("flights.tsv")
```

![screen shot 2018-12-18 at 2 04 37 pm](https://user-images.githubusercontent.com/205275/50179934-47a89c00-02d6-11e9-8716-3e50e88bc6c5.png)
