### PR TITLE
Update write_ documentation to indicate .zip support

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -64,4 +64,4 @@ Config/usethis/last-upkeep: 2025-11-14
 Encoding: UTF-8
 Language: en-US
 Roxygen: list(markdown = TRUE, r6 = FALSE)
-RoxygenNote: 7.3.3
+Config/roxygen2/version: 8.0.0

--- a/R/write.R
+++ b/R/write.R
@@ -24,7 +24,7 @@
 #' Values are only quoted if they contain a comma, quote or newline.
 #'
 #' The `write_*()` functions will automatically compress outputs if an appropriate extension is given.
-#' Three extensions are currently supported: `.gz` for gzip compression, `.bz2` for bzip2 compression and
+#' Four extensions are currently supported: `.zip` for zip compression, `.gz` for gzip compression, `.bz2` for bzip2 compression and
 #' `.xz` for lzma compression.  See the examples for more information.
 #'
 #' @param x A data frame or tibble to write to disk.
@@ -59,6 +59,7 @@
 #'
 #' # If you add an extension to the file name, write_()* will
 #' # automatically compress the output.
+#' write_tsv(mtcars, "mtcars.tsv.zip")
 #' write_tsv(mtcars, "mtcars.tsv.gz")
 #' write_tsv(mtcars, "mtcars.tsv.bz2")
 #' write_tsv(mtcars, "mtcars.tsv.xz")

--- a/man/callback.Rd
+++ b/man/callback.Rd
@@ -48,9 +48,9 @@ f <- function(x, pos, acc) sum(x$mpg) + acc
 read_csv_chunked(readr_example("mtcars.csv"), AccumulateCallback$new(f, acc = 0), chunk_size = 5)
 }
 \seealso{
-Other chunked: 
-\code{\link{read_delim_chunked}()},
-\code{\link{read_lines_chunked}()}
+Other chunked:
+\code{\link[=read_delim_chunked]{read_delim_chunked()}},
+\code{\link[=read_lines_chunked]{read_lines_chunked()}}
 }
 \concept{chunked}
 \keyword{internal}

--- a/man/col_skip.Rd
+++ b/man/col_skip.Rd
@@ -11,14 +11,14 @@ Use this function to ignore a column when reading in a file.
 To skip all columns not otherwise specified, use \code{\link[=cols_only]{cols_only()}}.
 }
 \seealso{
-Other parsers: 
-\code{\link{cols}()},
-\code{\link{cols_condense}()},
-\code{\link{parse_datetime}()},
-\code{\link{parse_factor}()},
-\code{\link{parse_guess}()},
-\code{\link{parse_logical}()},
-\code{\link{parse_number}()},
-\code{\link{parse_vector}()}
+Other parsers:
+\code{\link[=cols]{cols()}},
+\code{\link[=cols_condense]{cols_condense()}},
+\code{\link[=parse_datetime]{parse_datetime()}},
+\code{\link[=parse_factor]{parse_factor()}},
+\code{\link[=parse_guess]{parse_guess()}},
+\code{\link[=parse_logical]{parse_logical()}},
+\code{\link[=parse_number]{parse_number()}},
+\code{\link[=parse_vector]{parse_vector()}}
 }
 \concept{parsers}

--- a/man/cols.Rd
+++ b/man/cols.Rd
@@ -66,14 +66,14 @@ t3$cols <- c(t1$cols, t2$cols)
 t3
 }
 \seealso{
-Other parsers: 
-\code{\link{col_skip}()},
-\code{\link{cols_condense}()},
-\code{\link{parse_datetime}()},
-\code{\link{parse_factor}()},
-\code{\link{parse_guess}()},
-\code{\link{parse_logical}()},
-\code{\link{parse_number}()},
-\code{\link{parse_vector}()}
+Other parsers:
+\code{\link[=col_skip]{col_skip()}},
+\code{\link[=cols_condense]{cols_condense()}},
+\code{\link[=parse_datetime]{parse_datetime()}},
+\code{\link[=parse_factor]{parse_factor()}},
+\code{\link[=parse_guess]{parse_guess()}},
+\code{\link[=parse_logical]{parse_logical()}},
+\code{\link[=parse_number]{parse_number()}},
+\code{\link[=parse_vector]{parse_vector()}}
 }
 \concept{parsers}

