### PR TITLE
Compatibility with dev testthat

### DIFF
--- a/tests/testthat/test-read-lines.R
+++ b/tests/testthat/test-read-lines.R
@@ -11,7 +11,7 @@ test_that("read_lines returns an empty character vector on an empty file", {
 
 test_that("read_lines handles embedded nuls", {
   skip_if_edition_first()
-  res <- expect_warning(read_lines(test_path("null-file"), lazy = FALSE))
+  expect_warning(res <- read_lines(test_path("null-file"), lazy = FALSE))
   expect_equal(res, c("a,b,c", "1,2,", "3,4,5"))
 })
 


### PR DESCRIPTION
`expect_warning()` and `expect_message()` will now return the conditions instead of the value, consistently with `expect_error()`.

We're planning to release end of this week, see https://github.com/r-lib/testthat/issues/1454. A patch release would be great :)