### PR TITLE
Correct doc indenting

### DIFF
--- a/R/read_delim.R
+++ b/R/read_delim.R
@@ -29,28 +29,28 @@ NULL
 #' @param col_types One of `NULL`, a [cols()] specification, or
 #'   a string. See `vignette("readr")` for more details.
 #'
-#'   If `NULL`, all column types will be imputed from `guess_max` rows
-#'   on the input interspersed throughout the file. This is convenient (and
-#'   fast), but not robust. If the imputation fails, you'll need to increase
-#'   the `guess_max` or supply the correct types yourself.
+#'    If `NULL`, all column types will be imputed from `guess_max` rows
+#'    on the input interspersed throughout the file. This is convenient (and
+#'    fast), but not robust. If the imputation fails, you'll need to increase
+#'    the `guess_max` or supply the correct types yourself.
 #'
-#'   Column specifications created by [list()] or [cols()] must contain
-#'   one column specification for each column. If you only want to read a
-#'   subset of the columns, use [cols_only()].
+#'    Column specifications created by [list()] or [cols()] must contain
+#'    one column specification for each column. If you only want to read a
+#'    subset of the columns, use [cols_only()].
 #'
-#'   Alternatively, you can use a compact string representation where each
-#'   character represents one column:
-#' - c = character
-#' - i = integer
-#' - n = number
-#' - d = double
-#' - l = logical
-#' - f = factor
-#' - D = date
-#' - T = date time
-#' - t = time
-#' - ? = guess
-#' - _ or - = skip
+#'    Alternatively, you can use a compact string representation where each
+#'    character represents one column:
+#'    - c = character
+#'    - i = integer
+#'    - n = number
+#'    - d = double
+#'    - l = logical
+#'    - f = factor
+#'    - D = date
+#'    - T = date time
+#'    - t = time
+#'    - ? = guess
+#'    - _ or - = skip
 #'
 #'    By default, reading a file without a column specification will print a
 #'    message showing what `readr` guessed they were. To remove this message,

--- a/R/read_delim.R
+++ b/R/read_delim.R
@@ -29,10 +29,10 @@ NULL
 #' @param col_types One of `NULL`, a [cols()] specification, or
 #'   a string. See `vignette("readr")` for more details.
 #'
-#'    If `NULL`, all column types will be imputed from `guess_max` rows
-#'    on the input interspersed throughout the file. This is convenient (and
-#'    fast), but not robust. If the imputation fails, you'll need to increase
-#'    the `guess_max` or supply the correct types yourself.
+#'    If `NULL`, all column types will be inferred from `guess_max` rows of the
+#'    input, interspersed throughout the file. This is convenient (and fast),
+#'    but not robust. If the guessed types are wrong, you'll need to increase
+#'    `guess_max` or supply the correct types yourself.
 #'
 #'    Column specifications created by [list()] or [cols()] must contain
 #'    one column specification for each column. If you only want to read a

--- a/man/read_delim.Rd
+++ b/man/read_delim.Rd
@@ -151,10 +151,10 @@ how this is done.}
 \item{col_types}{One of \code{NULL}, a \code{\link[=cols]{cols()}} specification, or
 a string. See \code{vignette("readr")} for more details.
 
-If \code{NULL}, all column types will be imputed from \code{guess_max} rows
-on the input interspersed throughout the file. This is convenient (and
-fast), but not robust. If the imputation fails, you'll need to increase
-the \code{guess_max} or supply the correct types yourself.
+If \code{NULL}, all column types will be inferred from \code{guess_max} rows of the
+input, interspersed throughout the file. This is convenient (and fast),
+but not robust. If the guessed types are wrong, you'll need to increase
+\code{guess_max} or supply the correct types yourself.
 
 Column specifications created by \code{\link[=list]{list()}} or \code{\link[=cols]{cols()}} must contain
 one column specification for each column. If you only want to read a

--- a/man/read_delim.Rd
+++ b/man/read_delim.Rd
@@ -174,11 +174,11 @@ character represents one column:
 \item t = time
 \item ? = guess
 \item _ or - = skip
+}
 
 By default, reading a file without a column specification will print a
 message showing what \code{readr} guessed they were. To remove this message,