--- a/man/format_delim.Rd
+++ b/man/format_delim.Rd
@@ -110,7 +110,7 @@ This is common in some European countries.
 Values are only quoted if they contain a comma, quote or newline.
 
 The \verb{write_*()} functions will automatically compress outputs if an appropriate extension is given.
-Three extensions are currently supported: \code{.gz} for gzip compression, \code{.bz2} for bzip2 compression and
+Four extensions are currently supported: \code{.zip} for zip compression, \code{.gz} for gzip compression, \code{.bz2} for bzip2 compression and
 \code{.xz} for lzma compression.  See the examples for more information.
 }
 

--- a/man/parse_atomic.Rd
+++ b/man/parse_atomic.Rd
@@ -63,14 +63,14 @@ parse_double(x)
 parse_double(x, na = "-")
 }
 \seealso{
-Other parsers: 
-\code{\link{col_skip}()},
-\code{\link{cols}()},
-\code{\link{cols_condense}()},
-\code{\link{parse_datetime}()},
-\code{\link{parse_factor}()},
-\code{\link{parse_guess}()},
-\code{\link{parse_number}()},
-\code{\link{parse_vector}()}
+Other parsers:
+\code{\link[=col_skip]{col_skip()}},
+\code{\link[=cols]{cols()}},
+\code{\link[=cols_condense]{cols_condense()}},
+\code{\link[=parse_datetime]{parse_datetime()}},
+\code{\link[=parse_factor]{parse_factor()}},
+\code{\link[=parse_guess]{parse_guess()}},
+\code{\link[=parse_number]{parse_number()}},
+\code{\link[=parse_vector]{parse_vector()}}
 }
 \concept{parsers}

--- a/man/parse_datetime.Rd
+++ b/man/parse_datetime.Rd
@@ -188,14 +188,14 @@ parse_datetime("1979-10-14T1010Z", locale = us_central)
 parse_datetime("1979-10-14T1010", locale = locale(tz = ""))
 }
 \seealso{
-Other parsers: 
-\code{\link{col_skip}()},
-\code{\link{cols}()},
-\code{\link{cols_condense}()},
-\code{\link{parse_factor}()},
-\code{\link{parse_guess}()},
-\code{\link{parse_logical}()},
-\code{\link{parse_number}()},
-\code{\link{parse_vector}()}
+Other parsers:
+\code{\link[=col_skip]{col_skip()}},
+\code{\link[=cols]{cols()}},
+\code{\link[=cols_condense]{cols_condense()}},
+\code{\link[=parse_factor]{parse_factor()}},
+\code{\link[=parse_guess]{parse_guess()}},
+\code{\link[=parse_logical]{parse_logical()}},
+\code{\link[=parse_number]{parse_number()}},
+\code{\link[=parse_vector]{parse_vector()}}
 }
 \concept{parsers}

--- a/man/parse_factor.Rd
+++ b/man/parse_factor.Rd
@@ -68,14 +68,14 @@ factor(x, levels = animals)
 parse_factor(x, levels = animals)
 }
 \seealso{
-Other parsers: 
-\code{\link{col_skip}()},
-\code{\link{cols}()},
-\code{\link{cols_condense}()},
-\code{\link{parse_datetime}()},
-\code{\link{parse_guess}()},
-\code{\link{parse_logical}()},
-\code{\link{parse_number}()},
-\code{\link{parse_vector}()}
+Other parsers:
+\code{\link[=col_skip]{col_skip()}},
+\code{\link[=cols]{cols()}},
+\code{\link[=cols_condense]{cols_condense()}},
+\code{\link[=parse_datetime]{parse_datetime()}},
+\code{\link[=parse_guess]{parse_guess()}},
+\code{\link[=parse_logical]{parse_logical()}},
+\code{\link[=parse_number]{parse_number()}},
+\code{\link[=parse_vector]{parse_vector()}}
 }
 \concept{parsers}

