### PR TITLE
separate write_*() and format_*() examples

### DIFF
--- a/R/write.R
+++ b/R/write.R
@@ -58,17 +58,6 @@
 #' write_tsv(mtcars, "mtcars.tsv.bz2")
 #' write_tsv(mtcars, "mtcars.tsv.xz")
 #'
-#' # format_* is useful for testing and reprexes
-#' cat(format_csv(head(mtcars)))
-#' cat(format_tsv(head(mtcars)))
-#' cat(format_delim(head(mtcars), ";"))
-#'
-#' df <- data.frame(x = c(1, 2, NA))
-#' format_csv(df, na = ".")
-#'
-#' # Quotes are automatically as needed
-#' df <- data.frame(x = c("a ", '"', ",", "\n"))
-#' cat(format_csv(df))
 #' \dontshow{setwd(.old_wd)}
 write_delim <- function(x, path, delim = " ", na = "NA", append = FALSE,
                         col_names = !append, quote_escape = "double") {
@@ -140,7 +129,21 @@ write_tsv <- function(x, path, na = "NA", append = FALSE, col_names = !append, q
 #' of writing to disk, they return a string.
 #'
 #' @return A string.
-#' @inherit write_delim
+#' @inheritSection write_delim Output
+#' @inheritParams write_delim
+#' @inherit write_delim references
+#' @examples
+#' # format_()* functions are useful for testing and reprexes
+#' cat(format_csv(head(mtcars)))
+#' cat(format_tsv(head(mtcars)))
+#' cat(format_delim(head(mtcars), ";"))
+#'
+#' df <- data.frame(x = c(1, 2, NA))
+#' format_csv(df, na = ".")
+#'
+#' # Quotes are automatically added as needed
+#' df <- data.frame(x = c("a ", '"', ",", "\n"))
+#' cat(format_csv(df))
 #' @export
 format_delim <- function(x, delim, na = "NA", append = FALSE,
                          col_names = !append, quote_escape = "double") {

--- a/man/format_delim.Rd
+++ b/man/format_delim.Rd
@@ -71,19 +71,7 @@ the examples for more information.
 }
 
 \examples{
-\dontshow{.old_wd <- setwd(tempdir())}
-# If you only specify a file name, write_()* will write
-# the file to your current working directory.
-write_csv(mtcars, "mtcars.csv")
-write_tsv(mtcars, "mtcars.tsv")
-
-# If you add an extension to the file name, write_()* will
-# automatically compress the output.
-write_tsv(mtcars, "mtcars.tsv.gz")
-write_tsv(mtcars, "mtcars.tsv.bz2")
-write_tsv(mtcars, "mtcars.tsv.xz")
-
-# format_* is useful for testing and reprexes
+# format_()* functions are useful for testing and reprexes
 cat(format_csv(head(mtcars)))
 cat(format_tsv(head(mtcars)))
 cat(format_delim(head(mtcars), ";"))
@@ -91,10 +79,9 @@ cat(format_delim(head(mtcars), ";"))
 df <- data.frame(x = c(1, 2, NA))
 format_csv(df, na = ".")
 
-# Quotes are automatically as needed
+# Quotes are automatically added as needed
 df <- data.frame(x = c("a ", '"', ",", "\\n"))
 cat(format_csv(df))
-\dontshow{setwd(.old_wd)}
 }
 \references{
 Florian Loitsch, Printing Floating-Point Numbers Quickly and

--- a/man/write_delim.Rd
+++ b/man/write_delim.Rd
@@ -94,17 +94,6 @@ write_tsv(mtcars, "mtcars.tsv.gz")
 write_tsv(mtcars, "mtcars.tsv.bz2")
 write_tsv(mtcars, "mtcars.tsv.xz")
 
-# format_* is useful for testing and reprexes
-cat(format_csv(head(mtcars)))
-cat(format_tsv(head(mtcars)))
-cat(format_delim(head(mtcars), ";"))
-
-df <- data.frame(x = c(1, 2, NA))
-format_csv(df, na = ".")
-
-# Quotes are automatically as needed
-df <- data.frame(x = c("a ", '"', ",", "\\n"))
-cat(format_csv(df))
 \dontshow{setwd(.old_wd)}
 }
 \references{


### PR DESCRIPTION
- changes format_delim() documentation so that it no longer inherits examples from write_delim()
- removes write_*() examples from format_*() docs and format_*() examples from write_*() docs