-set \code{show_col_types = FALSE} or set `options(readr.show_col_types = FALSE).
-}}
+set \code{show_col_types = FALSE} or set `options(readr.show_col_types = FALSE).}
 
 \item{col_select}{Columns to include in the results. You can use the same
 mini-language as \code{dplyr::select()} to refer to the columns by name. Use

--- a/man/read_delim_chunked.Rd
+++ b/man/read_delim_chunked.Rd
@@ -162,11 +162,11 @@ character represents one column:
 \item t = time
 \item ? = guess
 \item _ or - = skip
+}
 
 By default, reading a file without a column specification will print a
 message showing what \code{readr} guessed they were. To remove this message,
-set \code{show_col_types = FALSE} or set `options(readr.show_col_types = FALSE).
-}}
+set \code{show_col_types = FALSE} or set `options(readr.show_col_types = FALSE).}
 
 \item{locale}{The locale controls defaults that vary from place to place.
 The default locale is US-centric (like R), but you can use

--- a/man/read_delim_chunked.Rd
+++ b/man/read_delim_chunked.Rd
@@ -139,10 +139,10 @@ how this is done.}
 \item{col_types}{One of \code{NULL}, a \code{\link[=cols]{cols()}} specification, or
 a string. See \code{vignette("readr")} for more details.
 
-If \code{NULL}, all column types will be imputed from \code{guess_max} rows
-on the input interspersed throughout the file. This is convenient (and
-fast), but not robust. If the imputation fails, you'll need to increase
-the \code{guess_max} or supply the correct types yourself.
+If \code{NULL}, all column types will be inferred from \code{guess_max} rows of the
+input, interspersed throughout the file. This is convenient (and fast),
+but not robust. If the guessed types are wrong, you'll need to increase
+\code{guess_max} or supply the correct types yourself.
 
 Column specifications created by \code{\link[=list]{list()}} or \code{\link[=cols]{cols()}} must contain
 one column specification for each column. If you only want to read a

--- a/man/read_fwf.Rd
+++ b/man/read_fwf.Rd
@@ -92,11 +92,11 @@ character represents one column:
 \item t = time
 \item ? = guess
 \item _ or - = skip
+}
 
 By default, reading a file without a column specification will print a
 message showing what \code{readr} guessed they were. To remove this message,
-set \code{show_col_types = FALSE} or set `options(readr.show_col_types = FALSE).
-}}
+set \code{show_col_types = FALSE} or set `options(readr.show_col_types = FALSE).}
 
 \item{col_select}{Columns to include in the results. You can use the same
 mini-language as \code{dplyr::select()} to refer to the columns by name. Use

--- a/man/read_fwf.Rd
+++ b/man/read_fwf.Rd
@@ -69,10 +69,10 @@ ragged fwf file), supply the last end position as NA.}
 \item{col_types}{One of \code{NULL}, a \code{\link[=cols]{cols()}} specification, or
 a string. See \code{vignette("readr")} for more details.
 
-If \code{NULL}, all column types will be imputed from \code{guess_max} rows
-on the input interspersed throughout the file. This is convenient (and
-fast), but not robust. If the imputation fails, you'll need to increase
-the \code{guess_max} or supply the correct types yourself.
+If \code{NULL}, all column types will be inferred from \code{guess_max} rows of the
+input, interspersed throughout the file. This is convenient (and fast),
+but not robust. If the guessed types are wrong, you'll need to increase
+\code{guess_max} or supply the correct types yourself.
 
 Column specifications created by \code{\link[=list]{list()}} or \code{\link[=cols]{cols()}} must contain
 one column specification for each column. If you only want to read a

--- a/man/read_log.Rd
+++ b/man/read_log.Rd
@@ -74,11 +74,11 @@ character represents one column:
 \item t = time
 \item ? = guess
 \item _ or - = skip
+}
 
 By default, reading a file without a column specification will print a
 message showing what \code{readr} guessed they were. To remove this message,
-set \code{show_col_types = FALSE} or set `options(readr.show_col_types = FALSE).
-}}
+set \code{show_col_types = FALSE} or set `options(readr.show_col_types = FALSE).}
 
 \item{trim_ws}{Should leading and trailing whitespace (ASCII spaces and tabs) be trimmed from
 each field before parsing it?}

