### PR TITLE
Update test for `NA` quoting

### DIFF
--- a/tests/testthat/test-write.R
+++ b/tests/testthat/test-write.R
@@ -7,9 +7,14 @@ test_that("strings are only quoted if needed", {
   expect_equal(ssv, "a\n,\n")
 })
 
+test_that("a literal NA is quoted", {
+  skip_if_edition_second()
+  expect_equal(format_csv(data.frame(x = "NA")), "x\n\"NA\"\n")
+})
+
 test_that("na argument modifies how missing values are written", {
-  df <- data.frame(x = c(NA, "x"), y = c(1, 2))
-  expect_equal(format_csv(df, na = "None"), "x,y\nNone,1\nx,2\n")
+  df <- data.frame(x = c(NA, "a", "b"), y = c(1, 2, NA))
+  expect_equal(format_csv(df, na = "None"), "x,y\nNone,1\na,2\nb,None\n")
 })
 
 test_that("read_delim/csv/tsv and write_delim round trip special chars", {

--- a/tests/testthat/test-write.R
+++ b/tests/testthat/test-write.R
@@ -7,10 +7,6 @@ test_that("strings are only quoted if needed", {
   expect_equal(ssv, "a\n,\n")
 })
 
-test_that("a literal NA is quoted", {
-  expect_equal(format_csv(data.frame(x = "NA")), "x\n\"NA\"\n")
-})
-
 test_that("na argument modifies how missing values are written", {
   df <- data.frame(x = c(NA, "x", "."), y = c(1, 2, NA))
   expect_equal(format_csv(df, na = "."), "x,y\n.,1\nx,2\n\".\",.\n")

--- a/tests/testthat/test-write.R
+++ b/tests/testthat/test-write.R
@@ -8,8 +8,8 @@ test_that("strings are only quoted if needed", {
 })
 
 test_that("na argument modifies how missing values are written", {
-  df <- data.frame(x = c(NA, "x", "."), y = c(1, 2, NA))
-  expect_equal(format_csv(df, na = "."), "x,y\n.,1\nx,2\n\".\",.\n")
+  df <- data.frame(x = c(NA, "x"), y = c(1, 2))
+  expect_equal(format_csv(df, na = "None"), "x,y\nNone,1\nx,2\n")
 })
 
 test_that("read_delim/csv/tsv and write_delim round trip special chars", {


### PR DESCRIPTION
When we made the changes necessary for https://github.com/tidyverse/vroom/pull/436 this caused test failures in readr that are outdated since we are no longer quoting `NA`s

Because `readr::format_csv()` uses `vroom::vroom_format()` the tests for https://github.com/tidyverse/vroom/pull/436 I think should stay there rather than also being in readr.