### PR TITLE
Add meltr link to documentation

### DIFF
--- a/R/melt_delim.R
+++ b/R/melt_delim.R
@@ -1,7 +1,8 @@
 #' Return melted data for each token in a delimited file (including csv & tsv)
 #'
 #' `r lifecycle::badge("superseded")`
-#' This function has been superseded in readr and moved to the meltr package.
+#' This function has been superseded in readr and moved to [the meltr
+#' package](https://r-lib.github.io/meltr/).
 #'
 #' For certain non-rectangular data formats, it can be useful to parse the data
 #' into a melted format where each row represents a single token.

--- a/R/melt_fwf.R
+++ b/R/melt_fwf.R
@@ -3,7 +3,8 @@
 #' Return melted data for each token in a fixed width file
 #'
 #' `r lifecycle::badge("superseded")`
-#' This function has been superseded in readr and moved to the meltr package.
+#' This function has been superseded in readr and moved to [the meltr
+#' package](https://r-lib.github.io/meltr/).
 #'
 #' For certain non-rectangular data formats, it can be useful to parse the data
 #' into a melted format where each row represents a single token.

--- a/R/melt_table.R
+++ b/R/melt_table.R
@@ -2,7 +2,8 @@
 #'
 #' @description
 #' `r lifecycle::badge("superseded")`
-#' This function has been superseded in readr and moved to the meltr package.
+#' This function has been superseded in readr and moved to [the meltr
+#' package](https://r-lib.github.io/meltr/).
 #'
 #' For certain non-rectangular data formats, it can be useful to parse the data
 #' into a melted format where each row represents a single token.

--- a/man/melt_delim.Rd
+++ b/man/melt_delim.Rd
@@ -144,7 +144,7 @@ how many, and you can retrieve the details with \code{\link[=problems]{problems(
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#superseded}{\figure{lifecycle-superseded.svg}{options: alt='[Superseded]'}}}{\strong{[Superseded]}}
-This function has been superseded in readr and moved to the meltr package.
+This function has been superseded in readr and moved to \href{https://r-lib.github.io/meltr/}{the meltr package}.
 }
 \details{
 For certain non-rectangular data formats, it can be useful to parse the data

--- a/man/melt_fwf.Rd
+++ b/man/melt_fwf.Rd
@@ -69,7 +69,7 @@ option is \code{TRUE} then blank rows will not be represented at all.  If it is
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#superseded}{\figure{lifecycle-superseded.svg}{options: alt='[Superseded]'}}}{\strong{[Superseded]}}
-This function has been superseded in readr and moved to the meltr package.
+This function has been superseded in readr and moved to \href{https://r-lib.github.io/meltr/}{the meltr package}.
 }
 \details{
 For certain non-rectangular data formats, it can be useful to parse the data

--- a/man/melt_table.Rd
+++ b/man/melt_table.Rd
@@ -74,7 +74,7 @@ option is \code{TRUE} then blank rows will not be represented at all.  If it is
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#superseded}{\figure{lifecycle-superseded.svg}{options: alt='[Superseded]'}}}{\strong{[Superseded]}}
-This function has been superseded in readr and moved to the meltr package.
+This function has been superseded in readr and moved to \href{https://r-lib.github.io/meltr/}{the meltr package}.
 
 For certain non-rectangular data formats, it can be useful to parse the data
 into a melted format where each row represents a single token.


### PR DESCRIPTION
For convenience of users wanting to jump straight to the package. I ran the Document button in RStudio that ultimately runs `devtools::document(roclets = c('rd', 'collate', 'namespace'))` and only committed the relevant changes to this PR. Open to feedback and other changes.