### PR TITLE
Mention clipboard() in read_delim() file param docs

### DIFF
--- a/R/read_delim.R
+++ b/R/read_delim.R
@@ -10,6 +10,22 @@ NULL
 #' decimal point. This format is common in some European countries.
 #' @inheritParams tokenizer_delim
 #' @inheritParams vroom::vroom
+#' @param file Either a path to a file, a connection, or literal data
+#'   (either a single string or a raw vector). `file` can also be a
+#'   character vector containing multiple filepaths or a list containing
+#'   multiple connections.
+#'
+#'   Files ending in `.gz`, `.bz2`, `.xz`, or `.zip` will be automatically
+#'   decompressed. Files starting with `http://`, `https://`, `ftp://`, or
+#'   `ftps://` will be automatically downloaded. Remote compressed files
+#'   (`.gz`, `.bz2`, `.xz`, `.zip`) will be automatically downloaded and
+#'   decompressed.
+#'
+#'   Literal data is most useful for examples and tests. To be recognised as
+#'   literal data, wrap the input with `I()`.
+#'
+#'   Using a value of [clipboard()] will read from the system clipboard.
+#'
 #' @param col_names Either `TRUE`, `FALSE` or a character vector
 #'   of column names.
 #'

--- a/man/read_delim.Rd
+++ b/man/read_delim.Rd
@@ -103,9 +103,10 @@ read_tsv(
 )
 }
 \arguments{
-\item{file}{Either a path to a file, a connection, or literal data (either a
-single string or a raw vector). \code{file} can also be a character vector
-containing multiple filepaths or a list containing multiple connections.
+\item{file}{Either a path to a file, a connection, or literal data
+(either a single string or a raw vector). \code{file} can also be a
+character vector containing multiple filepaths or a list containing
+multiple connections.
 
 Files ending in \code{.gz}, \code{.bz2}, \code{.xz}, or \code{.zip} will be automatically
 decompressed. Files starting with \verb{http://}, \verb{https://}, \verb{ftp://}, or
@@ -114,7 +115,9 @@ decompressed. Files starting with \verb{http://}, \verb{https://}, \verb{ftp://}
 decompressed.
 
 Literal data is most useful for examples and tests. To be recognised as
-literal data, wrap the input with \code{I()}.}
+literal data, wrap the input with \code{I()}.
+
+Using a value of \code{\link[=clipboard]{clipboard()}} will read from the system clipboard.}
 
 \item{delim}{Single character used to separate fields within a record.}
 

--- a/man/spec_delim.Rd
+++ b/man/spec_delim.Rd
@@ -119,9 +119,10 @@ spec_table(
 )
 }
 \arguments{
-\item{file}{Either a path to a file, a connection, or literal data (either a
-single string or a raw vector). \code{file} can also be a character vector
-containing multiple filepaths or a list containing multiple connections.
+\item{file}{Either a path to a file, a connection, or literal data
+(either a single string or a raw vector). \code{file} can also be a
+character vector containing multiple filepaths or a list containing
+multiple connections.
 
 Files ending in \code{.gz}, \code{.bz2}, \code{.xz}, or \code{.zip} will be automatically
 decompressed. Files starting with \verb{http://}, \verb{https://}, \verb{ftp://}, or
@@ -130,7 +131,9 @@ decompressed. Files starting with \verb{http://}, \verb{https://}, \verb{ftp://}
 decompressed.
 
 Literal data is most useful for examples and tests. To be recognised as
-literal data, wrap the input with \code{I()}.}
+literal data, wrap the input with \code{I()}.
+
+Using a value of \code{\link[=clipboard]{clipboard()}} will read from the system clipboard.}
 
 \item{delim}{Single character used to separate fields within a record.}
 


### PR DESCRIPTION
Closes #1614.

`read_delim()` inherits its `file` param docs from `vroom::vroom()`, which doesn't mention `clipboard()`. Other read functions (`read_table()`, `read_fwf()`, etc.) inherit from `datasource()` and already document it. This adds an explicit `@param file` to `read_delim()` that includes the `clipboard()` mention.