### PR TITLE
Fix incorrect column name w/ skipped column

### DIFF
--- a/R/read_delim.R
+++ b/R/read_delim.R
@@ -173,7 +173,7 @@ read_delim <- function(file, delim = NULL, quote = '"',
     lifecycle::deprecate_soft("2.0.0", "readr::read_delim(quoted_na = )")
   }
 
-  vroom::vroom(file,
+  out <- vroom::vroom(file,
     delim = delim, col_names = col_names, col_types = col_types,
     col_select = {{ col_select }},
     id = id,
@@ -194,6 +194,12 @@ read_delim <- function(file, delim = NULL, quote = '"',
     show_col_types = show_col_types,
     num_threads = num_threads
   )
+
+  if (!is.logical(col_names)) {
+    n <- min(length(col_names), length(out))
+    names(out)[seq_len(n)] <- col_names[seq_len(n)]
+  }
+  out
 }
 
 #' @rdname read_delim
@@ -235,7 +241,7 @@ read_csv <- function(file,
   if (!missing(quoted_na)) {
     lifecycle::deprecate_soft("2.0.0", "readr::read_csv(quoted_na = )")
   }
-  vroom::vroom(
+  out <- vroom::vroom(
     file,
     delim = ",",
     col_names = col_names,
@@ -259,6 +265,12 @@ read_csv <- function(file,
     altrep = lazy,
     num_threads = num_threads
   )
+
+  if (!is.logical(col_names)) {
+    n <- min(length(col_names), length(out))
+    names(out)[seq_len(n)] <- col_names[seq_len(n)]
+  }
+  out
 }
 
 #' @rdname read_delim
@@ -300,7 +312,7 @@ read_csv2 <- function(file,
       comment = comment, n_max = n_max, guess_max = guess_max, progress = progress
     ))
   }
-  vroom::vroom(file,
+  out <- vroom::vroom(file,
     delim = ";",
     col_names = col_names,
     col_types = col_types,
@@ -323,6 +335,12 @@ read_csv2 <- function(file,
     altrep = lazy,
     num_threads = num_threads
   )
+
+  if (!is.logical(col_names)) {
+    n <- min(length(col_names), length(out))
+    names(out)[seq_len(n)] <- col_names[seq_len(n)]
+  }
+  out
 }
 
 #' @rdname read_delim
@@ -350,7 +368,7 @@ read_tsv <- function(file, col_names = TRUE, col_types = NULL,
     ))
   }
 
-  vroom::vroom(file,
+  out <- vroom::vroom(file,
     delim = "\t",
     col_names = col_names,
     col_types = col_types,
@@ -368,6 +386,12 @@ read_tsv <- function(file, col_names = TRUE, col_types = NULL,
     altrep = lazy,
     num_threads = num_threads
   )
+
+  if (!is.logical(col_names)) {
+    n <- min(length(col_names), length(out))
+    names(out)[seq_len(n)] <- col_names[seq_len(n)]
+  }
+  out
 }
 
 # Helper functions for reading from delimited files ----------------------------


### PR DESCRIPTION
Fix #1215 

Rename columns after reading result by `vroom`. There is a little difference between this fix and `1.4.0`'s when `col_names`'s length is greater than skipped `col_types` 😞 But I think this one's is more reasonable.

- Before

``` r
devtools::load_all("E:/Projects/Repos/readr")
#> i<U+00A0>Loading readr
#> Warning in parse(con, n = -1, srcfile = srcfile, encoding = "UTF-8"): argument
#> encoding="UTF-8" is ignored in MBCS locales
read_csv(I("1,2,3\n3,4,5\n5,6,7"), col_names = c("a"), col_types = "i-i")
#> # A tibble: 3 x 2
#>       a    X3
#>   <int> <int>
#> 1     1     3
#> 2     3     5
#> 3     5     7
read_csv(I("1,2,3\n3,4,5\n5,6,7"), col_names = c("a", "b"), col_types = "i-i")
#> # A tibble: 3 x 2
#>       a    X3
#>   <int> <int>
#> 1     1     3
#> 2     3     5
#> 3     5     7
read_csv(I("1,2,3\n3,4,5\n5,6,7"), col_names = c("a", "b", "c", "d"), col_types = "i-i")
#> # A tibble: 3 x 2
#>       a     c
#>   <int> <int>
#> 1     1     3
#> 2     3     5
#> 3     5     7
```

- After

``` r
devtools::load_all("E:/Projects/Repos/readr")
#> i<U+00A0>Loading readr
#> Warning in parse(con, n = -1, srcfile = srcfile, encoding = "UTF-8"): argument
#> encoding="UTF-8" is ignored in MBCS locales
read_csv(I("1,2,3\n3,4,5\n5,6,7"), col_names = c("a"), col_types = "i-i")
#> # A tibble: 3 x 2
#>       a    X3
#>   <int> <int>
#> 1     1     3
#> 2     3     5
#> 3     5     7
read_csv(I("1,2,3\n3,4,5\n5,6,7"), col_names = c("a", "b"), col_types = "i-i")
#> # A tibble: 3 x 2
#>       a     b
#>   <int> <int>
#> 1     1     3
#> 2     3     5
#> 3     5     7
read_csv(I("1,2,3\n3,4,5\n5,6,7"), col_names = c("a", "b", "c", "d"), col_types = "i-i")
#> # A tibble: 3 x 2
#>       a     b
#>   <int> <int>
#> 1     1     3
#> 2     3     5
#> 3     5     7
```

- 1.4.0

``` r
sessioninfo::package_info("readr", dependencies = FALSE)
#>  package * version date       lib source        
#>  readr     1.4.0   2020-10-05 [1] CRAN (R 4.1.0)
#> 
#> [1] E:/Documents/R/win-library/4.1
#> [2] D:/Scoop/apps/r/4.1.0/library
readr::read_csv(I("1,2,3\n3,4,5\n5,6,7"), col_names = c("a"), col_types = "i-i")
#> Warning: Insufficient `col_names`. Adding 1 names.
#> # A tibble: 3 x 2
#>       a    X2
#>   <int> <int>
#> 1     1     3
#> 2     3     5
#> 3     5     7
readr::read_csv(I("1,2,3\n3,4,5\n5,6,7"), col_names = c("a", "b"), col_types = "i-i")
#> # A tibble: 3 x 2
#>       a     b
#>   <int> <int>
#> 1     1     3
#> 2     3     5
#> 3     5     7
readr::read_csv(I("1,2,3\n3,4,5\n5,6,7"), col_names = c("a", "b", "c", "d"), col_types = "i-i")
#> Warning: Insufficient `col_types`. Guessing 2 columns.
#> Warning: 3 parsing failures.
#> row col  expected    actual         file
#>   1  -- 4 columns 3 columns literal data
#>   2  -- 4 columns 3 columns literal data
#>   3  -- 4 columns 3 columns literal data
#> # A tibble: 3 x 3
#>       a     c d    
#>   <int> <int> <chr>
#> 1     1     3 <NA> 
#> 2     3     5 <NA> 
#> 3     5     7 <NA>
```
