### PR TITLE
docs: add 'I = big integer' to col_types compact string list in read_delim()

### DIFF
--- a/R/read_delim.R
+++ b/R/read_delim.R
@@ -65,7 +65,7 @@ NULL
 #' @param locale The locale controls defaults that vary from place to place.
 #'   The default locale is US-centric (like R), but you can use
 #'   [locale()] to create your own locale that controls things like
-#'   the default time zone, encoding, decimal mark, big mark, and day/month
+#'   the default time zone, encoding, decimal mark, grouping mark, and day/month
 #'   names.
 #' @param skip Number of lines to skip before reading data. If `comment` is
 #'   supplied any commented lines are ignored _after_ skipping.

--- a/R/read_delim.R
+++ b/R/read_delim.R
@@ -41,6 +41,7 @@ NULL
 #'    character represents one column:
 #'    - c = character
 #'    - i = integer
+#'    - I = big integer (requires the \pkg{bit64} package)
 #'    - n = number
 #'    - d = double
 #'    - l = logical

--- a/man/parse_atomic.Rd
+++ b/man/parse_atomic.Rd
@@ -36,7 +36,7 @@ option to \code{character()} to indicate no missing values.}
 \item{locale}{The locale controls defaults that vary from place to place.
 The default locale is US-centric (like R), but you can use
 \code{\link[=locale]{locale()}} to create your own locale that controls things like
-the default time zone, encoding, decimal mark, big mark, and day/month
+the default time zone, encoding, decimal mark, grouping mark, and day/month
 names.}
 
 \item{trim_ws}{Should leading and trailing whitespace (ASCII spaces and tabs) be trimmed from
@@ -63,14 +63,14 @@ parse_double(x)
 parse_double(x, na = "-")
 }
 \seealso{
-Other parsers: 
-\code{\link{col_skip}()},
-\code{\link{cols}()},
-\code{\link{cols_condense}()},
-\code{\link{parse_datetime}()},
-\code{\link{parse_factor}()},
-\code{\link{parse_guess}()},
-\code{\link{parse_number}()},
-\code{\link{parse_vector}()}
+Other parsers:
+\code{\link[=col_skip]{col_skip()}},
+\code{\link[=cols]{cols()}},
+\code{\link[=cols_condense]{cols_condense()}},
+\code{\link[=parse_datetime]{parse_datetime()}},
+\code{\link[=parse_factor]{parse_factor()}},
+\code{\link[=parse_guess]{parse_guess()}},
+\code{\link[=parse_number]{parse_number()}},
+\code{\link[=parse_vector]{parse_vector()}}
 }
 \concept{parsers}

--- a/man/parse_datetime.Rd
+++ b/man/parse_datetime.Rd
@@ -55,7 +55,7 @@ option to \code{character()} to indicate no missing values.}
 \item{locale}{The locale controls defaults that vary from place to place.
 The default locale is US-centric (like R), but you can use
 \code{\link[=locale]{locale()}} to create your own locale that controls things like
-the default time zone, encoding, decimal mark, big mark, and day/month
+the default time zone, encoding, decimal mark, grouping mark, and day/month
 names.}
 
 \item{trim_ws}{Should leading and trailing whitespace (ASCII spaces and tabs) be trimmed from
@@ -188,14 +188,14 @@ parse_datetime("1979-10-14T1010Z", locale = us_central)
 parse_datetime("1979-10-14T1010", locale = locale(tz = ""))
 }
 \seealso{
-Other parsers: 
-\code{\link{col_skip}()},
-\code{\link{cols}()},
-\code{\link{cols_condense}()},
-\code{\link{parse_factor}()},
-\code{\link{parse_guess}()},
-\code{\link{parse_logical}()},
-\code{\link{parse_number}()},
-\code{\link{parse_vector}()}
+Other parsers:
+\code{\link[=col_skip]{col_skip()}},
+\code{\link[=cols]{cols()}},
+\code{\link[=cols_condense]{cols_condense()}},
+\code{\link[=parse_factor]{parse_factor()}},
+\code{\link[=parse_guess]{parse_guess()}},
+\code{\link[=parse_logical]{parse_logical()}},
+\code{\link[=parse_number]{parse_number()}},
+\code{\link[=parse_vector]{parse_vector()}}
 }
 \concept{parsers}

