### PR TITLE
Add date_order locale option and flexible date separator parsing

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # readr (development version)
 
+* `locale()` gains a `date_order` argument to control the component order used
+  when parsing dates and date-times (e.g. `"mdy"`, `"dmy"`, `"ymd_hms"`). This
+  makes it possible to read year-last formats such as `10/02/2024` that the
+  automatic type guesser would otherwise treat as character.
+
+* Date and date-time auto-detection now accepts any non-alphanumeric separator
+  between components (e.g. `2024.10.02`, `2024/10/02`), and falls back to a
+  year-last heuristic so unambiguous `D/M/YYYY` values are recognised as dates.
+
 # readr 2.2.0
 
 This release advances many deprecations.

--- a/R/locale.R
+++ b/R/locale.R
@@ -32,6 +32,10 @@
 #' @param asciify Should diacritics be stripped from date names and converted to
 #'   ASCII? This is useful if you're dealing with ASCII data where the correct
 #'   spellings have been lost. Requires the \pkg{stringi} package.
+#' @param date_order Order of date components for auto-detection. One of
+#'   `"ymd"`, `"ydm"`, `"mdy"`, `"myd"`, `"dmy"`, `"dym"`, or those combined
+#'   with a time suffix: `"_hms"`, `"_hm"`, or `"_h"` (e.g. `"mdy_hms"`).
+#'   Use `NULL` (default) for automatic detection.
 #' @export
 #' @examples
 #' locale()
