### PR TITLE
Add support for show_col_types for edition 1 parser

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 * Jenny Bryan is now the maintainer.
 
 * `read_table()` and edition 1 parsers gain support for `show_col_types()` (#1331)
+* `read_table()`, `read_log()`, and `read_delim_chunked()` (and friends) gain the `show_col_types` argument found elsewhere. All `read_*()` functions now respect the `show_col_types` argument or option even when using the first edition parsing engine (#1331).
 * Fix buffer overflow when trying to parse an integer from a field that is over 64 characters long (#1326)
 
 # readr 2.1.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 
 * Jenny Bryan is now the maintainer.
 
+* `read_table()` and edition 1 parsers gain support for `show_col_types()` (#1331)
 * Fix buffer overflow when trying to parse an integer from a field that is over 64 characters long (#1326)
 
 # readr 2.1.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,11 +1,11 @@
 # readr (development version)
 
+* `read_table()`, `read_log()`, and `read_delim_chunked()` (and friends) gain the `show_col_types` argument found elsewhere. All `read_*()` functions now respect the `show_col_types` argument or option even when using the first edition parsing engine (#1331).
+
 # readr 2.1.1
 
 * Jenny Bryan is now the maintainer.
 
-* `read_table()` and edition 1 parsers gain support for `show_col_types()` (#1331)
-* `read_table()`, `read_log()`, and `read_delim_chunked()` (and friends) gain the `show_col_types` argument found elsewhere. All `read_*()` functions now respect the `show_col_types` argument or option even when using the first edition parsing engine (#1331).
 * Fix buffer overflow when trying to parse an integer from a field that is over 64 characters long (#1326)
 
 # readr 2.1.0

--- a/R/read_delim.R
+++ b/R/read_delim.R
@@ -390,13 +390,6 @@ read_tokens <- function(data, tokenizer, col_specs, col_names, locale_, n_max, p
   read_tokens_(data, tokenizer, col_specs, col_names, locale_, n_max, progress)
 }
 
-should_show_col_types <- function(has_col_types, show_col_types) {
-  if (is.null(show_col_types)) {
-    return(isTRUE(!has_col_types))
-  }
-  isTRUE(show_col_types)
-}
-
 read_delimited <- function(file, tokenizer, col_names = TRUE, col_types = NULL,
                            locale = default_locale(), skip = 0, skip_empty_rows = TRUE, skip_quote = TRUE,
                            comment = "", n_max = Inf, guess_max = min(1000, n_max), progress = show_progress(),

--- a/R/read_delim.R
+++ b/R/read_delim.R
@@ -427,7 +427,10 @@ read_delimited <- function(file, tokenizer, col_names = TRUE, col_types = NULL,
 
   has_col_types <- !is.null(col_types)
 
-  if (((is.null(show_col_types) && !has_col_types) || isTRUE(show_col_types)) && !inherits(ds, "source_string") && !is_testing()) {
+  if (
+    ((is.null(show_col_types) && !has_col_types) || isTRUE(show_col_types)) &&
+    !inherits(ds, "source_string")
+  ) {
     show_cols_spec(spec)
   }
 

--- a/R/read_delim.R
+++ b/R/read_delim.R
@@ -169,7 +169,8 @@ read_delim <- function(file, delim = NULL, quote = '"',
     return(read_delimited(file, tokenizer,
       col_names = col_names, col_types = col_types,
       locale = locale, skip = skip, skip_empty_rows = skip_empty_rows,
-      comment = comment, n_max = n_max, guess_max = guess_max, progress = progress
+      comment = comment, n_max = n_max, guess_max = guess_max, progress = progress,
+      show_col_types = show_col_types
     ))
   }
   if (!missing(quoted_na)) {
@@ -230,7 +231,8 @@ read_csv <- function(file,
       read_delimited(file, tokenizer,
         col_names = col_names, col_types = col_types,
         locale = locale, skip = skip, skip_empty_rows = skip_empty_rows,
-        comment = comment, n_max = n_max, guess_max = guess_max, progress = progress
+        comment = comment, n_max = n_max, guess_max = guess_max, progress = progress,
+        show_col_types = show_col_types
       )
     )
   }
@@ -300,7 +302,8 @@ read_csv2 <- function(file,
     return(read_delimited(file, tokenizer,
       col_names = col_names, col_types = col_types,
       locale = locale, skip = skip, skip_empty_rows = skip_empty_rows,
-      comment = comment, n_max = n_max, guess_max = guess_max, progress = progress
+      comment = comment, n_max = n_max, guess_max = guess_max, progress = progress,
+      show_col_types = show_col_types
     ))
   }
   vroom::vroom(file,
@@ -349,7 +352,8 @@ read_tsv <- function(file, col_names = TRUE, col_types = NULL,
     return(read_delimited(file, tokenizer,
       col_names = col_names, col_types = col_types,
       locale = locale, skip = skip, skip_empty_rows = skip_empty_rows,
-      comment = comment, n_max = n_max, guess_max = guess_max, progress = progress
+      comment = comment, n_max = n_max, guess_max = guess_max, progress = progress,
+      show_col_types = show_col_types
     ))
   }
 
@@ -386,9 +390,17 @@ read_tokens <- function(data, tokenizer, col_specs, col_names, locale_, n_max, p
   read_tokens_(data, tokenizer, col_specs, col_names, locale_, n_max, progress)
 }
 
+should_show_col_types <- function(has_col_types, show_col_types) {
+  if (is.null(show_col_types)) {
+    return(isTRUE(!has_col_types))
+  }
+  isTRUE(show_col_types)
+}
+
 read_delimited <- function(file, tokenizer, col_names = TRUE, col_types = NULL,
                            locale = default_locale(), skip = 0, skip_empty_rows = TRUE, skip_quote = TRUE,
-                           comment = "", n_max = Inf, guess_max = min(1000, n_max), progress = show_progress()) {
+                           comment = "", n_max = Inf, guess_max = min(1000, n_max), progress = show_progress(),
+                           show_col_types = should_show_col_types()) {
   name <- source_name(file)
   # If connection needed, read once.
   file <- standardise_path(file)
@@ -420,7 +432,9 @@ read_delimited <- function(file, tokenizer, col_names = TRUE, col_types = NULL,
 
   ds <- datasource(data, skip = spec$skip, skip_empty_rows = skip_empty_rows, comment = comment, skip_quote = skip_quote)
 
-  if (is.null(col_types) && !inherits(ds, "source_string") && !is_testing()) {
+  has_col_types <- !is.null(col_types)
+
+  if (((is.null(show_col_types) && !has_col_types) || isTRUE(show_col_types)) && !inherits(ds, "source_string") && !is_testing()) {
     show_cols_spec(spec)
   }
 

--- a/R/read_delim.R
+++ b/R/read_delim.R
@@ -393,7 +393,7 @@ read_tokens <- function(data, tokenizer, col_specs, col_names, locale_, n_max, p
 read_delimited <- function(file, tokenizer, col_names = TRUE, col_types = NULL,
                            locale = default_locale(), skip = 0, skip_empty_rows = TRUE, skip_quote = TRUE,
                            comment = "", n_max = Inf, guess_max = min(1000, n_max), progress = show_progress(),
-                           show_col_types = should_show_col_types()) {
+                           show_col_types = should_show_types()) {
   name <- source_name(file)
   # If connection needed, read once.
   file <- standardise_path(file)

--- a/R/read_delim_chunked.R
+++ b/R/read_delim_chunked.R
@@ -68,6 +68,7 @@ read_delim_chunked <- function(file, callback, delim = NULL, chunk_size = 10000,
                                comment = "", trim_ws = FALSE,
                                skip = 0, guess_max = chunk_size,
                                progress = show_progress(),
+                               show_col_types = should_show_types(),
                                skip_empty_rows = TRUE) {
   tokenizer <- tokenizer_delim(delim,
     quote = quote,
@@ -79,7 +80,8 @@ read_delim_chunked <- function(file, callback, delim = NULL, chunk_size = 10000,
     callback = callback, chunk_size = chunk_size, tokenizer = tokenizer,
     col_names = col_names, col_types = col_types, locale = locale, skip = skip,
     skip_empty_rows = skip_empty_rows, comment = comment, guess_max = guess_max,
-    progress = progress
+    progress = progress,
+    show_col_types = show_col_types
   )
 }
 
@@ -89,7 +91,9 @@ read_csv_chunked <- function(file, callback, chunk_size = 10000, col_names = TRU
                              locale = default_locale(), na = c("", "NA"),
                              quoted_na = TRUE, quote = "\"", comment = "", trim_ws = TRUE,
                              skip = 0, guess_max = chunk_size,
-                             progress = show_progress(), skip_empty_rows = TRUE) {
+                             progress = show_progress(),
+                             show_col_types = should_show_types(),
+                             skip_empty_rows = TRUE) {
   tokenizer <- tokenizer_csv(
     na = na, quoted_na = quoted_na, quote = quote,
     comment = comment, trim_ws = trim_ws, skip_empty_rows = skip_empty_rows
@@ -98,7 +102,8 @@ read_csv_chunked <- function(file, callback, chunk_size = 10000, col_names = TRU
     callback = callback, chunk_size = chunk_size,
     tokenizer = tokenizer, col_names = col_names, col_types = col_types, locale = locale,
     skip = skip, skip_empty_rows = skip_empty_rows, comment = comment,
-    guess_max = guess_max, progress = progress
+    guess_max = guess_max, progress = progress,
+    show_col_types = show_col_types
   )
 }
 
@@ -108,7 +113,9 @@ read_csv2_chunked <- function(file, callback, chunk_size = 10000, col_names = TR
                               locale = default_locale(), na = c("", "NA"),
                               quoted_na = TRUE, quote = "\"", comment = "", trim_ws = TRUE,
                               skip = 0, guess_max = chunk_size,
-                              progress = show_progress(), skip_empty_rows = TRUE) {
+                              progress = show_progress(),
+                              show_col_types = should_show_types(),
+                              skip_empty_rows = TRUE) {
   tokenizer <- tokenizer_delim(
     delim = ";", na = na, quoted_na = quoted_na,
     quote = quote, comment = comment, trim_ws = trim_ws,
@@ -118,7 +125,8 @@ read_csv2_chunked <- function(file, callback, chunk_size = 10000, col_names = TR
     callback = callback, chunk_size = chunk_size,
     tokenizer = tokenizer, col_names = col_names, col_types = col_types, locale = locale,
     skip = skip, skip_empty_rows = skip_empty_rows, comment = comment,
-    guess_max = guess_max, progress = progress
+    guess_max = guess_max, progress = progress,
+    show_col_types = show_col_types
   )
 }
 
@@ -128,7 +136,9 @@ read_tsv_chunked <- function(file, callback, chunk_size = 10000, col_names = TRU
                              locale = default_locale(), na = c("", "NA"),
                              quoted_na = TRUE, quote = "\"", comment = "", trim_ws = TRUE,
                              skip = 0, guess_max = chunk_size,
-                             progress = show_progress(), skip_empty_rows = TRUE) {
+                             progress = show_progress(),
+                             show_col_types = should_show_types(),
+                             skip_empty_rows = TRUE) {
   tokenizer <- tokenizer_tsv(
     na = na, quoted_na = quoted_na, quote = quote,
     comment = comment, trim_ws = trim_ws, skip_empty_rows = skip_empty_rows
@@ -137,6 +147,7 @@ read_tsv_chunked <- function(file, callback, chunk_size = 10000, col_names = TRU
     callback = callback, chunk_size = chunk_size,
     tokenizer = tokenizer, col_names = col_names, col_types = col_types, locale = locale,
     skip = skip, skip_empty_rows = skip_empty_rows, comment = comment,
-    guess_max = guess_max, progress = progress
+    guess_max = guess_max, progress = progress,
+    show_col_types = show_col_types
   )
 }

--- a/R/read_log.R
+++ b/R/read_log.R
@@ -10,10 +10,13 @@
 #' read_log(readr_example("example.log"))
 read_log <- function(file, col_names = FALSE, col_types = NULL,
                      trim_ws = TRUE,
-                     skip = 0, n_max = Inf, progress = show_progress()) {
+                     skip = 0, n_max = Inf,
+                     show_col_types = should_show_types(),
+                     progress = show_progress()) {
   tokenizer <- tokenizer_log(trim_ws = trim_ws)
   read_delimited(file, tokenizer,
     col_names = col_names, col_types = col_types,
-    skip = skip, n_max = n_max, progress = progress
+    skip = skip, n_max = n_max, progress = progress,
+    show_col_types = show_col_types
   )
 }

--- a/R/read_table.R
+++ b/R/read_table.R
@@ -34,6 +34,7 @@ read_table <- function(file, col_names = TRUE, col_types = NULL,
                         locale = default_locale(), na = "NA", skip = 0,
                         n_max = Inf, guess_max = min(n_max, 1000),
                         progress = show_progress(), comment = "",
+                        show_col_types = should_show_types(),
                         skip_empty_rows = TRUE) {
   tokenizer <- tokenizer_ws(
     na = na, comment = comment,
@@ -42,7 +43,8 @@ read_table <- function(file, col_names = TRUE, col_types = NULL,
   read_delimited(file, tokenizer,
     col_names = col_names, col_types = col_types,
     locale = locale, skip = skip, skip_empty_rows = skip_empty_rows,
-    skip_quote = FALSE, comment = comment, n_max = n_max, guess_max = guess_max, progress = progress
+    skip_quote = FALSE, comment = comment, n_max = n_max, guess_max = guess_max, progress = progress,
+    show_col_types = show_col_types
   )
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -27,12 +27,22 @@ show_progress <- function() {
 
 #' Determine whether column types should be shown
 #'
-#' Column types are shown unless
-#' - They are disabled by setting `options(readr.show_col_types = FALSE)`
-#' - The column types are supplied with the `col_types` argument.
+#' Wrapper around `getOption("readr.show_col_types")` that implements some fall
+#' back logic if the option is unset. This returns:
+#' * `TRUE` if the option is set to `TRUE`
+#' * `FALSE` if the option is set to `FALSE`
+#' * `FALSE` if the option is unset and we appear to be running tests
+#' * `NULL` otherwise, in which case the caller determines whether to show
+#'   column types based on context, e.g. whether `show_col_types` or actual
+#'   `col_types` were explicitly specified
 #' @export
 should_show_types <- function() {
-  if (identical(getOption("readr.show_col_types", TRUE), FALSE)) {
+  opt <- getOption("readr.show_col_types", NA)
+  if (isTRUE(opt)) {
+    TRUE
+  } else if (identical(opt, FALSE)) {
+    FALSE
+  } else if (is.na(opt) && is_testing()) {
     FALSE
   } else {
     NULL

--- a/man/read_delim_chunked.Rd
+++ b/man/read_delim_chunked.Rd
@@ -25,6 +25,7 @@ read_delim_chunked(
   skip = 0,
   guess_max = chunk_size,
   progress = show_progress(),
+  show_col_types = should_show_types(),
   skip_empty_rows = TRUE
 )
 
@@ -43,6 +44,7 @@ read_csv_chunked(
   skip = 0,
   guess_max = chunk_size,
   progress = show_progress(),
+  show_col_types = should_show_types(),
   skip_empty_rows = TRUE
 )
 
@@ -61,6 +63,7 @@ read_csv2_chunked(
   skip = 0,
   guess_max = chunk_size,
   progress = show_progress(),
+  show_col_types = should_show_types(),
   skip_empty_rows = TRUE
 )
 
@@ -79,6 +82,7 @@ read_tsv_chunked(
   skip = 0,
   guess_max = chunk_size,
   progress = show_progress(),
+  show_col_types = should_show_types(),
   skip_empty_rows = TRUE
 )
 }
@@ -191,6 +195,11 @@ supplied any commented lines are ignored \emph{after} skipping.}
 in an interactive session and not while knitting a document. The automatic
 progress bar can be disabled by setting option \code{readr.show_progress} to
 \code{FALSE}.}
+
+\item{show_col_types}{If \code{FALSE}, do not show the guessed column types. If
+\code{TRUE} always show the column types, even if they are supplied. If \code{NULL}
+(the default) only show the column types if they are not explicitly supplied
+by the \code{col_types} argument.}
 
 \item{skip_empty_rows}{Should blank rows be ignored altogether? i.e. If this
 option is \code{TRUE} then blank rows will not be represented at all.  If it is

--- a/man/read_log.Rd
+++ b/man/read_log.Rd
@@ -11,6 +11,7 @@ read_log(
   trim_ws = TRUE,
   skip = 0,
   n_max = Inf,
+  show_col_types = should_show_types(),
   progress = show_progress()
 )
 }
@@ -86,6 +87,11 @@ each field before parsing it?}
 supplied any commented lines are ignored \emph{after} skipping.}
 
 \item{n_max}{Maximum number of lines to read.}
+
+\item{show_col_types}{If \code{FALSE}, do not show the guessed column types. If
+\code{TRUE} always show the column types, even if they are supplied. If \code{NULL}
+(the default) only show the column types if they are not explicitly supplied
+by the \code{col_types} argument.}
 
 \item{progress}{Display a progress bar? By default it will only display
 in an interactive session and not while knitting a document. The automatic

--- a/man/read_table.Rd
+++ b/man/read_table.Rd
@@ -15,6 +15,7 @@ read_table(
   guess_max = min(n_max, 1000),
   progress = show_progress(),
   comment = "",
+  show_col_types = should_show_types(),
   skip_empty_rows = TRUE
 )
 }
@@ -105,6 +106,11 @@ progress bar can be disabled by setting option \code{readr.show_progress} to
 
 \item{comment}{A string used to identify comments. Any text after the
 comment characters will be silently ignored.}
+
+\item{show_col_types}{If \code{FALSE}, do not show the guessed column types. If
+\code{TRUE} always show the column types, even if they are supplied. If \code{NULL}
+(the default) only show the column types if they are not explicitly supplied
+by the \code{col_types} argument.}
 
 \item{skip_empty_rows}{Should blank rows be ignored altogether? i.e. If this
 option is \code{TRUE} then blank rows will not be represented at all.  If it is

--- a/man/should_show_types.Rd
+++ b/man/should_show_types.Rd
@@ -7,9 +7,14 @@
 should_show_types()
 }
 \description{
-Column types are shown unless
+Wrapper around \code{getOption("readr.show_col_types")} that implements some fall
+back logic if the option is unset. This returns:
 \itemize{
-\item They are disabled by setting \code{options(readr.show_col_types = FALSE)}
-\item The column types are supplied with the \code{col_types} argument.
+\item \code{TRUE} if the option is set to \code{TRUE}
+\item \code{FALSE} if the option is set to \code{FALSE}
+\item \code{FALSE} if the option is unset and we appear to be running tests
+\item \code{NULL} otherwise, in which case the caller determines whether to show
+column types based on context, e.g. whether \code{show_col_types} or actual
+\code{col_types} were explicitly specified
 }
 }

--- a/man/spec_delim.Rd
+++ b/man/spec_delim.Rd
@@ -114,6 +114,7 @@ spec_table(
   guess_max = 1000,
   progress = show_progress(),
   comment = "",
+  show_col_types = should_show_types(),
   skip_empty_rows = TRUE
 )
 }

--- a/tests/testthat/_snaps/edition-1/col-spec.md
+++ b/tests/testthat/_snaps/edition-1/col-spec.md
@@ -1,0 +1,42 @@
+# options(readr.show_col_spec) controls column specifications
+
+    Code
+      out <- read_csv(readr_example("mtcars.csv"))
+    Message <readr_spec_message>
+      
+      -- Column specification --------------------------------------------------------
+      cols(
+        mpg = col_double(),
+        cyl = col_double(),
+        disp = col_double(),
+        hp = col_double(),
+        drat = col_double(),
+        wt = col_double(),
+        qsec = col_double(),
+        vs = col_double(),
+        am = col_double(),
+        gear = col_double(),
+        carb = col_double()
+      )
+
+# `show_col_types` controls column specification
+
+    Code
+      out <- read_csv(readr_example("mtcars.csv"), show_col_types = TRUE)
+    Message <readr_spec_message>
+      
+      -- Column specification --------------------------------------------------------
+      cols(
+        mpg = col_double(),
+        cyl = col_double(),
+        disp = col_double(),
+        hp = col_double(),
+        drat = col_double(),
+        wt = col_double(),
+        qsec = col_double(),
+        vs = col_double(),
+        am = col_double(),
+        gear = col_double(),
+        carb = col_double()
+      )
+

--- a/tests/testthat/_snaps/edition-2/col-spec.md
+++ b/tests/testthat/_snaps/edition-2/col-spec.md
@@ -1,0 +1,28 @@
+# options(readr.show_col_spec) controls column specifications
+
+    Code
+      out <- read_csv(readr_example("mtcars.csv"))
+    Message <vroom_dim_message>
+      Rows: 32 Columns: 11
+    Message <vroom_spec_message>
+      -- Column specification --------------------------------------------------------
+      Delimiter: ","
+      dbl (11): mpg, cyl, disp, hp, drat, wt, qsec, vs, am, gear, carb
+      
+      i Use `spec()` to retrieve the full column specification for this data.
+      i Specify the column types or set `show_col_types = FALSE` to quiet this message.
+
+# `show_col_types` controls column specification
+
+    Code
+      out <- read_csv(readr_example("mtcars.csv"), show_col_types = TRUE)
+    Message <vroom_dim_message>
+      Rows: 32 Columns: 11
+    Message <vroom_spec_message>
+      -- Column specification --------------------------------------------------------
+      Delimiter: ","
+      dbl (11): mpg, cyl, disp, hp, drat, wt, qsec, vs, am, gear, carb
+      
+      i Use `spec()` to retrieve the full column specification for this data.
+      i Specify the column types or set `show_col_types = FALSE` to quiet this message.
+

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,4 +1,3 @@
 pre_test_options <- options(
-  readr.show_col_types = FALSE,
   readr.show_progress = FALSE
 )

--- a/tests/testthat/test-col-spec.R
+++ b/tests/testthat/test-col-spec.R
@@ -137,7 +137,6 @@ test_that("spec object attached to read data", {
   )
 })
 
-
 test_that("print(col_spec) works with dates", {
   out <- col_spec_standardise("a,b,c\n",
     col_types = cols(
@@ -317,21 +316,21 @@ test_that("as.character() works on col_spec objects", {
   expect_equal(as.character(spec), "ddddf")
 })
 
-test_that("options(readr.show_col_spec) can turn off showing column specifications", {
-  skip_if_edition_first()
-
-  old <- options("readr.show_col_types")
-  on.exit(options(old))
-
-  options(readr.show_col_types = NULL)
-  expect_message(
-    expect_message(
-      expect_message(
-        read_csv(readr_example("mtcars.csv"))
-      )
-    )
+test_that("options(readr.show_col_spec) controls column specifications", {
+  withr::local_options(list(readr.show_col_types = TRUE))
+  expect_snapshot(
+    out <- read_csv(readr_example("mtcars.csv")),
+    variant = edition_variant()
   )
 
-  options(readr.show_col_types = FALSE)
+  withr::local_options(list(readr.show_col_types = FALSE))
   expect_silent(read_csv(readr_example("mtcars.csv")))
+})
+
+test_that("`show_col_types` controls column specification", {
+  expect_snapshot(
+    out <- read_csv(readr_example("mtcars.csv"), show_col_types = TRUE),
+    variant = edition_variant()
+  )
+  expect_silent(read_csv(readr_example("mtcars.csv"), show_col_types = FALSE))
 })


### PR DESCRIPTION
`read_table()` is one of the functions that currently doesn't have a
vroom equivalent, so is still using the first edition parser. When we
added support for `show_col_types` we didn't port that back to the first
edition parser, so it was missing in `read_table()` and the
`read_delim_chunked()` functions.

Fixes #1331