### PR TITLE
Fix escaping of % on col_date()/col_datetime()'s doc

### DIFF
--- a/R/collectors.R
+++ b/R/collectors.R
@@ -261,9 +261,9 @@ col_factor <- function(levels = NULL, ordered = FALSE, include_na = FALSE) {
 #' There are three types of element:
 #'
 #' \enumerate{
-#'   \item Date components are specified with "\%" followed by a letter.
-#'     For example "\%Y" matches a 4 digit year, "\%m", matches a 2 digit
-#'     month and "\%d" matches a 2 digit day. Month and day default to `1`,
+#'   \item Date components are specified with "%" followed by a letter.
+#'     For example "%Y" matches a 4 digit year, "%m", matches a 2 digit
+#'     month and "%d" matches a 2 digit day. Month and day default to `1`,
 #'     (i.e. Jan 1st) if not present, for example if only a year is given.
 #'   \item Whitespace is any sequence of zero or more whitespace characters.
 #'   \item Any other character is matched exactly.
@@ -271,26 +271,26 @@ col_factor <- function(levels = NULL, ordered = FALSE, include_na = FALSE) {
 #'
 #' `parse_datetime()` recognises the following format specifications:
 #' \itemize{
-#'   \item Year: "\%Y" (4 digits). "\%y" (2 digits); 00-69 -> 2000-2069,
+#'   \item Year: "%Y" (4 digits). "%y" (2 digits); 00-69 -> 2000-2069,
 #'     70-99 -> 1970-1999.
-#'   \item Month: "\%m" (2 digits), "\%b" (abbreviated name in current
-#'     locale), "\%B" (full name in current locale).
-#'   \item Day: "\%d" (2 digits), "\%e" (optional leading space),
+#'   \item Month: "%m" (2 digits), "%b" (abbreviated name in current
+#'     locale), "%B" (full name in current locale).
+#'   \item Day: "%d" (2 digits), "%e" (optional leading space),
 #'     "%a" (abbreviated name in current locale).
-#'   \item Hour: "\%H" or "\%I" or "\%h", use I (and not H) with AM/PM,
+#'   \item Hour: "%H" or "%I" or "%h", use I (and not H) with AM/PM,
 #'     use h (and not H) if your times represent durations longer than one day.
-#'   \item Minutes: "\%M"
-#'   \item Seconds: "\%S" (integer seconds), "\%OS" (partial seconds)
-#'   \item Time zone: "\%Z" (as name, e.g. "America/Chicago"), "\%z" (as
+#'   \item Minutes: "%M"
+#'   \item Seconds: "%S" (integer seconds), "%OS" (partial seconds)
+#'   \item Time zone: "%Z" (as name, e.g. "America/Chicago"), "%z" (as
 #'     offset from UTC, e.g. "+0800")
-#'   \item AM/PM indicator: "\%p".
-#'   \item Non-digits: "\%." skips one non-digit character,
-#'     "\%+" skips one or more non-digit characters,
-#'     "\%*" skips any number of non-digits characters.
-#'   \item Automatic parsers: "\%AD" parses with a flexible YMD parser,
-#'      "\%AT" parses with a flexible HMS parser.
-#'   \item Shortcuts: "\%D" = "\%m/\%d/\%y",  "\%F" = "\%Y-\%m-\%d",
-#'       "\%R" = "\%H:\%M", "\%T" = "\%H:\%M:\%S",  "\%x" = "\%y/\%m/\%d".
+#'   \item AM/PM indicator: "%p".
+#'   \item Non-digits: "%." skips one non-digit character,
+#'     "%+" skips one or more non-digit characters,
+#'     "%*" skips any number of non-digits characters.
+#'   \item Automatic parsers: "%AD" parses with a flexible YMD parser,
+#'      "%AT" parses with a flexible HMS parser.
+#'   \item Shortcuts: "%D" = "%m/%d/%y",  "%F" = "%Y-%m-%d",
+#'       "%R" = "%H:%M", "%T" = "%H:%M:%S",  "%x" = "%y/%m/%d".
 #' }
 #'
 #' @section ISO8601 support:

--- a/man/parse_datetime.Rd
+++ b/man/parse_datetime.Rd
@@ -76,9 +76,9 @@ Parse date/times
 There are three types of element:
 
 \enumerate{
-\item Date components are specified with "\\%" followed by a letter.
-For example "\\%Y" matches a 4 digit year, "\\%m", matches a 2 digit
-month and "\\%d" matches a 2 digit day. Month and day default to \code{1},
+\item Date components are specified with "\%" followed by a letter.
+For example "\%Y" matches a 4 digit year, "\%m", matches a 2 digit
+month and "\%d" matches a 2 digit day. Month and day default to \code{1},
 (i.e. Jan 1st) if not present, for example if only a year is given.
 \item Whitespace is any sequence of zero or more whitespace characters.
 \item Any other character is matched exactly.
@@ -86,26 +86,26 @@ month and "\\%d" matches a 2 digit day. Month and day default to \code{1},
 
 \code{parse_datetime()} recognises the following format specifications:
 \itemize{
-\item Year: "\\%Y" (4 digits). "\\%y" (2 digits); 00-69 -> 2000-2069,
+\item Year: "\%Y" (4 digits). "\%y" (2 digits); 00-69 -> 2000-2069,
 70-99 -> 1970-1999.
-\item Month: "\\%m" (2 digits), "\\%b" (abbreviated name in current
-locale), "\\%B" (full name in current locale).
-\item Day: "\\%d" (2 digits), "\\%e" (optional leading space),
+\item Month: "\%m" (2 digits), "\%b" (abbreviated name in current
+locale), "\%B" (full name in current locale).
+\item Day: "\%d" (2 digits), "\%e" (optional leading space),
 "\%a" (abbreviated name in current locale).
-\item Hour: "\\%H" or "\\%I" or "\\%h", use I (and not H) with AM/PM,
+\item Hour: "\%H" or "\%I" or "\%h", use I (and not H) with AM/PM,
 use h (and not H) if your times represent durations longer than one day.
-\item Minutes: "\\%M"
-\item Seconds: "\\%S" (integer seconds), "\\%OS" (partial seconds)
-\item Time zone: "\\%Z" (as name, e.g. "America/Chicago"), "\\%z" (as
+\item Minutes: "\%M"
+\item Seconds: "\%S" (integer seconds), "\%OS" (partial seconds)
+\item Time zone: "\%Z" (as name, e.g. "America/Chicago"), "\%z" (as
 offset from UTC, e.g. "+0800")
-\item AM/PM indicator: "\\%p".
-\item Non-digits: "\\%." skips one non-digit character,
-"\\%+" skips one or more non-digit characters,
-"\\%*" skips any number of non-digits characters.
-\item Automatic parsers: "\\%AD" parses with a flexible YMD parser,
-"\\%AT" parses with a flexible HMS parser.
-\item Shortcuts: "\\%D" = "\\%m/\\%d/\\%y",  "\\%F" = "\\%Y-\\%m-\\%d",
-"\\%R" = "\\%H:\\%M", "\\%T" = "\\%H:\\%M:\\%S",  "\\%x" = "\\%y/\\%m/\\%d".
+\item AM/PM indicator: "\%p".
+\item Non-digits: "\%." skips one non-digit character,
+"\%+" skips one or more non-digit characters,
+"\%*" skips any number of non-digits characters.
+\item Automatic parsers: "\%AD" parses with a flexible YMD parser,
+"\%AT" parses with a flexible HMS parser.
+\item Shortcuts: "\%D" = "\%m/\%d/\%y",  "\%F" = "\%Y-\%m-\%d",
+"\%R" = "\%H:\%M", "\%T" = "\%H:\%M:\%S",  "\%x" = "\%y/\%m/\%d".
 }
 }
 


### PR DESCRIPTION
It seems this part of the doc is now broken. Maybe this is forgotten to be unescaped when migrated to markdown format?

https://readr.tidyverse.org/reference/parse_datetime.html#format-specification:
![image](https://user-images.githubusercontent.com/1978793/97800949-88b4ba00-1c7c-11eb-9c7a-7df0312df368.png)
