### PR TITLE
Test failure if file doesn't create

### DIFF
--- a/tests/testthat/test-read-csv.R
+++ b/tests/testthat/test-read-csv.R
@@ -211,9 +211,10 @@ test_that("empty file with col_names and col_types creates correct columns", {
 })
 
 test_that("empty file returns an empty tibble", {
-  file.create("foo.csv")
+  expect_true(file.create("foo.csv"))
+  on.exit(file.remove("foo.csv"))
+
   expect_equal(read_csv("foo.csv")[], tibble::tibble())
-  file.remove("foo.csv")
 })
 
 


### PR DESCRIPTION
Ran into a case where "foo.csv" wasn't created, then the test failed a bit confusingly as "foo.csv not found"

Adding the test here would make it a bit clearer how to debug.