### PR TITLE
param file can also take a vector of paths

### DIFF
--- a/R/source.R
+++ b/R/source.R
@@ -1,7 +1,8 @@
 #' Create a source object.
 #'
-#' @param file Either a path to a file, a connection, or literal data
-#'    (either a single string or a raw vector).
+#' @param file Either a path to a file, a connection, literal data
+#'    (either a single string or a raw vector), or a vector of
+#'    paths.
 #'
 #'    Files ending in `.gz`, `.bz2`, `.xz`, or `.zip` will
 #'    be automatically uncompressed. Files starting with `http://`,


### PR DESCRIPTION
based on a mastodon discussion, we felt that the option to provide a vector of paths was not clearly enough defined in the param documentation. This is a suggestion to make it somewhat more clear.