--- a/man/parse_factor.Rd
+++ b/man/parse_factor.Rd
@@ -32,7 +32,7 @@ option to \code{character()} to indicate no missing values.}
 \item{locale}{The locale controls defaults that vary from place to place.
 The default locale is US-centric (like R), but you can use
 \code{\link[=locale]{locale()}} to create your own locale that controls things like
-the default time zone, encoding, decimal mark, big mark, and day/month
+the default time zone, encoding, decimal mark, grouping mark, and day/month
 names.}
 
 \item{include_na}{If \code{TRUE} and \code{x} contains at least one \code{NA}, then \code{NA}
@@ -68,14 +68,14 @@ factor(x, levels = animals)
 parse_factor(x, levels = animals)
 }
 \seealso{
-Other parsers: 
-\code{\link{col_skip}()},
-\code{\link{cols}()},
-\code{\link{cols_condense}()},
-\code{\link{parse_datetime}()},
-\code{\link{parse_guess}()},
-\code{\link{parse_logical}()},
-\code{\link{parse_number}()},
-\code{\link{parse_vector}()}
+Other parsers:
+\code{\link[=col_skip]{col_skip()}},
+\code{\link[=cols]{cols()}},
+\code{\link[=cols_condense]{cols_condense()}},
+\code{\link[=parse_datetime]{parse_datetime()}},
+\code{\link[=parse_guess]{parse_guess()}},
+\code{\link[=parse_logical]{parse_logical()}},
+\code{\link[=parse_number]{parse_number()}},
+\code{\link[=parse_vector]{parse_vector()}}
 }
 \concept{parsers}

--- a/man/parse_guess.Rd
+++ b/man/parse_guess.Rd
@@ -32,7 +32,7 @@ option to \code{character()} to indicate no missing values.}
 \item{locale}{The locale controls defaults that vary from place to place.
 The default locale is US-centric (like R), but you can use
 \code{\link[=locale]{locale()}} to create your own locale that controls things like
-the default time zone, encoding, decimal mark, big mark, and day/month
+the default time zone, encoding, decimal mark, grouping mark, and day/month
 names.}
 
 \item{trim_ws}{Should leading and trailing whitespace (ASCII spaces and tabs) be trimmed from
@@ -65,14 +65,14 @@ guess_parser(c("2010-10-10"))
 parse_guess(c("2010-10-10"))
 }
 \seealso{
-Other parsers: 
-\code{\link{col_skip}()},
-\code{\link{cols}()},
-\code{\link{cols_condense}()},
-\code{\link{parse_datetime}()},
-\code{\link{parse_factor}()},
-\code{\link{parse_logical}()},
-\code{\link{parse_number}()},
-\code{\link{parse_vector}()}
+Other parsers:
+\code{\link[=col_skip]{col_skip()}},
+\code{\link[=cols]{cols()}},
+\code{\link[=cols_condense]{cols_condense()}},
+\code{\link[=parse_datetime]{parse_datetime()}},
+\code{\link[=parse_factor]{parse_factor()}},
+\code{\link[=parse_logical]{parse_logical()}},
+\code{\link[=parse_number]{parse_number()}},
+\code{\link[=parse_vector]{parse_vector()}}
 }
 \concept{parsers}

