### PR TITLE
Update locale.R example description

### DIFF
--- a/R/locale.R
+++ b/R/locale.R
@@ -37,7 +37,7 @@
 #' locale()
 #' locale("fr")
 #'
-#' # South American locale
+#' # A South American locale
 #' locale("es", decimal_mark = ",")
 locale <- function(date_names = "en",
                    date_format = "%AD", time_format = "%AT",


### PR DESCRIPTION
Obviously Spanish is one of the many languages in South America, spoken by 9 out of 12 South American countries, but it's still just one of the languages spoken and it's not even the one with the most speakers (which is Portuguese in Brazil, with 212 million inhabitants). 

This change simply makes it explicit that the example, which uses Spanish, is *a* South American locale, and not *the* South American locale.