### PR TITLE
Don't let git do implicit line ending normalization on test fixtures

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,6 @@
 /NEWS.md merge=union
-tests/testthat/sample_text.txt eol=lf
+
+# This tells git to NOT treat these files as text (even though they are), in
+# order to suppress line ending normalization. The intent is to preserve exact
+# line endings for cross-platform testing.
+tests/testthat/fixtures/** -text


### PR DESCRIPTION
Discovered this "excitement" in `.gitattributes` as a result of 12e9c2c6c8a3b357c09be77252f62c3f3f9349a7