### PR TITLE
Add "Supported By Posit" badge to website

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -6,6 +6,7 @@ template:
 
   includes:
     in_header: |
+      <script src="https://cdn.jsdelivr.net/gh/posit-dev/supported-by-posit/js/badge.min.js" data-max-height="43" data-light-bg="#666f76" data-light-fg="#f9f9f9"></script>
       <script defer data-domain="readr.tidyverse.org,all.tidyverse.org" src="https://plausible.io/js/plausible.js"></script>
 
 development:
@@ -95,8 +96,8 @@ reference:
     Version one is a single threaded eager parser that readr used by default from its first release to version 1.4.0.
     Version two is a multi-threaded lazy parser used by default from readr 2.0.0 onwards.
   contents:
-    - with_edition
-    - edition_get
+  - with_edition
+  - edition_get
 
 - title: Read non-rectangular files
   desc: >


### PR DESCRIPTION
## Overview

This PR adds the "Supported by Posit" badge to the website.

## Background

We've recently started adding a "Supported by Posit" badge across all Posit package websites to create a more cohesive brand presence. The badge appears on the far right of the top navigation bar or at the bottom of the hamburger menu. It links to Posit’s main website. @hadley is involved with this initiative.

The following websites already have the "Supported by Posit" badge: [ggplot2](https://ggplot2.tidyverse.org), [Great Tables](https://posit-dev.github.io/great-tables/articles/intro.html), [gt](https://gt.rstudio.com), [Plotnine](https://plotnine.org), [Pointblank](https://posit-dev.github.io/pointblank/), [pointblank](https://rstudio.github.io/pointblank/), and [Quarto](https://quarto.org).

See https://posit-dev.github.io/supported-by-posit/ for more information.

## Changes

- Added a line to `_pkgdown.yml` to include the JavaScript file
- Standardized indentation in `_pkgdown.yml`

## Screenshots

At 1200px browser width:

<img width="1200" height="300" alt="readr-1200" src="https://github.com/user-attachments/assets/7f7d0db8-5a96-4123-ac0e-004ef7615540" />


At 992px browser width:

<img width="992" height="300" alt="readr-992" src="https://github.com/user-attachments/assets/ec19f375-d7a3-4203-a9f0-58f4f7b3ebf0" />


At 991px browser width:

<img width="991" height="300" alt="readr-991" src="https://github.com/user-attachments/assets/4af2decf-e68c-4e64-82b2-efbc086d67b2" />