--- a/man/parse_number.Rd
+++ b/man/parse_number.Rd
@@ -18,7 +18,7 @@ option to \code{character()} to indicate no missing values.}
 \item{locale}{The locale controls defaults that vary from place to place.
 The default locale is US-centric (like R), but you can use
 \code{\link[=locale]{locale()}} to create your own locale that controls things like
-the default time zone, encoding, decimal mark, big mark, and day/month
+the default time zone, encoding, decimal mark, grouping mark, and day/month
 names.}
 
 \item{trim_ws}{Should leading and trailing whitespace (ASCII spaces and tabs) be trimmed from
@@ -49,14 +49,14 @@ parse_number(c("1", "2", "3", "NA"))
 parse_number(c("1", "2", "3", "NA", "Nothing"), na = c("NA", "Nothing"))
 }
 \seealso{
-Other parsers: 
-\code{\link{col_skip}()},
-\code{\link{cols}()},
-\code{\link{cols_condense}()},
-\code{\link{parse_datetime}()},
-\code{\link{parse_factor}()},
-\code{\link{parse_guess}()},
-\code{\link{parse_logical}()},
-\code{\link{parse_vector}()}
+Other parsers:
+\code{\link[=col_skip]{col_skip()}},
+\code{\link[=cols]{cols()}},
+\code{\link[=cols_condense]{cols_condense()}},
+\code{\link[=parse_datetime]{parse_datetime()}},
+\code{\link[=parse_factor]{parse_factor()}},
+\code{\link[=parse_guess]{parse_guess()}},
+\code{\link[=parse_logical]{parse_logical()}},
+\code{\link[=parse_vector]{parse_vector()}}
 }
 \concept{parsers}

--- a/man/parse_vector.Rd
+++ b/man/parse_vector.Rd
@@ -23,7 +23,7 @@ option to \code{character()} to indicate no missing values.}
 \item{locale}{The locale controls defaults that vary from place to place.
 The default locale is US-centric (like R), but you can use
 \code{\link[=locale]{locale()}} to create your own locale that controls things like
-the default time zone, encoding, decimal mark, big mark, and day/month
+the default time zone, encoding, decimal mark, grouping mark, and day/month
 names.}
 
 \item{trim_ws}{Should leading and trailing whitespace (ASCII spaces and tabs) be trimmed from
@@ -38,15 +38,15 @@ parse_vector(x, col_integer())
 parse_vector(x, col_double())
 }
 \seealso{
-Other parsers: 
-\code{\link{col_skip}()},
-\code{\link{cols}()},
-\code{\link{cols_condense}()},
-\code{\link{parse_datetime}()},
-\code{\link{parse_factor}()},
-\code{\link{parse_guess}()},
-\code{\link{parse_logical}()},
-\code{\link{parse_number}()}
+Other parsers:
+\code{\link[=col_skip]{col_skip()}},
+\code{\link[=cols]{cols()}},
+\code{\link[=cols_condense]{cols_condense()}},
+\code{\link[=parse_datetime]{parse_datetime()}},
+\code{\link[=parse_factor]{parse_factor()}},
+\code{\link[=parse_guess]{parse_guess()}},
+\code{\link[=parse_logical]{parse_logical()}},
+\code{\link[=parse_number]{parse_number()}}
 }
 \concept{parsers}
 \keyword{internal}

