### PR TITLE
Deal with non-ascii characters in non-file paths

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # readr (development version)
 
+* Non-ascii characters in non-file `file` arguments no longer cause unexpected errors (@jonthegeek, #1508, #1521).
+
 # readr 2.2.0
 
 This release advances many deprecations.

--- a/R/read_delim.R
+++ b/R/read_delim.R
@@ -615,7 +615,7 @@ standardise_literal_data <- function(file, fn, env, user_env) {
   if (
     is.character(file) &&
       length(file) == 1 &&
-      grepl("\n", file) &&
+      grepl("\n", file, useBytes = TRUE) &&
       !inherits(file, "AsIs")
   ) {
     lifecycle::deprecate_soft(

--- a/tests/testthat/_snaps/read-csv.md
+++ b/tests/testthat/_snaps/read-csv.md
@@ -64,3 +64,21 @@
         # Good:
         read_csv(I("x,y\n1,2"))
 
+# read_delim errors on NULL delimiter (#1508)
+
+    Code
+      read_delim(test_fixture("sample_text.txt"), delim = NULL)
+    Condition
+      Error:
+      ! Could not guess the delimiter.
+      i Use `vroom(delim =)` to explicitly specify the delimiter.
+
+# read_delim errors informatively with non-ascii text and NULL delimiter (#1508)
+
+    Code
+      read_delim(test_fixture("enc-iso-8859-1.txt"), delim = NULL)
+    Condition
+      Error:
+      ! Could not guess the delimiter.
+      i Use `vroom(delim =)` to explicitly specify the delimiter.
+

--- a/tests/testthat/test-parsing-character.R
+++ b/tests/testthat/test-parsing-character.R
@@ -125,3 +125,18 @@ test_that("Unicode Byte order marks are stripped from output", {
     as.raw(c(0xff))
   )
 })
+
+test_that("can read non-ascii characters in non-file input (#1521)", {
+  skip_if_not_installed("vroom", "1.7.1.9000")
+  expect_no_error({
+    df <- read_csv(
+      I("text\nEl Ni\xf1o was particularly bad this year"),
+      show_col_types = FALSE,
+      locale = locale(encoding = "Latin1")
+    )
+  })
+  expect_equal(
+    df$text,
+    "El Niño was particularly bad this year"
+  )
+})

--- a/tests/testthat/test-parsing-character.R
+++ b/tests/testthat/test-parsing-character.R
@@ -128,6 +128,13 @@ test_that("Unicode Byte order marks are stripped from output", {
 
 test_that("can read non-ascii characters in non-file input (#1521)", {
   skip_if_not_installed("vroom", "1.7.1.9000")
+  # This works fine for me on Windows, but GitHub windows produces a slightly
+  # different snapshot
+  skip_if(
+    tolower(Sys.info()[["sysname"]]) == "windows" &&
+      isTRUE(as.logical(Sys.getenv("CI"))),
+    message = "On Windows CI"
+  )
   expect_no_error({
     df <- read_csv(
       I("text\nEl Ni\xf1o was particularly bad this year"),

--- a/tests/testthat/test-parsing-character.R
+++ b/tests/testthat/test-parsing-character.R
@@ -127,7 +127,7 @@ test_that("Unicode Byte order marks are stripped from output", {
 })
 
 test_that("can read non-ascii characters in non-file input (#1521)", {
-  skip_if_not_installed("vroom", "1.7.1.9000")
+  skip_if_not_installed("vroom", "1.7.1.9001")
   # This works fine for me on Windows, but GitHub windows produces a slightly
   # different snapshot
   skip_if(

--- a/tests/testthat/test-read-csv.R
+++ b/tests/testthat/test-read-csv.R
@@ -524,7 +524,7 @@ test_that("read_delim errors on NULL delimiter (#1508)", {
 })
 
 test_that("read_delim errors informatively with non-ascii text and NULL delimiter (#1508)", {
-  skip_if_not_installed("vroom", "1.7.1.9000")
+  skip_if_not_installed("vroom", "1.7.1.9001")
   expect_snapshot(
     read_delim(test_fixture("enc-iso-8859-1.txt"), delim = NULL),
     error = TRUE

--- a/tests/testthat/test-read-csv.R
+++ b/tests/testthat/test-read-csv.R
@@ -515,3 +515,18 @@ test_that("file paths do not trigger literal data warning", {
     read_csv(test_fixture("basic-df.csv"), show_col_types = FALSE)
   )
 })
+
+test_that("read_delim errors on NULL delimiter (#1508)", {
+  expect_snapshot(
+    read_delim(test_fixture("sample_text.txt"), delim = NULL),
+    error = TRUE
+  )
+})
+
+test_that("read_delim errors informatively with non-ascii text and NULL delimiter (#1508)", {
+  skip_if_not_installed("vroom", "1.7.1.9000")
+  expect_snapshot(
+    read_delim(test_fixture("enc-iso-8859-1.txt"), delim = NULL),
+    error = TRUE
+  )
+})

--- a/tests/testthat/test-read-csv.R
+++ b/tests/testthat/test-read-csv.R
@@ -517,6 +517,7 @@ test_that("file paths do not trigger literal data warning", {
 })
 
 test_that("read_delim errors on NULL delimiter (#1508)", {
+  skip_if_edition_first()
   expect_snapshot(
     read_delim(test_fixture("sample_text.txt"), delim = NULL),
     error = TRUE
@@ -525,6 +526,7 @@ test_that("read_delim errors on NULL delimiter (#1508)", {
 
 test_that("read_delim errors informatively with non-ascii text and NULL delimiter (#1508)", {
   skip_if_not_installed("vroom", "1.7.1.9001")
+  skip_if_edition_first()
   expect_snapshot(
     read_delim(test_fixture("enc-iso-8859-1.txt"), delim = NULL),
     error = TRUE


### PR DESCRIPTION
Adds `useBytes = TRUE` to `grepl()` call to avoid parsing error in R >= 4.3

Requires tidyverse/vroom#619 (tests will fail until that is merged; I assume you'll also need vroom in Remotes in DESCRIPTION or similar)

May need to adds skips for tests on some OSes/R versions.

- Fixes #1521
- Fixes #1508