### PR TITLE
`write_excel_csv()` and `write_excel_csv2()` put datetimes in a format…

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # readr (development version)
 
+`write_excel_csv()` and `write_excel_csv()` put datetimes in a format that is
+readable again by `readr` on roundtrips (#1202).
+
 # readr 2.1.3
 
 * Help files below `man/` have been re-generated, so that they give rise to valid HTML5. (This is the impetus for this release, to keep the package safely on CRAN.)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # readr (development version)
 
-`write_excel_csv()` and `write_excel_csv2()` put datetimes in a format that is
-readable again by `readr` on roundtrips (#1202).
+* `write_excel_csv()` and `write_excel_csv2()` put datetimes in a format that is
+  readable again by `readr` on roundtrips (#1202).
 
 # readr 2.1.3
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # readr (development version)
 
-`write_excel_csv()` and `write_excel_csv()` put datetimes in a format that is
+`write_excel_csv()` and `write_excel_csv2()` put datetimes in a format that is
 readable again by `readr` on roundtrips (#1202).
 
 # readr 2.1.3

--- a/R/write.R
+++ b/R/write.R
@@ -193,7 +193,7 @@ write_excel_csv <- function(x, file, na = "NA", append = FALSE,
 
   x_out <- x
   datetime_cols <- vapply(x, inherits, logical(1), "POSIXt")
-  x[datetime_cols] <- lapply(x[datetime_cols], format, "%Y/%m/%d %H:%M:%S")
+  x[datetime_cols] <- lapply(x[datetime_cols], format, "%Y-%m-%d %H:%M:%S")
 
   x[] <- lapply(x, output_column)
   if (edition_first()) {
@@ -242,7 +242,7 @@ write_excel_csv2 <- function(x, file, na = "NA", append = FALSE,
   x <- change_decimal_separator(x, decimal_mark = ",")
 
   datetime_cols <- vapply(x, inherits, logical(1), "POSIXt")
-  x[datetime_cols] <- lapply(x[datetime_cols], format, "%Y/%m/%d %H:%M:%S")
+  x[datetime_cols] <- lapply(x[datetime_cols], format, "%Y-%m-%d %H:%M:%S")
 
   x[] <- lapply(x, output_column)
   write_excel_csv(x, file, na, append, col_names, delim,

--- a/tests/testthat/test-write.R
+++ b/tests/testthat/test-write.R
@@ -103,6 +103,28 @@ test_that("write_excel_csv/csv2 includes a byte order mark, but not when appendi
   expect_equal(output[-1:-3], charToRaw('"a"\n1\n2\n'))
 })
 
+test_that("write_excel_csv/csv2 preserves datetimes on roundtrip", {
+  tmp <- tempfile()
+  on.exit(unlink(tmp))
+
+  tmp2 <- tempfile()
+  on.exit(unlink(tmp2))
+
+  x <- as.POSIXct("2010-01-01 00:00:00") + 1:10
+  attr(x, "tzone") <- "UTC"
+
+  input <- data.frame(x = x)
+
+  write_excel_csv(input, tmp)
+  write_excel_csv2(input, tmp2)
+
+  output <- read_csv(tmp)
+  output2 <- read_csv2(tmp2)
+
+  expect_equal(output$x, x)
+  expect_equal(output2$x, x)
+})
+
 test_that("does not writes a tailing .0 for whole number doubles", {
   expect_equal(format_tsv(tibble::tibble(x = 1)), "x\n1\n")
 


### PR DESCRIPTION
… that is readable again by `readr` on roundtrips.  Best `strftime()` format for excel csv datetimes according to https://stackoverflow.com/questions/804118/best-timestamp-format-for-csv-excel#comment57807590_804137 Fixes #1202.