### PR TITLE
`type_convert()` removes a 'spec' attribute

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,8 @@
 
 * More helpful error when trying to write out data frames with list columns (@ellessenne, #938)
 
+* `type_convert()` removes a 'spec' attribute, because the current columns likely have modified data types.  The 'spec' attribute is set by functions like `read_delim()` (@jimhester, @wibeasley, #1032).
+
 # readr 1.3.1
 
 * Column specifications are now coloured when printed. This makes it easy to

--- a/R/type_convert.R
+++ b/R/type_convert.R
@@ -12,6 +12,9 @@
 #'   If `NULL`, column types will be imputed using all rows.
 #' @inheritParams tokenizer_delim
 #' @inheritParams read_delim
+#' @note `type_convert()` removes a 'spec' attribute,
+#' because it likely modifies the column data types.
+#' (see [spec()] for more information about column specifications).
 #' @export
 #' @examples
 #' df <- data.frame(
@@ -61,6 +64,8 @@ type_convert <- function(df, col_types = NULL, na = c("", "NA"), trim_ws = TRUE,
     type_convert_col(char_cols[[i]], specs$cols[[i]], which(is_character)[i],
       locale_ = locale, na = na, trim_ws = trim_ws)
   })
+
+  attr(df, "spec") <- NULL
 
   df
 }

--- a/man/type_convert.Rd
+++ b/man/type_convert.Rd
@@ -33,6 +33,11 @@ columns in as character, clean it up with (e.g.) regular expressions and
 then let readr take another stab at parsing it. The name is a homage to
 the base \code{\link[utils:type.convert]{utils::type.convert()}}.
 }
+\note{
+\code{type_convert()} removes a 'spec' attribute,
+because it likely modifies the column data types.
+(see \code{\link[=spec]{spec()}} for more information about column specifications).
+}
 \examples{
 df <- data.frame(
   x = as.character(runif(10)),

--- a/tests/testthat/test-type-convert.R
+++ b/tests/testthat/test-type-convert.R
@@ -35,3 +35,18 @@ test_that("col_types accepts cols specifications", {
   # non-character cols silently ignored
   expect_equal(type_convert(df, col_types = cols(x = "c", y = "i")), df_conv)
 })
+test_that("spec attribute is removed", {
+  df1 <-
+    read_csv(
+      readr_example("mtcars.csv"),
+      col_types = cols(.default = col_character())
+    )
+
+  df2 <- type_convert(df1)
+
+  # The spec attribute should exist initially (b/c it's set by `read_csv()`).
+  expect_false(is.null(attr(df1, "spec")))
+
+  # The spec attribute should be cleared by `type_convert()`.
+  expect_null(attr(df2, "spec"))
+})


### PR DESCRIPTION
closes #1032

(I realize I'm bending the [acknowledgement style](https://style.tidyverse.org/news.html#acknowledgement) by including Jim in this bullet.  But it was his idea to remove the spec attribute, instead of update it.)