### PR TITLE
Clarify parser edition used by parse functions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # readr (development version)
 
+* Clarified that `parse_*()` functions use the first edition parser, which can
+  differ from `col_*()` parsing in second edition `read_*()` calls (#1617).
+
 # readr 2.2.0
 
 This release advances many deprecations.

--- a/R/collectors.R
+++ b/R/collectors.R
@@ -57,6 +57,10 @@ parse_vector <- function(
 #' `col_*()` in conjunction with a `read_*()` function to parse the
 #' values as they're read in.
 #'
+#' The `parse_*()` functions use readr's first edition parser. When using
+#' readr's second edition, `read_*()` functions parse columns with vroom, so
+#' `col_*()` may differ from `parse_*()` in some edge cases.
+#'
 #' @name parse_atomic
 #' @aliases NULL
 #' @param x Character vector of values to parse.

--- a/man/parse_atomic.Rd
+++ b/man/parse_atomic.Rd
@@ -46,6 +46,10 @@ each field before parsing it?}
 Use \verb{parse_*()} if you have a character vector you want to parse. Use
 \verb{col_*()} in conjunction with a \verb{read_*()} function to parse the
 values as they're read in.
+
+The \verb{parse_*()} functions use readr's first edition parser. When using
+readr's second edition, \verb{read_*()} functions parse columns with vroom, so
+\verb{col_*()} may differ from \verb{parse_*()} in some edge cases.
 }
 \examples{
 parse_integer(c("1", "2", "3"))


### PR DESCRIPTION
Fixes #1617.

This updates the `parse_atomic` documentation to clarify that the `parse_*()` functions use readr's first edition parser, while second edition `read_*()` calls parse columns through vroom. That makes it explicit that `parse_*()` and `col_*()` can differ in some edge cases.

I also updated NEWS and the generated Rd file to keep the roxygen source and installed docs in sync.

Checks run locally:

```r
tools::checkRd("man/parse_atomic.Rd")
```

```sh
git diff --check
R CMD build --no-build-vignettes .
R_LIBS_USER=/tmp/readr-r-lib _R_CHECK_FORCE_SUGGESTS_=false R CMD check --no-manual --ignore-vignettes --no-build-vignettes --no-tests readr_2.2.0.9000.tar.gz
```

Notes:
- `vroom >= 1.7.0` was installed into a temporary local library for the package check.
- Full tests were not run locally because `testthat` is not installed in this environment.
