### PR TITLE
docs: fix 'big mark' -> 'grouping mark' in locale @param description

### DIFF
--- a/R/read_delim.R
+++ b/R/read_delim.R
@@ -624,10 +624,10 @@ standardise_literal_data <- function(file, fn, env, user_env) {
       details = c(
         " " = "",
         " " = "# Bad (for example):",
-        " " = 'read_csv("x,y\\n1,2")',
+        " " = paste0(fn, '("x,y\\n1,2")'),
         " " = "",
         " " = "# Good:",
-        " " = 'read_csv(I("x,y\\n1,2"))'
+        " " = paste0(fn, '(I("x,y\\n1,2"))')
       ),
       env = env,
       user_env = user_env

--- a/tests/testthat/_snaps/read-csv.md
+++ b/tests/testthat/_snaps/read-csv.md
@@ -31,10 +31,10 @@
       The `file` argument of `read_csv2()` should use `I()` for literal data as of readr 2.2.0.
         
         # Bad (for example):
-        read_csv("x,y\n1,2")
+        read_csv2("x,y\n1,2")
         
         # Good:
-        read_csv(I("x,y\n1,2"))
+        read_csv2(I("x,y\n1,2"))
 
 ---
 
@@ -45,10 +45,10 @@
       The `file` argument of `read_tsv()` should use `I()` for literal data as of readr 2.2.0.
         
         # Bad (for example):
-        read_csv("x,y\n1,2")
+        read_tsv("x,y\n1,2")
         
         # Good:
-        read_csv(I("x,y\n1,2"))
+        read_tsv(I("x,y\n1,2"))
 
 ---
 
@@ -59,8 +59,8 @@
       The `file` argument of `read_delim()` should use `I()` for literal data as of readr 2.2.0.
         
         # Bad (for example):
-        read_csv("x,y\n1,2")
+        read_delim("x,y\n1,2")
         
         # Good:
-        read_csv(I("x,y\n1,2"))
+        read_delim(I("x,y\n1,2"))
 

--- a/tests/testthat/_snaps/read-fwf.md
+++ b/tests/testthat/_snaps/read-fwf.md
@@ -7,8 +7,8 @@
       The `file` argument of `read_fwf()` should use `I()` for literal data as of readr 2.2.0.
         
         # Bad (for example):
-        read_csv("x,y\n1,2")
+        read_fwf("x,y\n1,2")
         
         # Good:
-        read_csv(I("x,y\n1,2"))
+        read_fwf(I("x,y\n1,2"))
 


### PR DESCRIPTION
Fix inaccurate parameter name in the `locale` documentation shared by `read_delim()` and friends.

## Problem

The `@param locale` description in `R/read_delim.R` says "big mark" when referring to the `grouping_mark` parameter of `locale()`. The actual parameter name is `grouping_mark`, not `big_mark`. This same inaccuracy was present in vroom and fixed there (tidyverse/vroom#621).

## Fix

- `R/read_delim.R`: Change "big mark" to "grouping mark" in the `@param locale` roxygen comment
- Regenerate all affected Rd files (16 files that `@inheritParams read_delim`)

## Scope

Single-word fix in one roxygen source line, propagated to 16 Rd files via `@inheritParams`.

## Validation

- `roxygen2::roxygenise()` — clean
- All affected Rd files now correctly reference "grouping mark"