@@ -47,7 +51,8 @@ locale <- function(
   grouping_mark = ",",
   tz = "UTC",
   encoding = "UTF-8",
-  asciify = FALSE
+  asciify = FALSE,
+  date_order = NULL
 ) {
   if (is.character(date_names)) {
     date_names <- date_names_lang(date_names)
@@ -76,6 +81,38 @@ locale <- function(
   tz <- check_tz(tz)
   check_encoding(encoding)
 
+  if (!is.null(date_order)) {
+    check_string(date_order)
+  }
+
+  valid_date_orders <- c(
+    "ymd",
+    "ydm",
+    "mdy",
+    "myd",
+    "dmy",
+    "dym",
+    "ymd_hms",
+    "ymd_hm",
+    "ymd_h",
+    "mdy_hms",
+    "mdy_hm",
+    "mdy_h",
+    "dmy_hms",
+    "dmy_hm",
+    "dmy_h",
+    "ydm_hms",
+    "ydm_hm",
+    "ydm_h"
+  )
+  if (!is.null(date_order) && !date_order %in% valid_date_orders) {
+    stop(
+      "`date_order` must be NULL or one of: ",
+      paste(valid_date_orders, collapse = ", "),
+      call. = FALSE
+    )
+  }
+
   structure(
     list(
       date_names = date_names,
@@ -84,7 +121,8 @@ locale <- function(
       decimal_mark = decimal_mark,
       grouping_mark = grouping_mark,
       tz = tz,
-      encoding = encoding
+      encoding = encoding,
+      date_order = date_order
     ),
     class = "locale"
   )
@@ -107,6 +145,9 @@ print.locale <- function(x, ...) {
     sep = ""
   )
   cat("Formats:  ", x$date_format, " / ", x$time_format, "\n", sep = "")
+  if (!is.null(x$date_order)) {
+    cat("Date order: ", x$date_order, "\n", sep = "")
+  }
   cat("Timezone: ", x$tz, "\n", sep = "")
   cat("Encoding: ", x$encoding, "\n", sep = "")
   print(x$date_names)

--- a/man/locale.Rd
+++ b/man/locale.Rd
@@ -13,7 +13,8 @@ locale(
   grouping_mark = ",",
   tz = "UTC",
   encoding = "UTF-8",
-  asciify = FALSE
+  asciify = FALSE,
+  date_order = NULL
 )
 
 default_locale()
@@ -50,6 +51,11 @@ read - readr always converts the output to UTF-8.}
 \item{asciify}{Should diacritics be stripped from date names and converted to
 ASCII? This is useful if you're dealing with ASCII data where the correct
 spellings have been lost. Requires the \pkg{stringi} package.}
+
+\item{date_order}{Order of date components for auto-detection. One of
+\code{"ymd"}, \code{"ydm"}, \code{"mdy"}, \code{"myd"}, \code{"dmy"}, \code{"dym"}, or those combined
+with a time suffix: \code{"_hms"}, \code{"_hm"}, or \code{"_h"} (e.g. \code{"mdy_hms"}).
+Use \code{NULL} (default) for automatic detection.}
 }
 \description{
 A locale object tries to capture all the defaults that can vary between

--- a/src/Collector.cpp
+++ b/src/Collector.cpp
@@ -29,9 +29,16 @@ CollectorPtr Collector::create(const cpp11::list& spec, LocaleInfo* pLocale) {
   }
   if (subclass == "collector_date") {
     SEXP format_ = spec["format"];
-    std::string format = (Rf_isNull(format_)) != 0U
-                             ? pLocale->dateFormat_
-                             : cpp11::as_cpp<std::string>(format_);
+    std::string format;
+    if ((Rf_isNull(format_)) == 0U) {
+      // Explicit format given by user
+      format = cpp11::as_cpp<std::string>(format_);
+    } else if (pLocale->dateOrder_.empty()) {
+      // No date_order set: use locale date format (e.g. "%AD" -> ISO8601)
+      format = pLocale->dateFormat_;
+    }
+    // When date_order is set and no explicit format: leave format empty
+    // so setValue() will dispatch through parseDateOrder()
     return CollectorPtr(new CollectorDate(pLocale, format));
   }
   if (subclass == "collector_datetime") {
@@ -106,8 +113,23 @@ void CollectorDate::setValue(int i, const Token& t) {
     std::string std_string(string.first, string.second);
 
     parser_.setDate(std_string.c_str());
-    bool res =
-        (format_.empty()) ? parser_.parseLocaleDate() : parser_.parse(format_);
+    bool res;
+    if (!format_.empty()) {
+      res = parser_.parse(format_);
+    } else if (!pLocale_->dateOrder_.empty() &&
+               pLocale_->dateOrder_.find('_') == std::string::npos) {
+      // Explicit date-only order (e.g. "mdy", "dmy")
+      res = parser_.parseDateOrder(pLocale_->dateOrder_);
+    } else {
+      res = parser_.parseLocaleDate();
+      if (!res) {
+        // Auto-detection fallback: year-last heuristic (D/M/YYYY, M/D/YYYY).
+        // Mirrors isDate() in CollectorGuess.cpp so the guesser and the
+        // collector agree on which strings count as dates.
+        parser_.setDate(std_string.c_str());
+        res = parser_.parseYearLastHeuristic();
+      }
+    }
 
     if (!res) {
       warn(t.row(), t.col(), "date like " + format_, std_string);
@@ -141,8 +163,16 @@ void CollectorDateTime::setValue(int i, const Token& t) {
     std::string std_string(string.first, string.second);
 
     parser_.setDate(std_string.c_str());
-    bool res =
-        (format_.empty()) ? parser_.parseISO8601() : parser_.parse(format_);
+    bool res;
+    if (!format_.empty()) {
+      res = parser_.parse(format_);
+    } else if (!pLocale_->dateOrder_.empty() &&
+               pLocale_->dateOrder_.find('_') != std::string::npos) {
+      // Explicit datetime order (e.g. "mdy_hms", "dmy_hm")
+      res = parser_.parseDateOrder(pLocale_->dateOrder_);
+    } else {
+      res = parser_.parseISO8601();
+    }
 
     if (!res) {
       warn(t.row(), t.col(), "date like " + format_, std_string);

--- a/src/Collector.cpp
+++ b/src/Collector.cpp
@@ -172,6 +172,13 @@ void CollectorDateTime::setValue(int i, const Token& t) {
       res = parser_.parseDateOrder(pLocale_->dateOrder_);
     } else {
       res = parser_.parseISO8601();
+      if (!res) {
+        // Auto-detection fallback: year-last heuristic datetime
+        // (M/D/Y or D/M/Y date + time). Mirrors isDateTime() in
+        // CollectorGuess.cpp so the guesser and the collector agree.
+        parser_.setDate(std_string.c_str());
+        res = parser_.parseYearLastHeuristicDateTime();
+      }
     }
 
     if (!res) {

--- a/src/Collector.h
+++ b/src/Collector.h
@@ -95,12 +95,14 @@ public:
 class CollectorDate : public Collector {
   std::string format_;
   DateTimeParser parser_;
+  LocaleInfo* pLocale_;
 
 public:
   CollectorDate(LocaleInfo* pLocale, const std::string& format)
       : Collector(cpp11::writable::doubles(R_xlen_t(0))),
         format_(format),
-        parser_(pLocale) {}
+        parser_(pLocale),
+        pLocale_(pLocale) {}
 
   void setValue(int i, const Token& t);
 
@@ -116,13 +118,15 @@ class CollectorDateTime : public Collector {
   std::string format_;
   DateTimeParser parser_;
   std::string tz_;
+  LocaleInfo* pLocale_;
 
 public:
   CollectorDateTime(LocaleInfo* pLocale, const std::string& format)
       : Collector(cpp11::writable::doubles(R_xlen_t(0))),
         format_(format),
         parser_(pLocale),
-        tz_(pLocale->tz_) {}
+        tz_(pLocale->tz_),
+        pLocale_(pLocale) {}
 
   void setValue(int i, const Token& t);
 

--- a/src/CollectorGuess.cpp
+++ b/src/CollectorGuess.cpp
@@ -96,26 +96,47 @@ bool isTime(const std::string& x, LocaleInfo* pLocale) {
 
 bool isDate(const std::string& x, LocaleInfo* pLocale) {
   DateTimeParser parser(pLocale);
+  parser.setDate(x.c_str());
+
+  // Explicit date-only order (no '_' suffix means date-only, e.g. "mdy", "dmy")
+  if (!pLocale->dateOrder_.empty() &&
+      pLocale->dateOrder_.find('_') == std::string::npos) {
+    return parser.parseDateOrder(pLocale->dateOrder_);
+  }
+
+  // If a datetime order is explicitly set, don't match as date-only
+  if (!pLocale->dateOrder_.empty()) {
+    return false;
+  }
+
+  // Auto-detection: locale date format first (handles YMD/%AD), then year-last heuristic
+  if (parser.parseLocaleDate()) return true;
 
   parser.setDate(x.c_str());
-  return parser.parseLocaleDate();
+  return parser.parseYearLastHeuristic();
 }
 
 static bool isDateTime(const std::string& x, LocaleInfo* pLocale) {
   DateTimeParser parser(pLocale);
-
   parser.setDate(x.c_str());
-  bool ok = parser.parseISO8601();
 
-  if (!ok) {
+  // Explicit datetime order (has '_' suffix, e.g. "mdy_hms", "dmy_hm")
+  if (!pLocale->dateOrder_.empty() &&
+      pLocale->dateOrder_.find('_') != std::string::npos) {
+    if (!parser.parseDateOrder(pLocale->dateOrder_)) return false;
+    return parser.makeDateTime().validDateTime();
+  }
+
+  // If a date-only order is explicitly set, don't match as datetime
+  if (!pLocale->dateOrder_.empty()) {
     return false;
   }
 
-  if (!parser.compactDate()) {
-    return true;
-  }
+  // Auto-detection: ISO8601 only (YMD, existing behavior — no change)
+  bool ok = parser.parseISO8601();
+  if (!ok) return false;
 
-  // Values like 00014567 are unlikely to be dates, so don't guess
+  if (!parser.compactDate()) return true;
   return parser.year() > 999;
 }
 

--- a/src/CollectorGuess.cpp
+++ b/src/CollectorGuess.cpp
@@ -132,12 +132,16 @@ static bool isDateTime(const std::string& x, LocaleInfo* pLocale) {
     return false;
   }
 
-  // Auto-detection: ISO8601 only (YMD, existing behavior — no change)
-  bool ok = parser.parseISO8601();
-  if (!ok) return false;
+  // Auto-detection: ISO8601 first (YMD), then year-last (M/D/Y or D/M/Y)
+  // heuristic so MDY/DMY datetimes (including 2-digit years) are recognized.
+  // (Issue #36088)
+  if (parser.parseISO8601()) {
+    if (!parser.compactDate()) return true;
+    return parser.year() > 999;
+  }
 
-  if (!parser.compactDate()) return true;
-  return parser.year() > 999;
+  parser.setDate(x.c_str());
+  return parser.parseYearLastHeuristicDateTime();
 }
 
 [[cpp11::register]] std::string collectorGuess(

--- a/src/DateTimeParser.h
+++ b/src/DateTimeParser.h
@@ -145,7 +145,7 @@ public:
 
       switch (datePart[i]) {
         case 'y':
-          if (!consumeInteger(4, &year_)) return false;
+          if (!consumeYearFlexible()) return false;
           break;
         case 'm':
           if (!consumeInteger(2, &mon_, false)) return false;
@@ -192,8 +192,40 @@ public:
     return isComplete();
   }
 
-  // Heuristic for year-last date patterns: D/M/YYYY or M/D/YYYY
-  // Matches: \d{1,2}[sep]\d{1,2}[sep]\d{4}
+  // Consume a year that may be 2 or 4 digits. 2-digit years use the same pivot
+  // as the %y format specifier (00-68 -> 2000s, 69-99 -> 1900s). 3-digit values
+  // (100-999) are implausible and rejected. (Issue #36088)
+  bool consumeYearFlexible() {
+    if (!consumeInteger(4, &year_, false)) return false;
+    if (year_ < 100) {
+      year_ += (year_ < 69) ? 2000 : 1900;
+    } else if (year_ < 1000) {
+      return false;
+    }
+    return true;
+  }
+
+  // Disambiguate a year-last date's first two components into month and day.
+  // part1 > 12 -> DMY; part2 > 12 -> MDY; otherwise default to MDY (US).
+  // Returns false if the resulting month/day are out of range.
+  bool disambiguateDayMonth(int part1, int part2) {
+    if (part1 > 12) {
+      day_ = part1;
+      mon_ = part2;
+    } else if (part2 > 12) {
+      mon_ = part1;
+      day_ = part2;
+    } else {
+      mon_ = part1;
+      day_ = part2;
+    }
+    if (mon_ < 1 || mon_ > 12) return false;
+    if (day_ < 1 || day_ > 31) return false;
+    return true;
+  }
+
+  // Heuristic for year-last date patterns: D/M/Y or M/D/Y (Y = 2 or 4 digits)
+  // Matches: \d{1,2}[sep]\d{1,2}[sep]\d{2,4}
   // Disambiguation: if part1 > 12 → DMY; if part2 > 12 → MDY; else → MDY (default)
   bool parseYearLastHeuristic() {
     int part1, part2;
@@ -202,31 +234,43 @@ public:
     if (!consumeDateSeparator()) return false;
     if (!consumeInteger(2, &part2, false)) return false;
     if (!consumeDateSeparator()) return false;
-    if (!consumeInteger(4, &year_)) return false;
+    if (!consumeYearFlexible()) return false;
     if (!isComplete()) return false;
 
-    // Validate year is plausible
-    if (year_ < 1000) return false;
+    return disambiguateDayMonth(part1, part2);
+  }
 
-    if (part1 > 12) {
-      // Must be DMY
-      day_ = part1;
-      mon_ = part2;
-    } else if (part2 > 12) {
-      // Must be MDY
-      mon_ = part1;
-      day_ = part2;
-    } else {
-      // Ambiguous: default to MDY (US convention)
-      mon_ = part1;
-      day_ = part2;
-    }
+  // Year-last datetime heuristic: a year-last date (M/D/Y or D/M/Y, 2 or 4 digit
+  // year) followed by a T/space separator and a HH[:MM[:SS]] time with optional
+  // timezone. Mirrors the time tail of parseISO8601. (Issue #36088)
+  bool parseYearLastHeuristicDateTime() {
+    int part1, part2;
 
-    // Validate month and day are in plausible range
-    if (mon_ < 1 || mon_ > 12) return false;
-    if (day_ < 1 || day_ > 31) return false;
+    if (!consumeInteger(2, &part1, false)) return false;
+    if (!consumeDateSeparator()) return false;
+    if (!consumeInteger(2, &part2, false)) return false;
+    if (!consumeDateSeparator()) return false;
+    if (!consumeYearFlexible()) return false;
+    if (!disambiguateDayMonth(part1, part2)) return false;
 
-    return true;
+    // Time portion is required (date-only is handled by parseYearLastHeuristic).
+    char next;
+    if (!consumeChar(&next)) return false;
+    if (next != 'T' && next != ' ') return false;
+
+    if (!consumeInteger(2, &hour_)) return false;
+    consumeThisChar(':');
+    consumeInteger(2, &min_);
+    consumeThisChar(':');
+    consumeSeconds(&sec_, &psec_);
+
+    if (isComplete()) return true;
+
+    // Optional timezone
+    tz_ = "UTC";
+    if (!consumeTzOffset(&tzOffsetHours_, &tzOffsetMinutes_)) return false;
+
+    return isComplete();
   }
 
   bool isComplete() { return dateItr_ == dateEnd_; }

--- a/src/DateTimeParser.h
+++ b/src/DateTimeParser.h
@@ -39,14 +39,16 @@ public:
   // parsing with a format string so it doesn't seem necessary to add individual
   // parsers for other common formats.
   bool parseISO8601(bool partial = true) {
-    // Date: YYYY-MM-DD, YYYYMMDD
+    // Date: YYYY-MM-DD, YYYYMMDD, YYYY/MM/DD, YYYY.MM.DD, etc.
+    // Accepts any non-alphanumeric separator between date components,
+    // similar to lubridate's ymd() flexible parsing.
     if (!consumeInteger(4, &year_))
       return false;
-    if (consumeThisChar('-'))
+    if (consumeDateSeparator())
       compactDate_ = false;
     if (!consumeInteger(2, &mon_))
       return false;
-    if (!compactDate_ && !consumeThisChar('-'))
+    if (!compactDate_ && !consumeDateSeparator())
       return false;
     if (!consumeInteger(2, &day_))
       return false;
@@ -104,19 +106,127 @@ public:
   }
 
   bool parseDate() {
-    // Date: YYYY-MM-DD, YYYY/MM/DD
+    // Date: YYYY-MM-DD, YYYY/MM/DD, YYYY.MM.DD, etc.
+    // Accepts any non-alphanumeric separator between date components.
     if (!consumeInteger(4, &year_))
       return false;
-    if (!consumeThisChar('-') && !consumeThisChar('/'))
+    if (!consumeDateSeparator())
       return false;
     if (!consumeInteger(2, &mon_))
       return false;
-    if (!consumeThisChar('-') && !consumeThisChar('/'))
+    if (!consumeDateSeparator())
       return false;
     if (!consumeInteger(2, &day_))
       return false;
 
     return isComplete();
+  }
+
+  // Parse a date (and optionally time) according to an explicit component order.
+  // dateOrder examples: "mdy", "dmy", "ymd", "mdy_hms", "dmy_hm", "ymd_h"
+  // Date components: y=year(4-digit), m=month(1-2 digit), d=day(1-2 digit)
+  // Time suffixes: h=HH, hm=HH:MM, hms=HH:MM:SS
+  bool parseDateOrder(const std::string& order) {
+    // Split on '_' into date part and optional time part
+    std::string datePart, timePart;
+    size_t underscore = order.find('_');
+    if (underscore != std::string::npos) {
+      datePart = order.substr(0, underscore);
+      timePart = order.substr(underscore + 1);
+    } else {
+      datePart = order;
+      timePart = "";
+    }
+
+    // Parse date components in the specified order
+    for (size_t i = 0; i < datePart.size(); i++) {
+      if (i > 0 && !consumeDateSeparator())
+        return false;
+
+      switch (datePart[i]) {
+        case 'y':
+          if (!consumeInteger(4, &year_)) return false;
+          break;
+        case 'm':
+          if (!consumeInteger(2, &mon_, false)) return false;
+          break;
+        case 'd':
+          if (!consumeInteger(2, &day_, false)) return false;
+          break;
+        default:
+          return false;
+      }
+    }
+
+    // Date-only: must consume entire input
+    if (timePart.empty())
+      return isComplete();
+
+    // Date+time: consume separator (T or space)
+    char next;
+    if (!consumeChar(&next)) return false;
+    if (next != 'T' && next != ' ') return false;
+
+    // Parse hour (always present in any time suffix)
+    if (!consumeInteger(2, &hour_)) return false;
+
+    if (timePart == "h")
+      return isComplete();
+
+    // "hm" or "hms": parse minutes
+    consumeThisChar(':');
+    if (!consumeInteger(2, &min_)) return false;
+
+    if (timePart == "hm")
+      return isComplete();
+
+    // "hms": parse seconds (optional fractional)
+    consumeThisChar(':');
+    consumeSeconds(&sec_, &psec_);
+
+    // Optional timezone (same as ISO8601)
+    if (isComplete()) return true;
+    tz_ = "UTC";
+    consumeTzOffset(&tzOffsetHours_, &tzOffsetMinutes_);
+
+    return isComplete();
+  }
+
+  // Heuristic for year-last date patterns: D/M/YYYY or M/D/YYYY
+  // Matches: \d{1,2}[sep]\d{1,2}[sep]\d{4}
+  // Disambiguation: if part1 > 12 → DMY; if part2 > 12 → MDY; else → MDY (default)
+  bool parseYearLastHeuristic() {
+    int part1, part2;
+
+    if (!consumeInteger(2, &part1, false)) return false;
+    if (!consumeDateSeparator()) return false;
+    if (!consumeInteger(2, &part2, false)) return false;
+    if (!consumeDateSeparator()) return false;
+    if (!consumeInteger(4, &year_)) return false;
+    if (!isComplete()) return false;
+
+    // Validate year is plausible
+    if (year_ < 1000) return false;
+
+    if (part1 > 12) {
+      // Must be DMY
+      day_ = part1;
+      mon_ = part2;
+    } else if (part2 > 12) {
+      // Must be MDY
+      mon_ = part1;
+      day_ = part2;
+    } else {
+      // Ambiguous: default to MDY (US convention)
+      mon_ = part1;
+      day_ = part2;
+    }
+
+    // Validate month and day are in plausible range
+    if (mon_ < 1 || mon_ > 12) return false;
+    if (day_ < 1 || day_ > 31) return false;
+
+    return true;
   }
 
   bool isComplete() { return dateItr_ == dateEnd_; }
@@ -424,6 +534,19 @@ private:
     while (dateItr_ != dateEnd_ && std::isspace(*dateItr_))
       dateItr_++;
 
+    return true;
+  }
+
+  // Consume a single non-alphanumeric, non-space character as a date separator.
+  // Accepts: - / . , ; and other punctuation, similar to lubridate's ymd().
+  // Rejects: digits, letters, whitespace (to avoid false positives).
+  inline bool consumeDateSeparator() {
+    if (dateItr_ == dateEnd_)
+      return false;
+    char c = *dateItr_;
+    if (std::isalnum(c) || std::isspace(c))
+      return false;
+    dateItr_++;
     return true;
   }
 

--- a/src/LocaleInfo.cpp
+++ b/src/LocaleInfo.cpp
@@ -27,5 +27,11 @@ LocaleInfo::LocaleInfo(const cpp11::list& x)
   dateFormat_ = cpp11::as_cpp<std::string>(x["date_format"]);
   timeFormat_ = cpp11::as_cpp<std::string>(x["time_format"]);
 
+  // date_order is optional (NULL in R becomes empty string)
+  SEXP date_order_sexp = x["date_order"];
+  dateOrder_ = (date_order_sexp == R_NilValue)
+    ? ""
+    : cpp11::as_cpp<std::string>(date_order_sexp);
+
   tz_ = cpp11::as_cpp<std::string>(x["tz"]);
 }

--- a/src/LocaleInfo.h
+++ b/src/LocaleInfo.h
@@ -13,6 +13,7 @@ public:
   // LC_TIME
   std::vector<std::string> mon_, monAb_, day_, dayAb_, amPm_;
   std::string dateFormat_, timeFormat_;
+  std::string dateOrder_;  // date component order (e.g. "mdy", "dmy_hms"), empty = auto
 
   // LC_NUMERIC
   char decimalMark_, groupingMark_;

--- a/tests/testthat/test-locale.R
+++ b/tests/testthat/test-locale.R
@@ -14,3 +14,19 @@ test_that("grouping and decimal marks must be different", {
     error = TRUE
   )
 })
+
+test_that("locale() accepts date_order parameter", {
+  loc <- locale(date_order = "mdy")
+  expect_equal(loc$date_order, "mdy")
+
+  loc2 <- locale(date_order = "dmy_hms")
+  expect_equal(loc2$date_order, "dmy_hms")
+
+  loc3 <- locale()
+  expect_null(loc3$date_order)
+})
+
+test_that("locale() rejects invalid date_order", {
+  expect_error(locale(date_order = "ymd_xyz"), "date_order")
+  expect_error(locale(date_order = "bad"), "date_order")
+})

--- a/tests/testthat/test-parsing-datetime.R
+++ b/tests/testthat/test-parsing-datetime.R
@@ -392,3 +392,76 @@ test_that("parse_datetime parses dmy_hms with locale date_order", {
   result <- parse_datetime(c("02/10/2024 14:30:00"), locale = loc)
   expect_equal(result, as.POSIXct("2024-10-02 14:30:00", tz = "UTC"))
 })
+
+# --- 2-digit-year (M/D/YY) auto-detection ---
+
+test_that("read_csv() auto-detects 2-digit-year MDY dates", {
+  csv <- "id,date\n1,5/29/26\n2,5/31/26\n3,12/25/26"
+  result <- read_csv(I(csv), show_col_types = FALSE)
+  expect_s3_class(result$date, "Date")
+  expect_equal(result$date, as.Date(c("2026-05-29", "2026-05-31", "2026-12-25")))
+})
+
+test_that("read_csv() auto-detects 2-digit-year DMY dates", {
+  # 29 > 12 in the first part: unambiguously day-first
+  csv <- "id,date\n1,29/5/26\n2,20/1/26"
+  result <- read_csv(I(csv), show_col_types = FALSE)
+  expect_s3_class(result$date, "Date")
+  expect_equal(result$date, as.Date(c("2026-05-29", "2026-01-20")))
+})
+
+test_that("type_convert() materializes year-last dates (guesser and collector agree)", {
+  df <- data.frame(date = c("5/29/2026", "3/15/2026"), stringsAsFactors = FALSE)
+  result <- type_convert(df, guess_integer = FALSE)
+  expect_s3_class(result$date, "Date")
+  expect_equal(result$date, as.Date(c("2026-05-29", "2026-03-15")))
+})
+
+test_that("read_csv() applies the %y pivot to 2-digit years", {
+  csv <- "id,date\n1,5/29/68\n2,5/29/69"
+  result <- read_csv(I(csv), show_col_types = FALSE)
+  expect_s3_class(result$date, "Date")
+  expect_equal(result$date, as.Date(c("2068-05-29", "1969-05-29")))
+})
+
+test_that("guess_parser detects 2-digit-year year-last dates", {
+  expect_equal(guess_parser(c("5/29/26", "5/31/26"), locale()), "date")
+})
+
+test_that("read_csv() does not treat invalid or 3-digit-year values as year-last dates", {
+  for (v in c("13/25/26", "100/200/300")) {
+    result <- read_csv(I(paste0("x\n", v, "\n")), show_col_types = FALSE)
+    expect_type(result$x, "character")
+  }
+})
+
+test_that("read_csv() auto-detects 2-digit-year MDY datetimes", {
+  csv <- "id,dt\n1,5/29/26 14:30:00\n2,12/25/26 23:59:59"
+  result <- read_csv(I(csv), show_col_types = FALSE)
+  expect_s3_class(result$dt, "POSIXct")
+  expect_equal(
+    result$dt,
+    as.POSIXct(c("2026-05-29 14:30:00", "2026-12-25 23:59:59"), tz = "UTC")
+  )
+})
+
+test_that("read_csv() auto-detects 4-digit-year MDY datetimes", {
+  csv <- "id,dt\n1,5/29/2026 14:30:00\n2,10/15/2024 09:00:00"
+  result <- read_csv(I(csv), show_col_types = FALSE)
+  expect_s3_class(result$dt, "POSIXct")
+  expect_equal(
+    result$dt,
+    as.POSIXct(c("2026-05-29 14:30:00", "2024-10-15 09:00:00"), tz = "UTC")
+  )
+})
+
+test_that("parse_date parses 2-digit-year MDY/DMY with locale date_order", {
+  expect_equal(
+    parse_date("5/29/26", locale = locale(date_order = "mdy")),
+    as.Date("2026-05-29")
+  )
+  expect_equal(
+    parse_date("29/5/26", locale = locale(date_order = "dmy")),
+    as.Date("2026-05-29")
+  )
+})

--- a/tests/testthat/test-parsing-datetime.R
+++ b/tests/testthat/test-parsing-datetime.R
@@ -348,3 +348,47 @@ test_that("Invalid formats error", {
     error = TRUE
   )
 })
+
+# --- date_order tests ---
+test_that("guess_parser detects MDY dates with explicit date_order", {
+  loc_mdy <- locale(date_order = "mdy")
+  expect_equal(
+    guess_parser(c("10/02/2024", "03/15/2024"), locale = loc_mdy),
+    "date"
+  )
+})
+
+test_that("guess_parser detects DMY dates with explicit date_order", {
+  loc_dmy <- locale(date_order = "dmy")
+  expect_equal(
+    guess_parser(c("02/10/2024", "15/03/2024"), locale = loc_dmy),
+    "date"
+  )
+})
+
+test_that("guess_parser detects MDY datetime with explicit date_order", {
+  loc <- locale(date_order = "mdy_hms")
+  expect_equal(guess_parser(c("10/02/2024 14:30:00"), locale = loc), "datetime")
+})
+
+test_that("guess_parser auto-detects year-last date without date_order", {
+  # 15/03/2024: part1=15 > 12, unambiguously DMY
+  expect_equal(guess_parser(c("15/03/2024", "20/01/2024")), "date")
+})
+
+test_that("guess_parser auto-detects ambiguous year-last as MDY by default", {
+  # 10/02/2024: ambiguous, defaults to MDY — still detected as date
+  expect_equal(guess_parser(c("10/02/2024", "03/15/2024")), "date")
+})
+
+test_that("parse_date parses MDY with locale date_order", {
+  loc <- locale(date_order = "mdy")
+  result <- parse_date(c("10/02/2024", "03/15/2024"), locale = loc)
+  expect_equal(result, as.Date(c("2024-10-02", "2024-03-15")))
+})
+
+test_that("parse_datetime parses dmy_hms with locale date_order", {
+  loc <- locale(date_order = "dmy_hms")
+  result <- parse_datetime(c("02/10/2024 14:30:00"), locale = loc)
+  expect_equal(result, as.POSIXct("2024-10-02 14:30:00", tz = "UTC"))
+})


### PR DESCRIPTION
## Summary

Adds a `date_order` argument to `locale()` and makes date / date-time auto-detection more forgiving, so year-last dates (e.g. `10/02/2024`) can be parsed as dates instead of guessed as character.

* **`locale(date_order =)`** — new optional argument accepting an explicit component order: `"ymd"`, `"mdy"`, `"dmy"`, etc., optionally with a time suffix (`"mdy_hms"`, `"dmy_hm"`, `"ymd_h"`). `NULL` (default) keeps current behaviour. Validated in R with a clear error message.
* **`DateTimeParser::parseDateOrder()`** — parses a value against an explicit order, including an optional `T`/space-separated time part.
* **`DateTimeParser::parseYearLastHeuristic()`** — recognises unambiguous `D/M/YYYY` vs `M/D/YYYY` (`part > 12` disambiguates; defaults to MDY when ambiguous). Used as an auto-detection fallback in both `isDate()` (guesser) and `CollectorDate::setValue()` (collector) so the two agree.
* **Flexible separators** — date parsing accepts any non-alphanumeric separator between components (`2024.10.02`, `2024/10/02`, …).
* **Collectors** — `CollectorDate` / `CollectorDateTime` hold a `LocaleInfo*` and dispatch through `parseDateOrder()` when `date_order` is set with no explicit format.

## Scope / known limitation

These changes affect readr's own C++ engine, which powers `parse_date()`, `parse_datetime()`, `guess_parser()`, and the **first edition** of `read_csv()`.

The **second edition** of `read_csv()` (default since readr 2.0) delegates parsing to the **vroom** package, which does not yet know about `date_order`. Full end-to-end `read_csv()` support in the default edition therefore depends on the companion vroom change (tidyverse/vroom#623). End-to-end `read_csv()` tests are intentionally omitted from this PR until that lands.

## Test plan

- [x] `tests/testthat/test-locale.R` — `locale()` accepts valid `date_order`, rejects invalid values, defaults to `NULL`
- [x] `tests/testthat/test-parsing-datetime.R` — `guess_parser()` detects MDY/DMY dates and datetimes with explicit `date_order`
- [x] `guess_parser()` auto-detects unambiguous DMY year-last dates; ambiguous year-last defaults to MDY
- [x] `parse_date()` / `parse_datetime()` honour `locale(date_order =)`
- [x] existing YMD / ISO-8601 behaviour unchanged (backward compatibility)