### PR TITLE
write_*() functions again return identical data frame they were given

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # readr (development version)
 
+* The `write_*()` functions now invisibly return the input data frame unchanged,
+  rather than a version with factors and dates converted to strings. This is the
+  documented behavior (@jesse-ross, #975).
+
 * The full problem field is now displayed in the problems tibble, as intended
   (#444).
 

--- a/R/write.R
+++ b/R/write.R
@@ -63,11 +63,12 @@ write_delim <- function(x, path, delim = " ", na = "NA", append = FALSE,
                         col_names = !append, quote_escape = "double") {
   stopifnot(is.data.frame(x))
 
+  x_out <- x
   x[] <- lapply(names(x), function(i) output_column(x[[i]], i))
   stream_delim(x, path, delim = delim, col_names = col_names, append = append,
     na = na, quote_escape = quote_escape)
 
-  invisible(x)
+  invisible(x_out)
 }
 
 #' @rdname write_delim
@@ -82,9 +83,12 @@ write_csv <- function(x, path, na = "NA", append = FALSE, col_names = !append,
 #' @export
 write_csv2 <- function(x, path, na = "NA", append = FALSE, col_names = !append,
                        quote_escape = "double") {
+  x_out <- x
   x <- change_decimal_separator(x, decimal_mark = ",")
   write_delim(x, path, delim = ";", na = na, append = append,
     col_names = col_names, quote_escape = quote_escape)
+  
+  invisible(x_out)
 }
 
 #' @rdname write_delim
@@ -94,6 +98,7 @@ write_excel_csv <- function(x, path, na = "NA", append = FALSE,
 
   stopifnot(is.data.frame(x))
 
+  x_out <- x
   datetime_cols <- vapply(x, inherits, logical(1), "POSIXt")
   x[datetime_cols] <- lapply(x[datetime_cols], format, "%Y/%m/%d %H:%M:%S")
 
@@ -101,13 +106,14 @@ write_excel_csv <- function(x, path, na = "NA", append = FALSE,
   stream_delim(x, path, delim, col_names = col_names, append = append,
     na = na, bom = TRUE, quote_escape = quote_escape)
 
-  invisible(x)
+  invisible(x_out)
 }
 
 #' @rdname write_delim
 #' @export
 write_excel_csv2 <- function(x, path, na = "NA", append = FALSE,
                              col_names = !append, delim = ";", quote_escape = "double") {
+  x_out <- x
   x <- change_decimal_separator(x, decimal_mark = ",")
 
   datetime_cols <- vapply(x, inherits, logical(1), "POSIXt")
@@ -115,6 +121,8 @@ write_excel_csv2 <- function(x, path, na = "NA", append = FALSE,
 
   x[] <- lapply(x, output_column)
   write_excel_csv(x, path, na, append, col_names, delim, quote_escape = quote_escape)
+
+  invisible(x_out)
 }
 
 #' @rdname write_delim

--- a/tests/testthat/test-write.R
+++ b/tests/testthat/test-write.R
@@ -168,3 +168,31 @@ test_that("More helpful error when trying to write out data frames with list col
   df <- tibble::tibble(id = seq(1), list = list(1))
   expect_error(write_csv(x = df, path = tempfile()), "Flat files can't store the list column")
 })
+
+
+test_that("write_ family of functions return input data frame without changes", {
+  tmp <- tempfile()
+  on.exit(unlink(tmp))
+
+  time_strings <- c("2019-11-14 15:44:00", "2019-11-14 15:47:00")
+  times <- as.POSIXlt(time_strings, tz = "America/Los_Angeles")
+  df <- data.frame(time = times, class = factor(c("a", "b")))
+
+  df_delim <- write_delim(df, tmp)
+  expect_identical(df, df_delim)
+
+  df_csv <- write_csv(df, tmp)
+  expect_identical(df, df_csv)
+
+  df_csv2 <- write_csv2(df, tmp)
+  expect_identical(df, df_csv2)
+
+  df_excel_csv <- write_excel_csv(df, tmp)
+  expect_identical(df, df_excel_csv)
+
+  df_excel_csv2 <- write_excel_csv2(df, tmp)
+  expect_identical(df, df_excel_csv2)
+
+  df_tsv <- write_tsv(df, tmp)
+  expect_identical(df, df_tsv)
+})


### PR DESCRIPTION
The write_*() functions were no longer returning the input 'x' invisibly as stated in the documentation, but rather similar data frames with factors and datetimes converted to character columns.

This PR fixes that, so that the invisible return value is identical to 'x'.

Fixes #975 