### PR TITLE
Add early check for connections with empty data

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # readr (development version)
 
+* `read_delimited()` function return an empty `tibble::data_frame()` rather
+  than signaling an error when given a connection for the `file` argument that
+  contains no data. This makes the behavior consistent as when called with an
+  empty file (@pralitp, #963).
+
 # readr 1.3.1
 
 * Column specifications are now coloured when printed. This makes it easy to

--- a/R/read_delim.R
+++ b/R/read_delim.R
@@ -181,6 +181,9 @@ read_delimited <- function(file, tokenizer, col_names = TRUE, col_types = NULL,
   file <- standardise_path(file)
   if (is.connection(file)) {
     data <- datasource_connection(file, skip, skip_empty_rows, comment)
+    if (empty_file(data[[1]])) {
+       return(tibble::data_frame())
+    }
   } else {
     if (empty_file(file)) {
        return(tibble::data_frame())


### PR DESCRIPTION
Add an early check if a `datasource_connection` results in an `empty_file` and just return an empty tibble if so.  Fixes tidyverse/readr#963