### PR TITLE
fix: use correct function name in literal data deprecation examples

### DIFF
--- a/R/read_delim.R
+++ b/R/read_delim.R
@@ -624,10 +624,10 @@ standardise_literal_data <- function(file, fn, env, user_env) {
       details = c(
         " " = "",
         " " = "# Bad (for example):",
-        " " = 'read_csv("x,y\\n1,2")',
+        " " = paste0(fn, '("x,y\\n1,2")'),
         " " = "",
         " " = "# Good:",
-        " " = 'read_csv(I("x,y\\n1,2"))'
+        " " = paste0(fn, '(I("x,y\\n1,2"))')
       ),
       env = env,
       user_env = user_env

--- a/tests/testthat/_snaps/read-csv.md
+++ b/tests/testthat/_snaps/read-csv.md
@@ -31,10 +31,10 @@
       The `file` argument of `read_csv2()` should use `I()` for literal data as of readr 2.2.0.
         
         # Bad (for example):
-        read_csv("x,y\n1,2")
+        read_csv2("x,y\n1,2")
         
         # Good:
-        read_csv(I("x,y\n1,2"))
+        read_csv2(I("x,y\n1,2"))
 
 ---
 
@@ -45,10 +45,10 @@
       The `file` argument of `read_tsv()` should use `I()` for literal data as of readr 2.2.0.
         
         # Bad (for example):
-        read_csv("x,y\n1,2")
+        read_tsv("x,y\n1,2")
         
         # Good:
-        read_csv(I("x,y\n1,2"))
+        read_tsv(I("x,y\n1,2"))
 
 ---
 
@@ -59,8 +59,8 @@
       The `file` argument of `read_delim()` should use `I()` for literal data as of readr 2.2.0.
         
         # Bad (for example):
-        read_csv("x,y\n1,2")
+        read_delim("x,y\n1,2")
         
         # Good:
-        read_csv(I("x,y\n1,2"))
+        read_delim(I("x,y\n1,2"))
 

--- a/tests/testthat/_snaps/read-fwf.md
+++ b/tests/testthat/_snaps/read-fwf.md
@@ -7,8 +7,8 @@
       The `file` argument of `read_fwf()` should use `I()` for literal data as of readr 2.2.0.
         
         # Bad (for example):
-        read_csv("x,y\n1,2")
+        read_fwf("x,y\n1,2")
         
         # Good:
-        read_csv(I("x,y\n1,2"))
+        read_fwf(I("x,y\n1,2"))
 


### PR DESCRIPTION
## Problem

The `standardise_literal_data()` function hardcodes `read_csv()` in the deprecation warning examples, even when called from `read_csv2()`, `read_tsv()`, `read_delim()`, or `read_fwf()`.

This produces confusing warning messages like:

```
Warning:
The `file` argument of `read_csv2()` should use `I()` for literal data as of readr 2.2.0.
  
  # Bad (for example):
  read_csv("x,y\n1,2")    # <-- should say read_csv2()
  
  # Good:
  read_csv(I("x,y\n1,2"))  # <-- should say read_csv2()
```

## Fix

Use the `fn` parameter (already passed to `standardise_literal_data()`) in the example text instead of hardcoding `read_csv()`.

## Changes
- `R/read_delim.R`: Use `fn` in example text (lines 627, 630)
- `tests/testthat/_snaps/read-csv.md`: Update snapshots for `read_csv2()`, `read_tsv()`, `read_delim()`
- `tests/testthat/_snaps/read-fwf.md`: Update snapshot for `read_fwf()`

## Testing
- `devtools::test(filter = "read-csv|read-fwf")`: 147 passed, 0 failed, 13 skipped
- All snapshot tests updated to reflect corrected warning messages

## Notes
- Bug introduced in readr 2.2.0 (commit c2a334f)
- No breaking changes
- No existing issue or PR addresses this specific bug
