### PR TITLE
Document time_format in locales vignette.

### DIFF
--- a/vignettes/locales.Rmd
+++ b/vignettes/locales.Rmd
@@ -107,10 +107,11 @@ df[is_datetime] <- lapply(df[is_datetime], function(x) {
 
 ### Default formats
 
-Locales also provide default date and time formats. The date format is used when guessing column types. The default date format is `%Y-%m-%d` because that's unambiguous:
+Locales also provide default date and time formats. The date format is used when guessing column types. The default date format is `%AD`, a flexible YMD parser (see `?parse_date`):
 
 ```{r}
 str(parse_guess("2010-10-10"))
+str(parse_guess("2010/10/10"))
 ```
 
 If you're an American, you might want you use your illogical date system::
@@ -120,10 +121,14 @@ str(parse_guess("01/02/2013"))
 str(parse_guess("01/02/2013", locale = locale(date_format = "%d/%m/%Y")))
 ```
 
-The time format is also used when guessing column types. The default time format is `%H:%M:%S`:
+The time format is also used when guessing column types. The default time format is `%AT`, a flexible HMS parser (see `?parse_time`):
 
 ```{r}
 str(parse_guess("17:55:14"))
+str(parse_guess("5:55:14 PM"))
+# Example of a non-standard time
+str(parse_guess("h5m55s14 PM"))
+str(parse_guess("h5m55s14 PM", locale = locale(time_format = "h%Hm%Ms%S %p")))
 ```
 
 ## Character

--- a/vignettes/locales.Rmd
+++ b/vignettes/locales.Rmd
@@ -107,7 +107,7 @@ df[is_datetime] <- lapply(df[is_datetime], function(x) {
 
 ### Default formats
 
-Locales also provide default date and time formats. The time format isn't currently used for anything, but the date format is used when guessing column types. The default date format is `%Y-%m-%d` because that's unambiguous:
+Locales also provide default date and time formats. The date format is used when guessing column types. The default date format is `%Y-%m-%d` because that's unambiguous:
 
 ```{r}
 str(parse_guess("2010-10-10"))
@@ -118,6 +118,12 @@ If you're an American, you might want you use your illogical date system::
 ```{r}
 str(parse_guess("01/02/2013"))
 str(parse_guess("01/02/2013", locale = locale(date_format = "%d/%m/%Y")))
+```
+
+The time format is also used when guessing column types. The default time format is `%H:%M:%S`:
+
+```{r}
+str(parse_guess("17:55:14"))
 ```
 
 ## Character


### PR DESCRIPTION
The locales vignette states that the argument `time_format` is not used for anything:

https://github.com/tidyverse/readr/blob/0384d8792d6efd961eb1c3c6cdd4df5888c93a4a/vignettes/locales.Rmd#L110

However as of readr [1.0.0](https://github.com/tidyverse/readr/blob/master/NEWS.md#readr-100), the `time_format` argument of `locale()` is used to guess the column type.

Furthermore, `local_time` can now be used to with `parse_time()`. Compare readr 1.3.1:

```
packageVersion("readr")
## [1] ‘1.3.1’
library(readr)
parse_time("01:02:03", locale = locale(time_format = "%H:%M:%S"))
## 01:02:03
parse_time("01:02:03", locale = locale(time_format = "%S:%M:%H"))
## 03:02:01
```

to 0.2.0:

```
packageVersion("readr")
## [1] ‘0.2.0’
library(readr)
parse_time("01:02:03", locale = locale(time_format = "%H:%M:%S"))
## [1] 1:02:03
parse_time("01:02:03", locale = locale(time_format = "%S:%M:%H"))
## [1] 1:02:03
```