### PR TITLE
Do not allow unclassed list columns in write_delim()

### DIFF
--- a/R/write.R
+++ b/R/write.R
@@ -79,10 +79,10 @@ write_delim <- function(
   progress = show_progress()
 ) {
   stopifnot(is.data.frame(x))
-  check_column_types(x)
 
   x_out <- x
   x[] <- lapply(x, output_column)
+  check_column_types(x)
   if (edition_first()) {
     stream_delim(
       x,
@@ -191,13 +191,13 @@ write_excel_csv <- function(
   progress = show_progress()
 ) {
   stopifnot(is.data.frame(x))
-  check_column_types(x)
 
   x_out <- x
   datetime_cols <- vapply(x, inherits, logical(1), "POSIXt")
   x[datetime_cols] <- lapply(x[datetime_cols], format, "%Y/%m/%d %H:%M:%S")
 
   x[] <- lapply(x, output_column)
+  check_column_types(x)
   if (edition_first()) {
     stream_delim(
       x,
@@ -246,7 +246,6 @@ write_excel_csv2 <- function(
   progress = show_progress()
 ) {
   stopifnot(is.data.frame(x))
-  check_column_types(x)
 
   x_out <- x
   x <- change_decimal_separator(x, decimal_mark = ",")
@@ -255,6 +254,7 @@ write_excel_csv2 <- function(
   x[datetime_cols] <- lapply(x[datetime_cols], format, "%Y/%m/%d %H:%M:%S")
 
   x[] <- lapply(x, output_column)
+  check_column_types(x)
   write_excel_csv(
     x,
     file,
@@ -336,9 +336,9 @@ format_delim <- function(
   eol = "\n"
 ) {
   stopifnot(is.data.frame(x))
-  check_column_types(x)
 
   x[] <- lapply(x, output_column)
+  check_column_types(x)
   if (edition_first()) {
     res <- stream_delim(
       df = x,
@@ -553,7 +553,9 @@ standardise_escape <- function(x) {
 }
 
 check_column_types <- function(x) {
-  is_bad_column <- vapply(x, function(xx) !is.null(dim(xx)), logical(1))
+  is_bad_column <- vapply(x, function(xx) {
+    !is.atomic(xx) || !is.null(dim(xx))
+  }, logical(1))
   if (any(is_bad_column)) {
     cli_block(type = rlang::abort, {
       cli::cli_text("`x` must not contain list or matrix columns:")

--- a/tests/testthat/_snaps/write.md
+++ b/tests/testthat/_snaps/write.md
@@ -5,7 +5,7 @@
     Condition
       Error in `cli_block()`:
       ! `x` must not contain list or matrix columns:
-      x invalid columns at index(s): 3
+      x invalid columns at index(s): 2
 
 ---
 

--- a/tests/testthat/test-write.R
+++ b/tests/testthat/test-write.R
@@ -225,11 +225,7 @@ test_that("hms NAs are written without padding (#930)", {
 })
 
 test_that("Error when writing list columns or matrix columns", {
-  df <- data.frame(
-    x = LETTERS[1:4],
-    y = I(list(1, "foo", 2:9, iris)),
-    z = I(matrix(1:16, nrow = 4))
-  )
+  df <- data.frame(x = LETTERS[1:4], y = I(list(1, "foo", 2:9, iris)))
   expect_snapshot(
     write_csv(df, tempfile()),
     error = TRUE

--- a/tests/testthat/test-write.R
+++ b/tests/testthat/test-write.R
@@ -288,3 +288,21 @@ test_that("write_*() supports writing with windows newlines", {
     charToRaw("x\r\n1\r\n2\r\n3\r\n")
   )
 })
+
+test_that("write_*() coerces S3 objects implemented as lists to character", {
+  tmp <- tempfile()
+  on.exit(unlink(tmp))
+
+  x <- c(
+    utils::person("John", "Doe"),
+    utils::person("Jane", "Smith")
+  )
+  df <- data.frame(row.names = 1:length(x))
+  df$x <- x
+  write_delim(df, tmp)
+
+  expect_identical(
+    gsub(pattern = "\"", replacement = "", readLines(tmp)[-1]),
+    as.character(x)
+  )
+})


### PR DESCRIPTION
- Fixes #1572 by adding a check for non-atomic columns to `check_column_types()`
- Modifies unit test [`"Error when writing list columns or matrix columns"`](https://github.com/iofarm/readr/blob/27095457690f37184f09913cebcaaabfa8d4c3dc/tests/testthat/test-write.R#L227-L239) to test that `write_csv()` throws an error when passed a data frame with an unclassed list column even if there is no matrix column
- Fixes #1341 by calling `output_column()` before `check_column_types()`, which is necessary to retain the current behavior of converting classed list columns to character vectors using `as.character()` rather than throwing an error.
- Add unit test [`"write_*() coerces S3 objects implemented as lists to character"`](https://github.com/iofarm/readr/blob/7f22e66b2fe093f033e607543daecc83c3f13cd9/tests/testthat/test-write.R#L292-L308) to test that the behavior mentioned above is retained.

I made this patch since it's helpful for my own use case, but I understand if it's not the right approach for the package. Also, one caveat is that this would allow writing classed matrix columns that currently result in an error. If this is undesirable, cherry-picking just 2709545 would avoid this, at the expense of losing the ability to write classed list columns that currently are allowed and work correctly. 