--- a/man/parse_guess.Rd
+++ b/man/parse_guess.Rd
@@ -65,14 +65,14 @@ guess_parser(c("2010-10-10"))
 parse_guess(c("2010-10-10"))
 }
 \seealso{
-Other parsers: 
-\code{\link{col_skip}()},
-\code{\link{cols}()},
-\code{\link{cols_condense}()},
-\code{\link{parse_datetime}()},
-\code{\link{parse_factor}()},
-\code{\link{parse_logical}()},
-\code{\link{parse_number}()},
-\code{\link{parse_vector}()}
+Other parsers:
+\code{\link[=col_skip]{col_skip()}},
+\code{\link[=cols]{cols()}},
+\code{\link[=cols_condense]{cols_condense()}},
+\code{\link[=parse_datetime]{parse_datetime()}},
+\code{\link[=parse_factor]{parse_factor()}},
+\code{\link[=parse_logical]{parse_logical()}},
+\code{\link[=parse_number]{parse_number()}},
+\code{\link[=parse_vector]{parse_vector()}}
 }
 \concept{parsers}

--- a/man/parse_number.Rd
+++ b/man/parse_number.Rd
@@ -49,14 +49,14 @@ parse_number(c("1", "2", "3", "NA"))
 parse_number(c("1", "2", "3", "NA", "Nothing"), na = c("NA", "Nothing"))
 }
 \seealso{
-Other parsers: 
-\code{\link{col_skip}()},
-\code{\link{cols}()},
-\code{\link{cols_condense}()},
-\code{\link{parse_datetime}()},
-\code{\link{parse_factor}()},
-\code{\link{parse_guess}()},
-\code{\link{parse_logical}()},
-\code{\link{parse_vector}()}
+Other parsers:
+\code{\link[=col_skip]{col_skip()}},
+\code{\link[=cols]{cols()}},
+\code{\link[=cols_condense]{cols_condense()}},
+\code{\link[=parse_datetime]{parse_datetime()}},
+\code{\link[=parse_factor]{parse_factor()}},
+\code{\link[=parse_guess]{parse_guess()}},
+\code{\link[=parse_logical]{parse_logical()}},
+\code{\link[=parse_vector]{parse_vector()}}
 }
 \concept{parsers}

--- a/man/parse_vector.Rd
+++ b/man/parse_vector.Rd
@@ -38,15 +38,15 @@ parse_vector(x, col_integer())
 parse_vector(x, col_double())
 }
 \seealso{
-Other parsers: 
-\code{\link{col_skip}()},
-\code{\link{cols}()},
-\code{\link{cols_condense}()},
-\code{\link{parse_datetime}()},
-\code{\link{parse_factor}()},
-\code{\link{parse_guess}()},
-\code{\link{parse_logical}()},
-\code{\link{parse_number}()}
+Other parsers:
+\code{\link[=col_skip]{col_skip()}},
+\code{\link[=cols]{cols()}},
+\code{\link[=cols_condense]{cols_condense()}},
+\code{\link[=parse_datetime]{parse_datetime()}},
+\code{\link[=parse_factor]{parse_factor()}},
+\code{\link[=parse_guess]{parse_guess()}},
+\code{\link[=parse_logical]{parse_logical()}},
+\code{\link[=parse_number]{parse_number()}}
 }
 \concept{parsers}
 \keyword{internal}

--- a/man/read_delim.Rd
+++ b/man/read_delim.Rd
@@ -268,7 +268,7 @@ Learn more in \code{\link[=should_read_lazy]{should_read_lazy()}} and in the doc
 \code{altrep} argument of \code{\link[vroom:vroom]{vroom::vroom()}}.}
 }
 \value{
-A \code{\link[tibble:tibble]{tibble::tibble()}}. If there are parsing problems, a warning will alert you.
+A \code{\link[tibble:tibble]{tibble()}}. If there are parsing problems, a warning will alert you.
 You can retrieve the full details by calling \code{\link[=problems]{problems()}} on your dataset.
 }
 \description{

--- a/man/read_delim_chunked.Rd
+++ b/man/read_delim_chunked.Rd
@@ -216,9 +216,9 @@ f <- function(x, pos) subset(x, gear == 3)
 read_csv_chunked(readr_example("mtcars.csv"), DataFrameCallback$new(f), chunk_size = 5)
 }
 \seealso{
-Other chunked: 
+Other chunked:
 \code{\link{callback}},
-\code{\link{read_lines_chunked}()}
+\code{\link[=read_lines_chunked]{read_lines_chunked()}}
 }
 \concept{chunked}
 \keyword{internal}

