### PR TITLE
Add detail to documentation of `read_delim_chunked`

### DIFF
--- a/R/read_delim_chunked.R
+++ b/R/read_delim_chunked.R
@@ -55,6 +55,7 @@ read_delimited_chunked <- generate_read_delimited_chunked(read_delimited)
 #' @keywords internal
 #' @family chunked
 #' @export
+#' @details The number of lines in `file` can exceed the maximum integer value in R (~2 billion).
 #' @examples
 #' # Cars with 3 gears
 #' f <- function(x, pos) subset(x, gear == 3)

--- a/man/read_delim_chunked.Rd
+++ b/man/read_delim_chunked.Rd
@@ -178,7 +178,7 @@ values (the default) or strings.}
 \item{comment}{A string used to identify comments. Any text after the
 comment characters will be silently ignored.}
 
-\item{trim_ws}{Should leading and trailing whitespace (spaces and tabs) be trimmed from
+\item{trim_ws}{Should leading and trailing whitespace (ASCII spaces and tabs) be trimmed from
 each field before parsing it?}
 
 \item{skip}{Number of lines to skip before reading data. If \code{comment} is
@@ -197,6 +197,9 @@ option is \code{TRUE} then blank rows will not be represented at all.  If it is
 }
 \description{
 Read a delimited file by chunks
+}
+\details{
+The number of lines in \code{file} can exceed the maximum integer value in R (~2 billion).
 }
 \examples{
 # Cars with 3 gears


### PR DESCRIPTION
Add a detail to the `read_delim_chunked` documentation indicating that the number of lines in file can exceed R's MAX_INT value, per this [commit](https://github.com/tidyverse/readr/commit/c3169d0470bd570d8915b8212b6b00e6ad5594d9).