### PR TITLE
docs: clarify delim accepts multi-char strings, add col_select + col_types example

### DIFF
--- a/R/read_delim.R
+++ b/R/read_delim.R
@@ -169,6 +169,15 @@ NULL
 #' y
 #' problems(y)
 #'
+#' # Combining col_select and col_types ----------------------------------------
+#' # Use col_select to choose columns and col_types to specify their types.
+#' # This is useful when you only care about a subset of columns in a wide file.
+#' read_csv(
+#'   readr_example("chickens.csv"),
+#'   col_select = c(chicken, eggs_laid),
+#'   col_types = list(chicken = col_character(), eggs_laid = col_integer())
+#' )
+#'
 #' # Column names --------------------------------------------------------------
 #' # By default, readr duplicate name repair is noisy
 #' read_csv(I("x,x\n1,2\n3,4"))

--- a/R/tokenizer.R
+++ b/R/tokenizer.R
@@ -44,7 +44,7 @@ NULL
 #'   parameter is only supported in certain legacy functions (e.g., the
 #'   `read_*_chunked()` functions) or when requesting the legacy first edition
 #'   parser with [read_delim()] and friends.
-#' @param delim Single character used to separate fields within a record.
+#' @param delim One or more characters used to separate fields within a record.
 #' @param quote Single character used to quote strings.
 #' @param trim_ws Should leading and trailing whitespace (ASCII spaces and tabs) be trimmed from
 #'     each field before parsing it?

--- a/man/Tokenizers.Rd
+++ b/man/Tokenizers.Rd
@@ -57,7 +57,7 @@ tokenizer_fwf(
 tokenizer_ws(na = "NA", comment = "", skip_empty_rows = TRUE)
 }
 \arguments{
-\item{delim}{Single character used to separate fields within a record.}
+\item{delim}{One or more characters used to separate fields within a record.}
 
 \item{quote}{Single character used to quote strings.}
 

--- a/man/read_delim.Rd
+++ b/man/read_delim.Rd
@@ -116,7 +116,7 @@ decompressed.
 Literal data is most useful for examples and tests. To be recognised as
 literal data, wrap the input with \code{I()}.}
 
-\item{delim}{Single character used to separate fields within a record.}
+\item{delim}{One or more characters used to separate fields within a record.}
 
 \item{quote}{Single character used to quote strings.}
 
@@ -268,7 +268,7 @@ Learn more in \code{\link[=should_read_lazy]{should_read_lazy()}} and in the doc
 \code{altrep} argument of \code{\link[vroom:vroom]{vroom::vroom()}}.}
 }
 \value{
-A \code{\link[tibble:tibble]{tibble::tibble()}}. If there are parsing problems, a warning will alert you.
+A \code{\link[tibble:tibble]{tibble()}}. If there are parsing problems, a warning will alert you.
 You can retrieve the full details by calling \code{\link[=problems]{problems()}} on your dataset.
 }
 \description{
@@ -331,6 +331,15 @@ read_csv(I("x,y\n1,2\n3,4"), col_types = list(col_double(), col_character()))
 y <- read_csv(I("x\n1\n2\nb"), col_types = list(col_double()))
 y
 problems(y)
+
+# Combining col_select and col_types ----------------------------------------
+# Use col_select to choose columns and col_types to specify their types.
+# This is useful when you only care about a subset of columns in a wide file.
+read_csv(
+  readr_example("chickens.csv"),
+  col_select = c(chicken, eggs_laid),
+  col_types = list(chicken = col_character(), eggs_laid = col_integer())
+)
 
 # Column names --------------------------------------------------------------
 # By default, readr duplicate name repair is noisy


### PR DESCRIPTION
## What

Two documentation improvements:

1. **Clarify `delim` parameter** (fixes #1455): Update the `delim` parameter documentation from "Single character" to "One or more characters" to accurately reflect that multi-character delimiters are supported.

2. **Add `col_select` + `col_types` example** (fixes #1377): Add an example showing how to use `col_select` and `col_types` together, which is useful when reading a subset of columns from wide files with specific type requirements.

## Changes

- `R/tokenizer.R`: Update `@param delim` documentation
- `R/read_delim.R`: Add example combining `col_select` and `col_types`
- `man/Tokenizers.Rd`: Regenerated
- `man/read_delim.Rd`: Regenerated

## Validation

- `devtools::document()` — clean
- `devtools::test()` — 644 pass, 1 pre-existing failure (encoding on macOS), 16 skip