### PR TITLE
Clarify docs for parse number

### DIFF
--- a/R/collectors.R
+++ b/R/collectors.R
@@ -142,6 +142,7 @@ col_skip <- function() {
 #' ## These all return 1000
 #' parse_number("$1,000") ## leading $ and grouping character , ignored
 #' parse_number("euro1,000") ## leading non-numeric euro ignored
+#' parse_number("t1000t1000") ## only parses first number found
 #'
 #' parse_number("1,234.56")
 #' ## explicit locale specifying European grouping and decimal marks

--- a/R/collectors.R
+++ b/R/collectors.R
@@ -140,7 +140,7 @@ col_skip <- function() {
 #' @export
 #' @examples
 #' ## These all return 1000
-#' parse_number("$1,000") ## leading $ and grouping character ignored
+#' parse_number("$1,000") ## leading `$` and grouping character `,` ignored
 #' parse_number("euro1,000") ## leading non-numeric euro ignored
 #' parse_number("t1000t1000") ## only parses first number found
 #'

--- a/R/collectors.R
+++ b/R/collectors.R
@@ -128,8 +128,9 @@ col_skip <- function() {
 
 #' Parse numbers, flexibly
 #'
-#' This drops any non-numeric characters before or after the first number.
-#' The grouping mark specified by the locale is ignored inside the number.
+#' This parses the first number it finds, dropping any non-numeric characters
+#' before the first number and all characters after the first number. The
+#' grouping mark specified by the locale is ignored inside the number.
 #'
 #' @inheritParams parse_atomic
 #' @inheritParams tokenizer_delim

--- a/R/collectors.R
+++ b/R/collectors.R
@@ -140,7 +140,7 @@ col_skip <- function() {
 #' @export
 #' @examples
 #' ## These all return 1000
-#' parse_number("$1,000") ## leading $ and grouping character , ignored
+#' parse_number("$1,000") ## leading $ and grouping character ignored
 #' parse_number("euro1,000") ## leading non-numeric euro ignored
 #' parse_number("t1000t1000") ## only parses first number found
 #'

--- a/man/parse_number.Rd
+++ b/man/parse_number.Rd
@@ -36,6 +36,7 @@ grouping mark specified by the locale is ignored inside the number.
 ## These all return 1000
 parse_number("$1,000") ## leading $ and grouping character , ignored
 parse_number("euro1,000") ## leading non-numeric euro ignored
+parse_number("t1000t1000") ## only parses first number found
 
 parse_number("1,234.56")
 ## explicit locale specifying European grouping and decimal marks

--- a/man/parse_number.Rd
+++ b/man/parse_number.Rd
@@ -34,7 +34,7 @@ grouping mark specified by the locale is ignored inside the number.
 }
 \examples{
 ## These all return 1000
-parse_number("$1,000") ## leading $ and grouping character ignored
+parse_number("$1,000") ## leading `$` and grouping character `,` ignored
 parse_number("euro1,000") ## leading non-numeric euro ignored
 parse_number("t1000t1000") ## only parses first number found
 

--- a/man/parse_number.Rd
+++ b/man/parse_number.Rd
@@ -34,7 +34,7 @@ grouping mark specified by the locale is ignored inside the number.
 }
 \examples{
 ## These all return 1000
-parse_number("$1,000") ## leading $ and grouping character , ignored
+parse_number("$1,000") ## leading $ and grouping character ignored
 parse_number("euro1,000") ## leading non-numeric euro ignored
 parse_number("t1000t1000") ## only parses first number found
 

--- a/man/parse_number.Rd
+++ b/man/parse_number.Rd
@@ -28,8 +28,9 @@ each field before parsing it?}
 A numeric vector (double) of parsed numbers.
 }
 \description{
-This drops any non-numeric characters before or after the first number.
-The grouping mark specified by the locale is ignored inside the number.
+This parses the first number it finds, dropping any non-numeric characters
+before the first number and all characters after the first number. The
+grouping mark specified by the locale is ignored inside the number.
 }
 \examples{
 ## These all return 1000


### PR DESCRIPTION
Fixes #1424

Developed from #1415

Tightening up the docs for how `parse_number()` would parse a string that contains valid numbers and non-numeric characters. Specifically, to detail this situation, where `parse_number()` only parses the first number it finds:

```r
readr::parse_number("132aa000")
#> [1] 132
```