### PR TITLE
update fread parser info

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -115,9 +115,7 @@ Compared to the corresponding base functions, readr functions:
 * Are slower (currently ~1.2-2x slower. If you want absolutely the best 
   performance, use `data.table::fread()`.
   
-* Use a slightly more sophisticated parser, recognising both 
-  doubled (`""""`) and backslash escapes (`"\""`), and can produce
-  factors and date/times directly.
+* Use a slightly more sophisticated parser.
   
 * Forces you to supply all parameters, where `fread()` saves you work by
   automatically guessing the delimiter, whether or not the file has a


### PR DESCRIPTION
I can imagine `readr` is more flexible on some of those, like handling various datetime formats etc. but in general listed operations seems to be working in DT already
```r
> str(fread(text="a,b\nz,x\n", stringsAsFactors=TRUE))
Classes 'data.table' and 'data.frame':	1 obs. of  2 variables:
 $ a: Factor w/ 1 level "z": 1
 $ b: Factor w/ 1 level "x": 1

> str(fread(text="a,b\nz,x\n", colClass=c("character","factor")))
Classes 'data.table' and 'data.frame':	1 obs. of  2 variables:
 $ a: chr "z"
 $ b: Factor w/ 1 level "x": 1

> str(fread(text="a,b\nz,2011-09-03\n"))
Classes 'data.table' and 'data.frame':	1 obs. of  2 variables:
 $ a: chr "z"
 $ b: IDate, format: "2011-09-03"

> str(fread(text="a,b\nz,2020-05-01T03:14:18.343Z\n"))
Classes 'data.table' and 'data.frame':	1 obs. of  2 variables:
 $ a: chr "z"
 $ b: POSIXct, format: "2020-05-01 03:14:18"

> str(fread(text='a,b\n"z",x\n', quote='"'))
Classes 'data.table' and 'data.frame':	1 obs. of  2 variables:
 $ a: chr "z"
 $ b: chr "x"

> str(fread(text='a,b\n\"z\",x\n', quote=""))
Classes 'data.table' and 'data.frame':	1 obs. of  2 variables:
 $ a: chr "\"z\""
 $ b: chr "x"
```
for datetime you need recent version 1.13.0