### PR TITLE
Fix in examples of read_fwf: cat() → writeLines()

### DIFF
--- a/R/read_fwf.R
+++ b/R/read_fwf.R
@@ -20,7 +20,7 @@
 #' @export
 #' @examples
 #' fwf_sample <- readr_example("fwf-sample.txt")
-#' cat(read_lines(fwf_sample))
+#' writeLines(read_lines(fwf_sample))
 #'
 #' # You can specify column positions in several ways:
 #' # 1. Guess based on position of empty columns


### PR DESCRIPTION
`writeLines()` shows the example data in a more representative way than `cat()`

``` r
library(readr)
fwf_sample <- readr_example("fwf-sample.txt")

cat(read_lines(fwf_sample))
#> John Smith          WA        418-Y11-4111 Mary Hartford       CA        319-Z19-4341 Evan Nolan          IL        219-532-c301

writeLines(read_lines(fwf_sample))
#> John Smith          WA        418-Y11-4111
#> Mary Hartford       CA        319-Z19-4341
#> Evan Nolan          IL        219-532-c301
```

<sup>Created on 2019-10-24 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>