--- a/man/read_lines_chunked.Rd
+++ b/man/read_lines_chunked.Rd
@@ -62,9 +62,9 @@ progress bar can be disabled by setting option \code{readr.show_progress} to
 Read lines from a file or string by chunk.
 }
 \seealso{
-Other chunked: 
+Other chunked:
 \code{\link{callback}},
-\code{\link{read_delim_chunked}()}
+\code{\link[=read_delim_chunked]{read_delim_chunked()}}
 }
 \concept{chunked}
 \keyword{internal}

--- a/man/read_rds.Rd
+++ b/man/read_rds.Rd
@@ -27,7 +27,7 @@ write_rds(
 \item{compress}{Compression method to use: "none", "gz" ,"bz", or "xz".}
 
 \item{version}{Serialization format version to be used. The default value is 2
-as it's compatible for R versions prior to 3.5.0. See \code{\link[base:readRDS]{base::saveRDS()}}
+as it's compatible for R versions prior to 3.5.0. See \code{\link[base:saveRDS]{base::saveRDS()}}
 for more details.}
 
 \item{text}{If \code{TRUE} a text representation is used, otherwise a binary representation is used.}

--- a/man/readr-package.Rd
+++ b/man/readr-package.Rd
@@ -24,6 +24,7 @@ Useful links:
 
 Authors:
 \itemize{
+  \item Jennifer Bryan \email{jenny@posit.co} (\href{https://orcid.org/0000-0002-6983-2759}{ORCID})
   \item Hadley Wickham \email{hadley@posit.co}
   \item Jim Hester
 }

--- a/man/spec.Rd
+++ b/man/spec.Rd
@@ -31,14 +31,14 @@ s
 cols_condense(s)
 }
 \seealso{
-Other parsers: 
-\code{\link{col_skip}()},
-\code{\link{cols}()},
-\code{\link{parse_datetime}()},
-\code{\link{parse_factor}()},
-\code{\link{parse_guess}()},
-\code{\link{parse_logical}()},
-\code{\link{parse_number}()},
-\code{\link{parse_vector}()}
+Other parsers:
+\code{\link[=col_skip]{col_skip()}},
+\code{\link[=cols]{cols()}},
+\code{\link[=parse_datetime]{parse_datetime()}},
+\code{\link[=parse_factor]{parse_factor()}},
+\code{\link[=parse_guess]{parse_guess()}},
+\code{\link[=parse_logical]{parse_logical()}},
+\code{\link[=parse_number]{parse_number()}},
+\code{\link[=parse_vector]{parse_vector()}}
 }
 \concept{parsers}

--- a/man/write_delim.Rd
+++ b/man/write_delim.Rd
@@ -166,7 +166,7 @@ This is common in some European countries.
 Values are only quoted if they contain a comma, quote or newline.
 
 The \verb{write_*()} functions will automatically compress outputs if an appropriate extension is given.
-Three extensions are currently supported: \code{.gz} for gzip compression, \code{.bz2} for bzip2 compression and
+Four extensions are currently supported: \code{.zip} for zip compression, \code{.gz} for gzip compression, \code{.bz2} for bzip2 compression and
 \code{.xz} for lzma compression.  See the examples for more information.
 }
 
@@ -181,6 +181,7 @@ write_tsv(mtcars, "mtcars.tsv")
 
 # If you add an extension to the file name, write_()* will
 # automatically compress the output.
+write_tsv(mtcars, "mtcars.tsv.zip")
 write_tsv(mtcars, "mtcars.tsv.gz")
 write_tsv(mtcars, "mtcars.tsv.bz2")
 write_tsv(mtcars, "mtcars.tsv.xz")


### PR DESCRIPTION
vroom supports writing .zip files and so does readr::write_csv() but documentation doesn't state that.  