### PR TITLE
Add minimal lifecycle version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,7 +46,7 @@ Imports:
     R6,
     tibble,
     utils,
-    lifecycle
+    lifecycle (>= 0.2.0)
 Suggests:
     covr,
     curl,


### PR DESCRIPTION
since readr uses `is_present()` https://github.com/r-lib/lifecycle/blob/master/NEWS.md#lifecycle-020