### PR TITLE
docs: document file column in problems() return value

### DIFF
--- a/R/problems.R
+++ b/R/problems.R
@@ -9,17 +9,26 @@
 #' an error as soon as you encounter a problem.
 #'
 #' @param x A data frame (from `read_*()`) or a vector (from `parse_*()`).
-#' @return A data frame with one row for each problem and four columns:
+#' @return A data frame with one row for each problem. Columns include:
 #'   \item{row,col}{Row and column of problem}
 #'   \item{expected}{What readr expected to find}
 #'   \item{actual}{What it actually got}
+#'
+#'   When using the edition 2 parser (the default for `read_*()` functions),
+#'   the result also includes a `file` column identifying the source file.
 #' @export
 #' @examples
+#' # parse_*() functions return problems with row, col, expected, actual
 #' x <- parse_integer(c("1X", "blah", "3"))
 #' problems(x)
 #'
+#' # When there are no problems, the result is an empty data frame
 #' y <- parse_integer(c("1", "2", "3"))
 #' problems(y)
+#'
+#' # read_*() functions also include a file column
+#' z <- read_csv(I("x\n1\n2\nb"), col_types = "d", show_col_types = FALSE)
+#' problems(z)
 problems <- local({
   no_problems <- tibble::tibble(
     row = integer(),

--- a/man/problems.Rd
+++ b/man/problems.Rd
@@ -13,10 +13,13 @@ stop_for_problems(x)
 \item{x}{A data frame (from \verb{read_*()}) or a vector (from \verb{parse_*()}).}
 }
 \value{
-A data frame with one row for each problem and four columns:
+A data frame with one row for each problem. Columns include:
 \item{row,col}{Row and column of problem}
 \item{expected}{What readr expected to find}
 \item{actual}{What it actually got}
+
+When using the edition 2 parser (the default for \verb{read_*()} functions),
+the result also includes a \code{file} column identifying the source file.
 }
 \description{
 Readr functions will only throw an error if parsing fails in an unrecoverable
@@ -28,9 +31,15 @@ problems: this is useful for automated scripts where you want to throw
 an error as soon as you encounter a problem.
 }
 \examples{
+# parse_*() functions return problems with row, col, expected, actual
 x <- parse_integer(c("1X", "blah", "3"))
 problems(x)
 
+# When there are no problems, the result is an empty data frame
 y <- parse_integer(c("1", "2", "3"))
 problems(y)
+
+# read_*() functions also include a file column
+z <- read_csv(I("x\n1\n2\nb"), col_types = "d", show_col_types = FALSE)
+problems(z)
 }


### PR DESCRIPTION
## What

The `problems()` return value documentation claims the result has "four columns" but edition 2 `read_*()` functions (via vroom) actually return five columns, including a `file` column. This PR updates the `@return` tag to describe both cases and adds an example demonstrating the `file` column.

## Changes

- `R/problems.R`: Updated roxygen `@return` to document the `file` column present in edition 2 results; added comments and a `read_csv()` example.
- `man/problems.Rd`: Regenerated from roxygen source.

## Validation

```r
tools::checkRd(man/problems.Rd)
```

```sh
R CMD build --no-build-vignettes .
R CMD check --no-manual --ignore-vignettes --no-build-vignettes --no-tests readr_*.tar.gz
```

Check status: OK (clean).

## Related

- Complements #1626 (clarifying parser edition used by parse functions)
- Addresses the documentation gap noted in #1617