### PR TITLE
docs: document col_big_integer() [I] in cols() help

### DIFF
--- a/R/col_types.R
+++ b/R/col_types.R
@@ -9,6 +9,9 @@
 #'
 #' * `col_logical()` \[l\], containing only `T`, `F`, `TRUE` or `FALSE`.
 #' * `col_integer()` \[i\], integers.
+#' * `col_big_integer()` \[I\], 64-bit (big) integers. Requires the \pkg{bit64}
+#'   package. Available when using the edition 2 parser (the default for
+#'   `read_*()` functions).
 #' * `col_double()` \[d\], doubles.
 #' * `col_character()` \[c\], everything else.
 #' * `col_factor(levels, ordered)` \[f\], a fixed set of values.

--- a/man/cols.Rd
+++ b/man/cols.Rd
@@ -30,6 +30,9 @@ The available specifications are: (with string abbreviations in brackets)
 \itemize{
 \item \code{col_logical()} [l], containing only \code{T}, \code{F}, \code{TRUE} or \code{FALSE}.
 \item \code{col_integer()} [i], integers.
+\item \code{col_big_integer()} [I], 64-bit (big) integers. Requires the \pkg{bit64}
+package. Available when using the edition 2 parser (the default for
+\verb{read_*()} functions).
 \item \code{col_double()} [d], doubles.
 \item \code{col_character()} [c], everything else.
 \item \code{col_factor(levels, ordered)} [f], a fixed set of values.
@@ -66,14 +69,14 @@ t3$cols <- c(t1$cols, t2$cols)
 t3
 }
 \seealso{
-Other parsers: 
-\code{\link{col_skip}()},
-\code{\link{cols_condense}()},
-\code{\link{parse_datetime}()},
-\code{\link{parse_factor}()},
-\code{\link{parse_guess}()},
-\code{\link{parse_logical}()},
-\code{\link{parse_number}()},
-\code{\link{parse_vector}()}
+Other parsers:
+\code{\link[=col_skip]{col_skip()}},
+\code{\link[=cols_condense]{cols_condense()}},
+\code{\link[=parse_datetime]{parse_datetime()}},
+\code{\link[=parse_factor]{parse_factor()}},
+\code{\link[=parse_guess]{parse_guess()}},
+\code{\link[=parse_logical]{parse_logical()}},
+\code{\link[=parse_number]{parse_number()}},
+\code{\link[=parse_vector]{parse_vector()}}
 }
 \concept{parsers}


### PR DESCRIPTION
Closes #1564.

## What

Adds `col_big_integer()` [I] to the list of available column type specifications in the `cols()` documentation.

## Why

The `I` shortcut for 64-bit integers works when using readr edition 2 parser (vroom backend, the default for `read_*()` functions), but was not listed in the `cols()` help page. Users had no way to discover this from the docs.

## Changes

- `R/col_types.R`: Added `col_big_integer()` [I] entry to the roxygen documentation list, noting the `bit64` dependency and edition 2 availability.
- `man/cols.Rd`: Regenerated from roxygen source.

## Validation

- tools::checkRd("man/cols.Rd") -- clean
- R CMD build --no-build-vignettes . -- OK
- R CMD check --no-manual --ignore-vignettes --no-build-vignettes --no-tests -- Status: OK