### PR TITLE
docs: add @return, @details, and example to type_convert() documentation

### DIFF
--- a/R/type_convert.R
+++ b/R/type_convert.R
@@ -5,6 +5,14 @@
 #' then let readr take another stab at parsing it. The name is a homage to
 #' the base [utils::type.convert()].
 #'
+#' Column types are guessed from the data using [guess_parser()]. Values
+#' that cannot be converted to the guessed type are replaced with `NA`
+#' and a warning.
+#'
+#' Note that the numeric parser recognizes some alphanumeric strings as
+#' valid numbers (e.g., `"100e5"`, `"100L"`, `"100S"`). If this is
+#' undesirable, specify column types explicitly with [cols()].
+#'
 #' @param df A data frame.
 #' @param col_types One of `NULL`, a [cols()] specification, or
 #'   a string. See `vignette("readr")` for more details.
@@ -17,6 +25,9 @@
 #' because it likely modifies the column data types.
 #' (see [spec()] for more information about column specifications).
 #' @export
+#' @return A data frame with the character columns converted to their
+#'   guessed types. Values that cannot be converted to the guessed type
+#'   are replaced with `NA` and a warning.
 #' @examples
 #' df <- data.frame(
 #'   x = as.character(runif(10)),
@@ -38,6 +49,10 @@
 #' str(data)
 #' # Then convert it with type_convert
 #' type_convert(data)
+#'
+#' # Values that cannot be parsed as the guessed type become NA
+#' df <- data.frame(x = c("100", "200", "abc"), stringsAsFactors = FALSE)
+#' type_convert(df, col_types = cols(x = col_double()))
 type_convert <- function(
   df,
   col_types = NULL,

--- a/man/type_convert.Rd
+++ b/man/type_convert.Rd
@@ -36,11 +36,25 @@ names.}
 \item{guess_integer}{If \code{TRUE}, guess integer types for whole numbers, if
 \code{FALSE} guess numeric type for all numbers.}
 }
+\value{
+A data frame with the character columns converted to their
+guessed types. Values that cannot be converted to the guessed type
+are replaced with \code{NA} and a warning.
+}
 \description{
 This is useful if you need to do some manual munging - you can read the
 columns in as character, clean it up with (e.g.) regular expressions and
 then let readr take another stab at parsing it. The name is a homage to
 the base \code{\link[utils:type.convert]{utils::type.convert()}}.
+}
+\details{
+Column types are guessed from the data using \code{\link[=guess_parser]{guess_parser()}}. Values
+that cannot be converted to the guessed type are replaced with \code{NA}
+and a warning.
+
+Note that the numeric parser recognizes some alphanumeric strings as
+valid numbers (e.g., \code{"100e5"}, \code{"100L"}, \code{"100S"}). If this is
+undesirable, specify column types explicitly with \code{\link[=cols]{cols()}}.
 }
 \note{
 \code{type_convert()} removes a 'spec' attribute,
@@ -68,4 +82,8 @@ data <- read_csv(readr_example("mtcars.csv"),
 str(data)
 # Then convert it with type_convert
 type_convert(data)
+
+# Values that cannot be parsed as the guessed type become NA
+df <- data.frame(x = c("100", "200", "abc"), stringsAsFactors = FALSE)
+type_convert(df, col_types = cols(x = col_double()))
 }


### PR DESCRIPTION
## What

Adds missing documentation to `type_convert()`:

1. **@return tag**: Documents that the function returns a data frame with character columns converted to guessed types, and that unparsable values become `NA` with a warning.

2. **@details section**: Explains that column types are guessed using `guess_parser()`, and notes that the numeric parser recognizes some alphanumeric strings as valid numbers (e.g., `"100e5"`, `"100L"`, `"100S"`). Suggests using explicit `cols()` specifications to avoid unexpected parsing.

3. **Example**: Shows parsing failure with explicit `col_types = cols(x = col_double())`.

## Why

Partially addresses #1562. While the underlying Qi parser behavior (treating F/L/S as floating-point suffixes) requires a C++ code fix, this PR documents the current behavior so users can understand and work around it.

## Validation

- `tools::checkRd("man/type_convert.Rd")` — clean
- Example runs correctly:
  ```r
  df <- data.frame(x = c("100", "200", "abc"), stringsAsFactors = FALSE)
  type_convert(df, col_types = cols(x = col_double()))
  # Warning: [2, 1]: expected a double, but got 'abc'
  #     x
  # 1 100
  # 2 200
  # 3  NA
  ```

## Files changed

- `R/type_convert.R` (roxygen source)
- `man/type_convert.Rd` (generated)
