### PR TITLE
Check read_builtin()'s inputs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,7 +41,7 @@ BugReports: https://github.com/tidyverse/readr/issues
 Depends:
     R (>= 3.1)
 Imports:
-    cli,
+    cli (>= 3.0.0),
     clipr,
     crayon,
     hms (>= 0.4.1),

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * `show_progress()` uses `rlang::is_interactive()` instead of `base::interactive()` (#1356).
 
+* `read_builtin()` does more argument checking, so that we catch obviously malformed input before passing along to `utils::data()`.
+
 # readr 2.1.1
 
 * Jenny Bryan is now the maintainer.

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 * `show_progress()` uses `rlang::is_interactive()` instead of `base::interactive()` (#1356).
 
-* `read_builtin()` does more argument checking, so that we catch obviously malformed input before passing along to `utils::data()`.
+* `read_builtin()` does more argument checking, so that we catch obviously malformed input before passing along to `utils::data()` (#1361).
 
 # readr 2.1.1
 

--- a/R/date-symbols.R
+++ b/R/date-symbols.R
@@ -38,7 +38,7 @@ date_names <- function(mon, mon_ab = mon, day, day_ab = day,
 #'   e.g. `"en"` for American English. See `date_names_langs()`
 #'   for a complete list of available locales.
 date_names_lang <- function(language) {
-  stopifnot(is.character(language), length(language) == 1)
+  check_string(language)
 
   symbols <- date_symbols[[language]]
   if (is.null(symbols)) {

--- a/R/locale.R
+++ b/R/locale.R
@@ -59,7 +59,7 @@ locale <- function(date_names = "en",
   }
 
   stopifnot(decimal_mark %in% c(".", ","))
-  stopifnot(is.character(grouping_mark), length(grouping_mark) == 1)
+  check_string(grouping_mark)
   if (decimal_mark == grouping_mark) {
     stop("`decimal_mark` and `grouping_mark` must be different", call. = FALSE)
   }
@@ -109,7 +109,7 @@ default_locale <- function() {
 }
 
 check_tz <- function(x) {
-  stopifnot(is.character(x), length(x) == 1)
+  check_string(x, nm = "tz")
 
   if (identical(x, "")) {
     x <- Sys.timezone()
@@ -127,7 +127,7 @@ check_tz <- function(x) {
 }
 
 check_encoding <- function(x) {
-  stopifnot(is.character(x), length(x) == 1)
+  check_string(x, nm = "encoding")
 
   if (tolower(x) %in% tolower(iconvlist())) {
     return(TRUE)

--- a/R/read_builtin.R
+++ b/R/read_builtin.R
@@ -16,10 +16,12 @@ read_builtin <- function(x, package = NULL) {
   warn_to_error <- function(e) {
     stop(conditionMessage(e), call. = FALSE)
   }
+  check_string(x)
+  check_string(package, optional = TRUE)
   tryCatch(
     warning = function(e) warn_to_error(e),
     expr = {
-      res <- utils::data(list = list(x), package = package, envir = environment(), verbose = FALSE)
+      res <- utils::data(list = x, package = package, envir = environment(), verbose = FALSE)
       get(res[[1]], envir = environment())
     }
   )

--- a/R/utils.R
+++ b/R/utils.R
@@ -190,3 +190,13 @@ readr_enquo <- function(x) {
   }
   x
 }
+
+check_string <- function(x, nm = deparse(substitute(x)), optional = FALSE) {
+  if (rlang::is_string(x)) {
+    return()
+  }
+  if (optional && is.null(x)) {
+    return()
+  }
+  cli::cli_abort("{.code {nm}} must be a string.")
+}

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -22,9 +22,9 @@ release_questions <- function() {
 }
 
 register_s3_method <- function(pkg, generic, class, fun = NULL) {
-  stopifnot(is.character(pkg), length(pkg) == 1)
-  stopifnot(is.character(generic), length(generic) == 1)
-  stopifnot(is.character(class), length(class) == 1)
+  check_string(pkg)
+  check_string(generic)
+  check_string(class)
 
   if (is.null(fun)) {
     fun <- get(paste0(generic, ".", class), envir = parent.frame())

--- a/tests/testthat/_snaps/utils.md
+++ b/tests/testthat/_snaps/utils.md
@@ -1,0 +1,12 @@
+# check_string() works
+
+    Code
+      name <- 1
+      check_string(name)
+    Error <rlang_error>
+      `name` must be a string.
+    Code
+      check_string(name, nm = "NAME!")
+    Error <rlang_error>
+      `NAME!` must be a string.
+

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,0 +1,10 @@
+test_that("check_string() works", {
+  expect_null(check_string("string"))
+  expect_null(check_string(NULL, optional = TRUE))
+
+  expect_snapshot(error = TRUE, {
+    name <- 1
+    check_string(name)
+    check_string(name, nm = "NAME!")
+  })
+})


### PR DESCRIPTION
This is in reponse to a request from CRAN.

Previously this expectation:

```
expect_error(read_builtin(AirPassengers, "datasets"))
```

would call `utils::data()` on malformed input, i.e. intentionally calling with the symbol `AirPassengers`. Eventually that lead to some condition having length greater than 1. So we got an error, alright, but an error that indicates a programming problem.

I think this means `utils::data()` might have an input-checking problem, but it's not my problem.

Instead, I'll be more careful to catch obviously bad input in readr itself.

I was able to reproduce what CRAN reported with released R (they used R-devel) with env var settings such as:

```
_R_CHECK_LENGTH_1_CONDITION_=verbose
_R_CHECK_LENGTH_1_CONDITION_="abort,verbose"
```

Note that "true" is not enough to surface the issue, because the offending code is inside `expect_error()`.