### PR TITLE
fix: support epoch seconds in parse_datetime

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # readr (development version)
 
+* `parse_datetime()` now supports the documented `%s` format for parsing seconds
+  since the Unix epoch (#1492, @LeonidasZhak).
+
 # readr 2.2.0
 
 This release advances many deprecations.

--- a/src/DateTimeParser.h
+++ b/src/DateTimeParser.h
@@ -7,6 +7,7 @@
 #include "cpp11/protect.hpp"
 
 #include "utils.h"
+#include <cmath>
 #include <ctime>
 
 // Parsing ---------------------------------------------------------------------
@@ -210,6 +211,14 @@ public:
         if (!consumeSeconds(&sec_, NULL))
           return false;
         break;
+      case 's': { // seconds since the Unix epoch
+        double epochSeconds;
+        if (!consumeEpochSeconds(&epochSeconds))
+          return false;
+        if (!setEpochSeconds(epochSeconds))
+          return false;
+        break;
+      }
       case 'O': // seconds (double)
         if (formatItr + 1 == formatEnd || *(formatItr + 1) != 'S')
           cpp11::stop("Invalid format: %%O must be followed by %%S");
@@ -420,6 +429,16 @@ private:
     return ok;
   }
 
+  inline bool consumeEpochSeconds(double* pOut) {
+    if (dateItr_ == dateEnd_)
+      return false;
+
+    const char* end = dateEnd_;
+    bool ok = parseDouble(pLocale_->decimalMark_, dateItr_, end, *pOut);
+    dateItr_ = end;
+    return ok;
+  }
+
   inline bool consumeWhiteSpace() {
     while (dateItr_ != dateEnd_ && std::isspace(*dateItr_))
       dateItr_++;
@@ -516,6 +535,40 @@ private:
 
     pOut->assign(tzStart, dateItr_);
     return tzStart != dateItr_;
+  }
+
+  inline bool setEpochSeconds(double seconds) {
+    if (!std::isfinite(seconds))
+      return false;
+
+    double wholeSeconds = std::floor(seconds);
+    double partialSeconds = seconds - wholeSeconds;
+
+    auto timestamp =
+        date::sys_time<std::chrono::seconds>(std::chrono::seconds(
+            static_cast<long long>(wholeSeconds)));
+    const date::sys_days day = date::floor<date::days>(timestamp);
+    const date::year_month_day ymd(day);
+
+    const auto time = timestamp - day;
+    const auto hours = std::chrono::duration_cast<std::chrono::hours>(time);
+    const auto minutes =
+        std::chrono::duration_cast<std::chrono::minutes>(time - hours);
+    const auto secs = std::chrono::duration_cast<std::chrono::seconds>(
+        time - hours - minutes);
+
+    year_ = static_cast<int>(ymd.year());
+    mon_ = static_cast<int>(static_cast<unsigned>(ymd.month()));
+    day_ = static_cast<int>(static_cast<unsigned>(ymd.day()));
+    hour_ = static_cast<int>(hours.count());
+    min_ = static_cast<int>(minutes.count());
+    sec_ = static_cast<int>(secs.count());
+    psec_ = partialSeconds;
+    tz_ = "UTC";
+    tzOffsetHours_ = 0;
+    tzOffsetMinutes_ = 0;
+
+    return true;
   }
 
   void reset() {

--- a/tests/testthat/test-parsing-datetime.R
+++ b/tests/testthat/test-parsing-datetime.R
@@ -58,6 +58,17 @@ test_that("%OS captures partial seconds", {
   expect_equal(as.POSIXlt(x)$sec, 1.333, tolerance = 1e-6)
 })
 
+test_that("%s parses seconds since the Unix epoch", {
+  expect_equal(
+    parse_datetime("1285912800", "%s"),
+    POSIXct(1285912800, "UTC")
+  )
+  expect_equal(
+    parse_datetime("-0.5", "%s"),
+    POSIXct(-0.5, "UTC")
+  )
+})
+
 test_that("%y requries 4 digits", {
   expect_warning(parse_date("003-01-01", "%Y-%m-%d"), "parsing failure")
   expect_warning(parse_date("03-01-01", "%Y-%m-%d"), "parsing failure")


### PR DESCRIPTION
Fixes #1492.

## Summary
- add `%s` handling to the datetime format parser
- convert parsed Unix epoch seconds back into the existing UTC DateTime path
- add regression coverage for integer and fractional epoch seconds

## Checks
- `git diff --check`
- `R CMD INSTALL .`
- `Rscript -e 'library(readr); x <- parse_datetime("1285912800", "%s"); y <- parse_datetime("-0.5", "%s"); stopifnot(inherits(x, "POSIXct"), identical(as.numeric(x), 1285912800), identical(as.numeric(y), -0.5))'`\n- `R CMD build --no-build-vignettes .`\n\nI also tried `R CMD check --no-manual --ignore-vignettes --no-build-vignettes`, but this local machine has `vroom` 1.6.7 while readr development requires a newer version, and is missing optional suggested packages `covr` and `spelling`.