### PR TITLE
Differentiate param `x`

### DIFF
--- a/R/file.R
+++ b/R/file.R
@@ -11,6 +11,7 @@
 #' @return
 #'   `read_file`: A length 1 character vector.
 #'   `read_lines_raw`: A raw vector.
+#' @param x A single string, or a raw vector to write to disk.
 #' @export
 #' @examples
 #' read_file(file.path(R.home("doc"), "AUTHORS"))

--- a/R/lines.R
+++ b/R/lines.R
@@ -12,6 +12,7 @@
 #'   file will be read.
 #' @return `read_lines()`: A character vector with one element for each line.
 #'   `read_lines_raw()`: A list containing a raw vector for each line.
+#' @param x A character vector or list of raw vectors to write to disk.
 #' @param sep The line separator. Defaults to `\\n`, commonly used on POSIX
 #' systems like macOS and linux. For native windows (CRLF) separators use
 #' `\\r\\n`.

--- a/R/write.R
+++ b/R/write.R
@@ -24,7 +24,7 @@
 #' extensions are supported, `.gz` for gzip compression, `.bz2` for bzip2 compression and `.xz` for lzma compression.  See
 #' the examples for more information.
 #'
-#' @param x A data frame to write to disk
+#' @param x A data frame to write to disk.
 #' @param path Path or connection to write to.
 #' @param append If `FALSE`, will overwrite existing file. If `TRUE`,
 #'   will append to existing file. In both cases, if file does not exist a new
@@ -139,6 +139,7 @@ write_tsv <- function(x, path, na = "NA", append = FALSE, col_names = !append, q
 #' @return A string.
 #' @inheritSection write_delim Output
 #' @inheritParams write_delim
+#' @param x A data frame.
 #' @inherit write_delim references
 #' @examples
 #' # format_()* functions are useful for testing and reprexes

--- a/man/format_delim.Rd
+++ b/man/format_delim.Rd
@@ -20,7 +20,7 @@ format_tsv(x, na = "NA", append = FALSE, col_names = !append,
   quote_escape = "double")
 }
 \arguments{
-\item{x}{A data frame to write to disk}
+\item{x}{A data frame.}
 
 \item{delim}{Delimiter used to separate values. Defaults to \code{" "} for \code{write_delim()}, \code{","} for \code{write_excel_csv()} and
 \code{";"} for \code{write_excel_csv2()}. Must be a single character.}

--- a/man/read_file.Rd
+++ b/man/read_file.Rd
@@ -34,7 +34,7 @@ The default locale is US-centric (like R), but you can use
 the default time zone, encoding, decimal mark, big mark, and day/month
 names.}
 
-\item{x}{A data frame to write to disk}
+\item{x}{A single string, or a raw vector to write to disk.}
 
 \item{path}{Path or connection to write to.}
 

--- a/man/read_lines.Rd
+++ b/man/read_lines.Rd
@@ -55,7 +55,7 @@ is updated every 50,000 values and will only display if estimated reading
 time is 5 seconds or more. The automatic progress bar can be disabled by
 setting option \code{readr.show_progress} to \code{FALSE}.}
 
-\item{x}{A data frame to write to disk}
+\item{x}{A character vector or list of raw vectors to write to disk.}
 
 \item{path}{Path or connection to write to.}
 

--- a/man/write_delim.Rd
+++ b/man/write_delim.Rd
@@ -28,7 +28,7 @@ write_tsv(x, path, na = "NA", append = FALSE, col_names = !append,
   quote_escape = "double")
 }
 \arguments{
-\item{x}{A data frame to write to disk}
+\item{x}{A data frame to write to disk.}
 
 \item{path}{Path or connection to write to.}
 


### PR DESCRIPTION
Before, the documentation for param `x` in `write_delim()` inside `R/write.R` **was reused** for `write_file()`, `write_lines()` and `format_*()` – which is obviously wrong. This PR redefines/overwrites the param `x` documentation where appropriate.