--- a/man/read_log.Rd
+++ b/man/read_log.Rd
@@ -51,10 +51,10 @@ how this is done.}
 \item{col_types}{One of \code{NULL}, a \code{\link[=cols]{cols()}} specification, or
 a string. See \code{vignette("readr")} for more details.
 
-If \code{NULL}, all column types will be imputed from \code{guess_max} rows
-on the input interspersed throughout the file. This is convenient (and
-fast), but not robust. If the imputation fails, you'll need to increase
-the \code{guess_max} or supply the correct types yourself.
+If \code{NULL}, all column types will be inferred from \code{guess_max} rows of the
+input, interspersed throughout the file. This is convenient (and fast),
+but not robust. If the guessed types are wrong, you'll need to increase
+\code{guess_max} or supply the correct types yourself.
 
 Column specifications created by \code{\link[=list]{list()}} or \code{\link[=cols]{cols()}} must contain
 one column specification for each column. If you only want to read a

--- a/man/read_table.Rd
+++ b/man/read_table.Rd
@@ -78,11 +78,11 @@ character represents one column:
 \item t = time
 \item ? = guess
 \item _ or - = skip
+}
 
 By default, reading a file without a column specification will print a
 message showing what \code{readr} guessed they were. To remove this message,
-set \code{show_col_types = FALSE} or set `options(readr.show_col_types = FALSE).
-}}
+set \code{show_col_types = FALSE} or set `options(readr.show_col_types = FALSE).}
 
 \item{locale}{The locale controls defaults that vary from place to place.
 The default locale is US-centric (like R), but you can use

--- a/man/read_table.Rd
+++ b/man/read_table.Rd
@@ -55,10 +55,10 @@ how this is done.}
 \item{col_types}{One of \code{NULL}, a \code{\link[=cols]{cols()}} specification, or
 a string. See \code{vignette("readr")} for more details.
 
-If \code{NULL}, all column types will be imputed from \code{guess_max} rows
-on the input interspersed throughout the file. This is convenient (and
-fast), but not robust. If the imputation fails, you'll need to increase
-the \code{guess_max} or supply the correct types yourself.
+If \code{NULL}, all column types will be inferred from \code{guess_max} rows of the
+input, interspersed throughout the file. This is convenient (and fast),
+but not robust. If the guessed types are wrong, you'll need to increase
+\code{guess_max} or supply the correct types yourself.
 
 Column specifications created by \code{\link[=list]{list()}} or \code{\link[=cols]{cols()}} must contain
 one column specification for each column. If you only want to read a

--- a/man/spec_delim.Rd
+++ b/man/spec_delim.Rd
@@ -167,10 +167,10 @@ how this is done.}
 \item{col_types}{One of \code{NULL}, a \code{\link[=cols]{cols()}} specification, or
 a string. See \code{vignette("readr")} for more details.
 
-If \code{NULL}, all column types will be imputed from \code{guess_max} rows
-on the input interspersed throughout the file. This is convenient (and
-fast), but not robust. If the imputation fails, you'll need to increase
-the \code{guess_max} or supply the correct types yourself.
+If \code{NULL}, all column types will be inferred from \code{guess_max} rows of the
+input, interspersed throughout the file. This is convenient (and fast),
+but not robust. If the guessed types are wrong, you'll need to increase
+\code{guess_max} or supply the correct types yourself.
 
 Column specifications created by \code{\link[=list]{list()}} or \code{\link[=cols]{cols()}} must contain
 one column specification for each column. If you only want to read a

--- a/man/spec_delim.Rd
+++ b/man/spec_delim.Rd
@@ -190,11 +190,11 @@ character represents one column:
 \item t = time
 \item ? = guess
 \item _ or - = skip
+}
 
 By default, reading a file without a column specification will print a
 message showing what \code{readr} guessed they were. To remove this message,
-set \code{show_col_types = FALSE} or set `options(readr.show_col_types = FALSE).
-}}
+set \code{show_col_types = FALSE} or set `options(readr.show_col_types = FALSE).}
 
 \item{col_select}{Columns to include in the results. You can use the same
 mini-language as \code{dplyr::select()} to refer to the columns by name. Use


### PR DESCRIPTION
So "By default, reading a" is no longer nested within the bulleted list