### PR TITLE
Adds callback function `ListCallback`  in the docs

### DIFF
--- a/R/callback.R
+++ b/R/callback.R
@@ -21,6 +21,7 @@ as_chunk_callback.ChunkCallback <- function(x) {
 #'    Callback function that accumulates a single result. Requires the parameter `acc` to specify
 #'    the initial value of the accumulator.  The parameter `acc` is `NULL` by default.
 #'  }
+#'  \item{ListCallback}{Callback function that returns the results in a list.}
 #' }
 #' @usage NULL
 #' @format NULL

--- a/man/callback.Rd
+++ b/man/callback.Rd
@@ -20,6 +20,7 @@ These classes are used to define callback behaviors.
 Callback function that accumulates a single result. Requires the parameter \code{acc} to specify
 the initial value of the accumulator.  The parameter \code{acc} is \code{NULL} by default.
 }
+\item{ListCallback}{Callback function that returns the results in a list.}
 }
 }
 \examples{


### PR DESCRIPTION
The `ListCallback` is not listed in the [callback classes](https://readr.tidyverse.org/reference/callback.html). This PR  adds it in the list. 