### PR TITLE
add examples of quiet `name_repair`

### DIFF
--- a/R/read_delim.R
+++ b/R/read_delim.R
@@ -139,6 +139,20 @@ NULL
 #' y
 #' problems(y)
 #'
+#' # Column names --------------------------------------------------------------
+#' # By default, readr duplicate name repair is noisy
+#' read_csv(I("x,x\n1,2\n3,4"))
+#'
+#' # To quiet, use a function that does name repair quietly
+#' quiet_repair <- function(x){
+#'   vctrs::vec_as_names(x, repair = "unique", quiet = TRUE)
+#' }
+#'
+#' read_csv(I("x,x\n1,2\n3,4"), name_repair = quiet_repair)
+#'
+#' # Or use "minimal" to turn off name repair
+#' read_csv(I("x,x\n1,2\n3,4"), name_repair = "minimal")
+#'
 #' # File types ----------------------------------------------------------------
 #' read_csv(I("a,b\n1.0,2.0"))
 #' read_csv2(I("a;b\n1,0;2,0"))

--- a/man/read_delim.Rd
+++ b/man/read_delim.Rd
@@ -302,6 +302,20 @@ y <- read_csv(I("x\n1\n2\nb"), col_types = list(col_double()))
 y
 problems(y)
 
+# Column names --------------------------------------------------------------
+# By default, readr duplicate name repair is noisy
+read_csv(I("x,x\n1,2\n3,4"))
+
+# To quiet, use a function that does name repair quietly
+quiet_repair <- function(x){
+  vctrs::vec_as_names(x, repair = "unique", quiet = TRUE)
+}
+
+read_csv(I("x,x\n1,2\n3,4"), name_repair = quiet_repair)
+
+# Or use "minimal" to turn off name repair
+read_csv(I("x,x\n1,2\n3,4"), name_repair = "minimal")
+
 # File types ----------------------------------------------------------------
 read_csv(I("a,b\n1.0,2.0"))
 read_csv2(I("a;b\n1,0;2,0"))


### PR DESCRIPTION
Fixes #1405

We describe using functions for custom name repair in documentation but don't include any examples of doing so. These examples show how to quiet `vctrs::vec_as_names()` without exposing `quiet=` to the user which doesn't feel worth it since there is a method to quiet name repair already. This is also a relatively rare use case.