### PR TITLE
add the close in on.exit before opening the connection

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # readr (development version)
 
+* The `read_*` functions now close properly all connections, including on 
+  errors like HTTP errors when reading from a url (@cderv, #1050).
+
 * `write_csv2` and `format_csv2` no longer pad number columns with whitespaces
   (@keesdeschepper, #1046).
 

--- a/R/source.R
+++ b/R/source.R
@@ -107,8 +107,8 @@ read_connection <- function(con) {
   stopifnot(is.connection(con))
 
   if (!isOpen(con)) {
-    open(con, "rb")
     on.exit(close(con), add = TRUE)
+    open(con, "rb")
   }
 
   read_connection_(con, tempfile())


### PR DESCRIPTION
This fixes #1050 by adding the `on.exit(close(con, add = TRUE))` before opening the connection as in other function like `write_file`
https://github.com/tidyverse/readr/blob/192cb1ca5c445e359f153d2259391e6d324fd0a2/R/file.R#L49-L58