### PR TITLE
docs: fix typos in read_fwf documentation and tests

### DIFF
--- a/R/read_fwf.R
+++ b/R/read_fwf.R
@@ -25,7 +25,7 @@
 #' decompress, if relevant) the file first.
 #'
 #' @details
-#' Here's a enhanced example using the contents of the file accessed via
+#' Here's an enhanced example using the contents of the file accessed via
 #' `readr_example("fwf-sample.txt")`.
 #'
 #' ```

--- a/tests/testthat/test-read-fwf.R
+++ b/tests/testthat/test-read-fwf.R
@@ -1,4 +1,4 @@
-test_that("trailing spaces ommitted", {
+test_that("trailing spaces omitted", {
   spec <- fwf_empty(test_fixture("fwf-trailing.txt"))
   expect_equal(spec$begin, c(0, 4))
   expect_equal(spec$end, c(3, NA))


### PR DESCRIPTION
Two minor typo fixes in read_fwf() documentation and tests.

Changes:
- R/read_fwf.R: Fix grammar 'a enhanced' -> 'an enhanced' in the @details section
- tests/testthat/test-read-fwf.R: Fix spelling 'ommitted' -> 'omitted' in test name

Validation:
- devtools::document() - clean
- devtools::test(filter = read-fwf) - all pass