### PR TITLE
locale(encoding=) should not strictly rely on iconvlist()

### DIFF
--- a/R/locale.R
+++ b/R/locale.R
@@ -129,9 +129,11 @@ check_tz <- function(x) {
 check_encoding <- function(x) {
   check_string(x, nm = "encoding")
 
-  if (tolower(x) %in% tolower(iconvlist())) {
+  ## iconvlist() is not complete on all platforms,
+  ## but encodings "latin1" and "UTF-8" are portable.
+  if (tolower(x) %in% tolower(c("latin1", "UTF-8", iconvlist()))) {
     return(TRUE)
   }
 
-  stop("Unknown encoding ", x, call. = FALSE)
+  warning("Unknown encoding ", x, call. = FALSE)
 }


### PR DESCRIPTION
The `check_encoding()` auxiliary function verifies the specified input `encoding` via `iconvlist()`
https://github.com/tidyverse/readr/blob/e529cb2775f1b52a0dfa30dabc9f8e0014aa77e6/R/locale.R#L132
and rejects any non-listed encoding.

Unfortunately, this unnecessarily breaks `locale()` on platforms where `iconvlist()` is incomplete. As `?iconvlist` says

> On *most* platforms 'iconvlist' provides an alphabetical list of the
> supported encodings.  On others, the information is on the man
> page for 'iconv(5)' or elsewhere in the man pages

I'd suggest to always accept the portable encodings "latin1" and "UTF-8" and otherwise only give a `warning` rather than `stop` if the specified encoding is not found.

This PR also fixes long-standing package check failures on Alpine Linux, e.g.,
```
--- re-building ‘locales.Rmd’ using rmarkdown
Quitting from lines  at lines 141-166 [unnamed-chunk-12] (locales.Rmd)
Error: processing vignette 'locales.Rmd' failed with diagnostics:
Unknown encoding latin1
--- failed re-building ‘locales.Rmd’
```