### PR TITLE
Document how to silence `col_types` messages

### DIFF
--- a/R/read_delim.R
+++ b/R/read_delim.R
@@ -49,6 +49,10 @@ NULL
 #' - t = time
 #' - ? = guess
 #' - _ or - = skip
+#'
+#'    By default, reading a file without a column specification will print a
+#'    message showing what `readr` guessed they were. To remove this message,
+#'    use `col_types = cols()`.
 #' @param locale The locale controls defaults that vary from place to place.
 #'   The default locale is US-centric (like R), but you can use
 #'   [locale()] to create your own locale that controls things like


### PR DESCRIPTION
This PR simply adds one line to the documentation of `read_delim` in order to explain how to silence the `col_types` message that is printed out if the user does not provide a `cols()` specification.

Rationale:

- Some users do not need to see the "Parsed with column specification" messages that `readr` prints out when `col_types` is not defined by a user-provided `cols` object.

- Removing those messages is [easy in R Markdown](https://github.com/tidyverse/readr/issues/954), but not outside of it, unless the user adds `suppressMessages` calls everywhere in the code.

- Adding a `quiet` argument is far less elegant than [what @jimhester suggests](https://github.com/tidyverse/readr/issues/695): passing `col_types = cols()` (brilliant tip, thanks!).

This PR simply adds this tip to the end of the documentation for the `col_types` argument.

This way, `readr` can be used like other tidyverse data import packages `readxl` and `haven`, i.e. without printed messages on every `read_*` function call.

This will be useful to the user who needs e.g. to monitor the output of a script that merges (or binds) 100+ CSV files, which is not uncommon at all :-)