### PR TITLE
Add missing backticks.

### DIFF
--- a/R/write.R
+++ b/R/write.R
@@ -40,8 +40,8 @@
 #'   "double", "backslash" or "none". You can also use `FALSE`, which is
 #'   equivalent to "none". The default is to double the quotes, which is the
 #'   format excel expects.
-#' @param eol The end of line character to use. Most commonly either "\n" for
-#'   Unix style newlines, or "\r\n" for Windows style newlines.
+#' @param eol The end of line character to use. Most commonly either `"\n"` for
+#'   Unix style newlines, or `"\r\n"` for Windows style newlines.
 #' @return `write_*()` returns the input `x` invisibly.
 #' @references Florian Loitsch, Printing Floating-Point Numbers Quickly and
 #' Accurately with Integers, PLDI '10,

--- a/man/format_delim.Rd
+++ b/man/format_delim.Rd
@@ -66,8 +66,8 @@ file is created.}
 equivalent to "none". The default is to double the quotes, which is the
 format excel expects.}
 
-\item{eol}{The end of line character to use. Most commonly either "\n" for
-Unix style newlines, or "\r\n" for Windows style newlines.}
+\item{eol}{The end of line character to use. Most commonly either \code{"\\n"} for
+Unix style newlines, or \code{"\\r\\n"} for Windows style newlines.}
 }
 \value{
 A string.

--- a/man/write_delim.Rd
+++ b/man/write_delim.Rd
@@ -96,8 +96,8 @@ file is created.}
 equivalent to "none". The default is to double the quotes, which is the
 format excel expects.}
 
-\item{eol}{The end of line character to use. Most commonly either "\n" for
-Unix style newlines, or "\r\n" for Windows style newlines.}
+\item{eol}{The end of line character to use. Most commonly either \code{"\\n"} for
+Unix style newlines, or \code{"\\r\\n"} for Windows style newlines.}
 }
 \value{
 \verb{write_*()} returns the input \code{x} invisibly.


### PR DESCRIPTION
Backticks were skipped in documentation, so Rd file failed to parse