### PR TITLE
Update tibble::data_frame references to tibble::tibble

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -32,9 +32,7 @@
 
 * New `%h` placeholder for parsing unrestricted hours (<0 and >23) to support parsing durations (#549, @krlmlr).
 
-* Uses of `tibble::data_frame` updated to `tibble::tibble`
-([tidyverse/dplyr#4069](https://github.com/tidyverse/dplyr/issues/4069),
-@thays42)
+* Uses of `tibble::data_frame` updated to `tibble::tibble` ([tidyverse/dplyr#4069](https://github.com/tidyverse/dplyr/issues/4069), @thays42, #1124, @brianrice2)
 
 * `read_delimited()` function return an empty `tibble::data_frame()` rather
   than signaling an error when given a connection for the `file` argument that

--- a/R/read_delim.R
+++ b/R/read_delim.R
@@ -193,14 +193,14 @@ read_delimited <- function(file, tokenizer, col_names = TRUE, col_types = NULL,
   if (is.connection(file)) {
     data <- datasource_connection(file, skip, skip_empty_rows, comment)
     if (empty_file(data[[1]])) {
-       return(tibble::data_frame())
+       return(tibble::tibble())
     }
   } else {
     if (!isTRUE(grepl("\n", file)[[1]]) && empty_file(file)) {
        return(tibble::tibble())
     }
     if (is.character(file) && identical(locale$encoding, "UTF-8")) {
-      # When locale is not set, file is probablly marked as its correct encoding.
+      # When locale is not set, file is probably marked as its correct encoding.
       # As default_locale() assumes file is UTF-8, file should be encoded as UTF-8 for non-UTF-8 MBCS locales.
       data <- enc2utf8(file)
     } else {

--- a/tests/testthat/test-read-csv.R
+++ b/tests/testthat/test-read-csv.R
@@ -184,6 +184,12 @@ test_that("empty file with col_names and col_types creates correct columns", {
   expect_equal(class(x$b), "integer")
 })
 
+test_that("empty file returns an empty tibble", {
+  file.create("foo.csv")
+  expect_equal(read_csv("foo.csv"), tibble::tibble())
+  file.remove("foo.csv")
+})
+
 
 # Comments ----------------------------------------------------------------
 


### PR DESCRIPTION
tibble::data_frame is now deprecated but was still used for empty datasource connections. I found no change to passing tests or documentation.

Fixes #1099