--- a/man/read_delim.Rd
+++ b/man/read_delim.Rd
@@ -162,6 +162,7 @@ character represents one column:
 \itemize{
 \item c = character
 \item i = integer
+\item I = big integer (requires the \pkg{bit64} package)
 \item n = number
 \item d = double
 \item l = logical

--- a/man/read_delim.Rd
+++ b/man/read_delim.Rd
@@ -192,7 +192,7 @@ column is created.}
 \item{locale}{The locale controls defaults that vary from place to place.
 The default locale is US-centric (like R), but you can use
 \code{\link[=locale]{locale()}} to create your own locale that controls things like
-the default time zone, encoding, decimal mark, big mark, and day/month
+the default time zone, encoding, decimal mark, grouping mark, and day/month
 names.}
 
 \item{na}{Character vector of strings to interpret as missing values. Set this
@@ -268,7 +268,7 @@ Learn more in \code{\link[=should_read_lazy]{should_read_lazy()}} and in the doc
 \code{altrep} argument of \code{\link[vroom:vroom]{vroom::vroom()}}.}
 }
 \value{
-A \code{\link[tibble:tibble]{tibble::tibble()}}. If there are parsing problems, a warning will alert you.
+A \code{\link[tibble:tibble]{tibble()}}. If there are parsing problems, a warning will alert you.
 You can retrieve the full details by calling \code{\link[=problems]{problems()}} on your dataset.
 }
 \description{

--- a/man/read_delim_chunked.Rd
+++ b/man/read_delim_chunked.Rd
@@ -169,7 +169,7 @@ set \code{show_col_types = FALSE} or set \code{options(readr.show_col_types = FA
 \item{locale}{The locale controls defaults that vary from place to place.
 The default locale is US-centric (like R), but you can use
 \code{\link[=locale]{locale()}} to create your own locale that controls things like
-the default time zone, encoding, decimal mark, big mark, and day/month
+the default time zone, encoding, decimal mark, grouping mark, and day/month
 names.}
 
 \item{na}{Character vector of strings to interpret as missing values. Set this
@@ -216,9 +216,9 @@ f <- function(x, pos) subset(x, gear == 3)
 read_csv_chunked(readr_example("mtcars.csv"), DataFrameCallback$new(f), chunk_size = 5)
 }
 \seealso{
-Other chunked: 
+Other chunked:
 \code{\link{callback}},
-\code{\link{read_lines_chunked}()}
+\code{\link[=read_lines_chunked]{read_lines_chunked()}}
 }
 \concept{chunked}
 \keyword{internal}

--- a/man/read_file.Rd
+++ b/man/read_file.Rd
@@ -30,7 +30,7 @@ Using a value of \code{\link[=clipboard]{clipboard()}} will read from the system
 \item{locale}{The locale controls defaults that vary from place to place.
 The default locale is US-centric (like R), but you can use
 \code{\link[=locale]{locale()}} to create your own locale that controls things like
-the default time zone, encoding, decimal mark, big mark, and day/month
+the default time zone, encoding, decimal mark, grouping mark, and day/month
 names.}
 
 \item{x}{A single string, or a raw vector to write to disk.}

--- a/man/read_fwf.Rd
+++ b/man/read_fwf.Rd
@@ -111,7 +111,7 @@ column is created.}
 \item{locale}{The locale controls defaults that vary from place to place.
 The default locale is US-centric (like R), but you can use
 \code{\link[=locale]{locale()}} to create your own locale that controls things like
-the default time zone, encoding, decimal mark, big mark, and day/month
+the default time zone, encoding, decimal mark, grouping mark, and day/month
 names.}
 
 \item{na}{Character vector of strings to interpret as missing values. Set this

--- a/man/read_lines.Rd
+++ b/man/read_lines.Rd
@@ -62,7 +62,7 @@ file will be read.}
 \item{locale}{The locale controls defaults that vary from place to place.
 The default locale is US-centric (like R), but you can use
 \code{\link[=locale]{locale()}} to create your own locale that controls things like
-the default time zone, encoding, decimal mark, big mark, and day/month
+the default time zone, encoding, decimal mark, grouping mark, and day/month
 names.}
 
 \item{na}{Character vector of strings to interpret as missing values. Set this

--- a/man/read_lines_chunked.Rd
+++ b/man/read_lines_chunked.Rd
@@ -47,7 +47,7 @@ Using a value of \code{\link[=clipboard]{clipboard()}} will read from the system
 \item{locale}{The locale controls defaults that vary from place to place.
 The default locale is US-centric (like R), but you can use
 \code{\link[=locale]{locale()}} to create your own locale that controls things like
-the default time zone, encoding, decimal mark, big mark, and day/month
+the default time zone, encoding, decimal mark, grouping mark, and day/month
 names.}
 
 \item{na}{Character vector of strings to interpret as missing values. Set this
@@ -62,9 +62,9 @@ progress bar can be disabled by setting option \code{readr.show_progress} to
 Read lines from a file or string by chunk.
 }
 \seealso{
-Other chunked: 
+Other chunked:
 \code{\link{callback}},
-\code{\link{read_delim_chunked}()}
+\code{\link[=read_delim_chunked]{read_delim_chunked()}}
 }
 \concept{chunked}
 \keyword{internal}

--- a/man/read_rds.Rd
+++ b/man/read_rds.Rd
@@ -27,7 +27,7 @@ write_rds(
 \item{compress}{Compression method to use: "none", "gz" ,"bz", or "xz".}
 
 \item{version}{Serialization format version to be used. The default value is 2
-as it's compatible for R versions prior to 3.5.0. See \code{\link[base:readRDS]{base::saveRDS()}}
+as it's compatible for R versions prior to 3.5.0. See \code{\link[base:saveRDS]{base::saveRDS()}}
 for more details.}
 
 \item{text}{If \code{TRUE} a text representation is used, otherwise a binary representation is used.}

--- a/man/read_table.Rd
+++ b/man/read_table.Rd
@@ -85,7 +85,7 @@ set \code{show_col_types = FALSE} or set \code{options(readr.show_col_types = FA
 \item{locale}{The locale controls defaults that vary from place to place.
 The default locale is US-centric (like R), but you can use
 \code{\link[=locale]{locale()}} to create your own locale that controls things like
-the default time zone, encoding, decimal mark, big mark, and day/month
+the default time zone, encoding, decimal mark, grouping mark, and day/month
 names.}
 
 \item{na}{Character vector of strings to interpret as missing values. Set this

--- a/man/spec_delim.Rd
+++ b/man/spec_delim.Rd
@@ -208,7 +208,7 @@ column is created.}
 \item{locale}{The locale controls defaults that vary from place to place.
 The default locale is US-centric (like R), but you can use
 \code{\link[=locale]{locale()}} to create your own locale that controls things like
-the default time zone, encoding, decimal mark, big mark, and day/month
+the default time zone, encoding, decimal mark, grouping mark, and day/month
 names.}
 
 \item{na}{Character vector of strings to interpret as missing values. Set this

--- a/man/spec_delim.Rd
+++ b/man/spec_delim.Rd
@@ -178,6 +178,7 @@ character represents one column:
 \itemize{
 \item c = character
 \item i = integer
+\item I = big integer (requires the \pkg{bit64} package)
 \item n = number
 \item d = double
 \item l = logical

--- a/man/type_convert.Rd
+++ b/man/type_convert.Rd
@@ -30,7 +30,7 @@ each field before parsing it?}
 \item{locale}{The locale controls defaults that vary from place to place.
 The default locale is US-centric (like R), but you can use
 \code{\link[=locale]{locale()}} to create your own locale that controls things like
-the default time zone, encoding, decimal mark, big mark, and day/month
+the default time zone, encoding, decimal mark, grouping mark, and day/month
 names.}
 
 \item{guess_integer}{If \code{TRUE}, guess integer types for whole numbers, if


### PR DESCRIPTION
## What

Adds the missing `I = big integer` entry to the `col_types` compact string representation list in the `read_delim()` documentation (which is shared by `read_csv()`, `read_tsv()`, `read_csv2()`, and `spec_*()` functions).

vroom's `vroom()` documentation already lists `I = big integer`, but readr's `read_delim()` docs were missing it. This aligns the two.

## Changes

- `R/read_delim.R`: Add `I = big integer (requires the bit64 package)` to the compact string list in the `@param col_types` roxygen block.
- `man/read_delim.Rd`: Regenerated.
- `man/spec_delim.Rd`: Regenerated (inherits from read_delim).

## Validation

- `tools::checkRd("man/read_delim.Rd")` — clean
- `tools::checkRd("man/spec_delim.Rd")` — clean
- `R CMD build --no-build-vignettes .` — OK
- `R CMD check --no-manual --ignore-vignettes --no-build-vignettes --no-tests` — Status: OK

## Related

- Complements #1629 (documenting `col_big_integer()` [I] in `cols()` help)