### PR TITLE
Add examples for `col_select` and remove mention of `list()`

### DIFF
--- a/R/read_delim.R
+++ b/R/read_delim.R
@@ -10,6 +10,7 @@ NULL
 #' decimal point. This format is common in some European countries.
 #' @inheritParams datasource
 #' @inheritParams tokenizer_delim
+#' @inheritParams vroom::vroom
 #' @param col_names Either `TRUE`, `FALSE` or a character vector
 #'   of column names.
 #'
@@ -54,12 +55,6 @@ NULL
 #'    By default, reading a file without a column specification will print a
 #'    message showing what `readr` guessed they were. To remove this message,
 #'    set `show_col_types = FALSE` or set `options(readr.show_col_types = FALSE).
-#' @param col_select Columns to include in the results. You can use the same
-#'   mini-language as `dplyr::select()` to refer to the columns by name. Use
-#'   `c()` or `list()` to use more than one selection expression. Although this
-#'   usage is less common, `col_select` also accepts a numeric column index. See
-#'   [`?tidyselect::language`][tidyselect::language] for full details on the
-#'   selection language.
 #' @param id The name of a column in which to store the file path. This is
 #'   useful when reading multiple input files and there is data in the file
 #'   paths, such as the data collection date. If `NULL` (the default) no extra

--- a/R/read_delim.R
+++ b/R/read_delim.R
@@ -120,6 +120,23 @@ NULL
 #' # Or directly from a string with `I()`
 #' read_csv(I("x,y\n1,2\n3,4"))
 #'
+#' # Column selection-----------------------------------------------------------
+#' # Pass column names or indexes directly to select them
+#' read_csv(readr_example("chickens.csv"), col_select = c(chicken, eggs_laid))
+#' read_csv(readr_example("chickens.csv"), col_select = c(1, 3:4))
+#'
+#' # Or use the selection helpers
+#' read_csv(
+#'   readr_example("chickens.csv"),
+#'   col_select = c(starts_with("c"), last_col())
+#' )
+#'
+#' # You can also rename specific columns
+#' read_csv(
+#'   readr_example("chickens.csv"),
+#'   col_select = c(egg_yield = eggs_laid, everything())
+#' )
+#'
 #' # Column types --------------------------------------------------------------
 #' # By default, readr guesses the columns types, looking at `guess_max` rows.
 #' # You can override with a compact specification:

--- a/man/read_delim.Rd
+++ b/man/read_delim.Rd
@@ -182,7 +182,7 @@ set \code{show_col_types = FALSE} or set `options(readr.show_col_types = FALSE).
 
 \item{col_select}{Columns to include in the results. You can use the same
 mini-language as \code{dplyr::select()} to refer to the columns by name. Use
-\code{c()} or \code{list()} to use more than one selection expression. Although this
+\code{c()} to use more than one selection expression. Although this
 usage is less common, \code{col_select} also accepts a numeric column index. See
 \code{\link[tidyselect:language]{?tidyselect::language}} for full details on the
 selection language.}

--- a/man/read_delim.Rd
+++ b/man/read_delim.Rd
@@ -288,6 +288,23 @@ read_csv("https://github.com/tidyverse/readr/raw/main/inst/extdata/mtcars.csv")
 # Or directly from a string with `I()`
 read_csv(I("x,y\n1,2\n3,4"))
 
+# Column selection-----------------------------------------------------------
+# Pass column names or indexes directly to select them
+read_csv(readr_example("chickens.csv"), col_select = c(chicken, eggs_laid))
+read_csv(readr_example("chickens.csv"), col_select = c(1, 3:4))
+
+# Or use the selection helpers
+read_csv(
+  readr_example("chickens.csv"),
+  col_select = c(starts_with("c"), last_col())
+)
+
+# You can also rename specific columns
+read_csv(
+  readr_example("chickens.csv"),
+  col_select = c(egg_yield = eggs_laid, everything())
+)
+
 # Column types --------------------------------------------------------------
 # By default, readr guesses the columns types, looking at `guess_max` rows.
 # You can override with a compact specification:

--- a/man/read_fwf.Rd
+++ b/man/read_fwf.Rd
@@ -100,7 +100,7 @@ set \code{show_col_types = FALSE} or set `options(readr.show_col_types = FALSE).
 
 \item{col_select}{Columns to include in the results. You can use the same
 mini-language as \code{dplyr::select()} to refer to the columns by name. Use
-\code{c()} or \code{list()} to use more than one selection expression. Although this
+\code{c()} to use more than one selection expression. Although this
 usage is less common, \code{col_select} also accepts a numeric column index. See
 \code{\link[tidyselect:language]{?tidyselect::language}} for full details on the
 selection language.}

--- a/man/spec_delim.Rd
+++ b/man/spec_delim.Rd
@@ -198,7 +198,7 @@ set \code{show_col_types = FALSE} or set `options(readr.show_col_types = FALSE).
 
 \item{col_select}{Columns to include in the results. You can use the same
 mini-language as \code{dplyr::select()} to refer to the columns by name. Use
-\code{c()} or \code{list()} to use more than one selection expression. Although this
+\code{c()} to use more than one selection expression. Although this
 usage is less common, \code{col_select} also accepts a numeric column index. See
 \code{\link[tidyselect:language]{?tidyselect::language}} for full details on the
 selection language.}


### PR DESCRIPTION
Fixes #1421

Add examples for `col_select` in readr since we currently don't have any. 