### PR TITLE
change examples to no longer use tempfiles

### DIFF
--- a/R/write.R
+++ b/R/write.R
@@ -46,9 +46,17 @@
 #' <http://www.cs.tufts.edu/~nr/cs257/archive/florian-loitsch/printf.pdf>
 #' @export
 #' @examples
-#' tmp <- tempfile()
-#' write_csv(mtcars, tmp)
-#' head(read_csv(tmp))
+#' \dontshow{.old_wd <- setwd(tempdir())}
+#' # If you only specify a file name, write_()* will write
+#' # the file to your current working directory.
+#' write_csv(mtcars, "mtcars.csv")
+#' write_tsv(mtcars, "mtcars.tsv")
+#'
+#' # If you add an extension to the file name, write_()* will
+#' # automatically compress the output.
+#' write_tsv(mtcars, "mtcars.tsv.gz")
+#' write_tsv(mtcars, "mtcars.tsv.bz2")
+#' write_tsv(mtcars, "mtcars.tsv.xz")
 #'
 #' # format_* is useful for testing and reprexes
 #' cat(format_csv(head(mtcars)))
@@ -59,15 +67,9 @@
 #' format_csv(df, na = ".")
 #'
 #' # Quotes are automatically as needed
-#' df <- data.frame(x = c("a", '"', ",", "\n"))
+#' df <- data.frame(x = c("a ", '"', ",", "\n"))
 #' cat(format_csv(df))
-#'
-#' # A output connection will be automatically created for output filenames
-#' # with appropriate extensions.
-#' dir <- tempdir()
-#' write_tsv(mtcars, file.path(dir, "mtcars.tsv.gz"))
-#' write_tsv(mtcars, file.path(dir, "mtcars.tsv.bz2"))
-#' write_tsv(mtcars, file.path(dir, "mtcars.tsv.xz"))
+#' \dontshow{setwd(.old_wd)}
 write_delim <- function(x, path, delim = " ", na = "NA", append = FALSE,
                         col_names = !append, quote_escape = "double") {
   stopifnot(is.data.frame(x))

--- a/man/format_delim.Rd
+++ b/man/format_delim.Rd
@@ -71,9 +71,17 @@ the examples for more information.
 }
 
 \examples{
-tmp <- tempfile()
-write_csv(mtcars, tmp)
-head(read_csv(tmp))
+\dontshow{.old_wd <- setwd(tempdir())}
+# If you only specify a file name, write_()* will write
+# the file to your current working directory.
+write_csv(mtcars, "mtcars.csv")
+write_tsv(mtcars, "mtcars.tsv")
+
+# If you add an extension to the file name, write_()* will
+# automatically compress the output.
+write_tsv(mtcars, "mtcars.tsv.gz")
+write_tsv(mtcars, "mtcars.tsv.bz2")
+write_tsv(mtcars, "mtcars.tsv.xz")
 
 # format_* is useful for testing and reprexes
 cat(format_csv(head(mtcars)))
@@ -84,15 +92,9 @@ df <- data.frame(x = c(1, 2, NA))
 format_csv(df, na = ".")
 
 # Quotes are automatically as needed
-df <- data.frame(x = c("a", '"', ",", "\\n"))
+df <- data.frame(x = c("a ", '"', ",", "\\n"))
 cat(format_csv(df))
-
-# A output connection will be automatically created for output filenames
-# with appropriate extensions.
-dir <- tempdir()
-write_tsv(mtcars, file.path(dir, "mtcars.tsv.gz"))
-write_tsv(mtcars, file.path(dir, "mtcars.tsv.bz2"))
-write_tsv(mtcars, file.path(dir, "mtcars.tsv.xz"))
+\dontshow{setwd(.old_wd)}
 }
 \references{
 Florian Loitsch, Printing Floating-Point Numbers Quickly and

--- a/man/write_delim.Rd
+++ b/man/write_delim.Rd
@@ -82,9 +82,17 @@ the examples for more information.
 }
 
 \examples{
-tmp <- tempfile()
-write_csv(mtcars, tmp)
-head(read_csv(tmp))
+\dontshow{.old_wd <- setwd(tempdir())}
+# If you only specify a file name, write_()* will write
+# the file to your current working directory.
+write_csv(mtcars, "mtcars.csv")
+write_tsv(mtcars, "mtcars.tsv")
+
+# If you add an extension to the file name, write_()* will
+# automatically compress the output.
+write_tsv(mtcars, "mtcars.tsv.gz")
+write_tsv(mtcars, "mtcars.tsv.bz2")
+write_tsv(mtcars, "mtcars.tsv.xz")
 
 # format_* is useful for testing and reprexes
 cat(format_csv(head(mtcars)))
@@ -95,15 +103,9 @@ df <- data.frame(x = c(1, 2, NA))
 format_csv(df, na = ".")
 
 # Quotes are automatically as needed
-df <- data.frame(x = c("a", '"', ",", "\\n"))
+df <- data.frame(x = c("a ", '"', ",", "\\n"))
 cat(format_csv(df))
-
-# A output connection will be automatically created for output filenames
-# with appropriate extensions.
-dir <- tempdir()
-write_tsv(mtcars, file.path(dir, "mtcars.tsv.gz"))
-write_tsv(mtcars, file.path(dir, "mtcars.tsv.bz2"))
-write_tsv(mtcars, file.path(dir, "mtcars.tsv.xz"))
+\dontshow{setwd(.old_wd)}
 }
 \references{
 Florian Loitsch, Printing Floating-Point Numbers Quickly and


### PR DESCRIPTION
Implements changes suggested in #635 

Changes the examples so that they demonstrate write_*() behavior when you only specify a file name. Removes use of tempfile() and tempdir()