### PR TITLE
Fix typo in example of illogical date system.

### DIFF
--- a/vignettes/locales.Rmd
+++ b/vignettes/locales.Rmd
@@ -116,8 +116,8 @@ str(parse_guess("2010-10-10"))
 If you're an American, you might want to use your illogical date system::
 
 ```{r}
-str(parse_guess("01/02/2013"))
-str(parse_guess("01/02/2013", locale = locale(date_format = "%m/%d/%Y")))
+str(parse_guess("01/31/2013"))
+str(parse_guess("01/31/2013", locale = locale(date_format = "%m/%d/%Y")))
 ```
 
 ## Character

--- a/vignettes/locales.Rmd
+++ b/vignettes/locales.Rmd
@@ -113,11 +113,11 @@ Locales also provide default date and time formats. The time format isn't curren
 str(parse_guess("2010-10-10"))
 ```
 
-If you're an American, you might want you use your illogical date system::
+If you're an American, you might want to use your illogical date system::
 
 ```{r}
 str(parse_guess("01/02/2013"))
-str(parse_guess("01/02/2013", locale = locale(date_format = "%d/%m/%Y")))
+str(parse_guess("01/02/2013", locale = locale(date_format = "%m/%d/%Y")))
 ```
 
 ## Character


### PR DESCRIPTION
The locales vignette specifies the American date system as `"%d/%m/%Y"`, but the month should be first, i.e. `"%m/%d/%Y"`. In other words, in the American system 01/02/2013 is January 2nd, not February 1st.

https://github.com/tidyverse/readr/blob/0384d8792d6efd961eb1c3c6cdd4df5888c93a4a/vignettes/locales.Rmd#L120

The similar code in the test below has the correct order, so I assume the vignette is a typo:

https://github.com/tidyverse/readr/blob/05890c3b493458ad4699654ceed58d2515939e94/tests/testthat/test-parsing-datetime.R#L187

One suggestion to make the example less ambiguous would be to use a date such 01/31/2013, where it is clear that 31 must refer to the day (I'm happy to make that change to the vignette if you like).

I agree, the American date system is illogical!