### PR TITLE
docs: fix tokenize() example param, add @return to tokenize() and count_fields()

### DIFF
--- a/R/count_fields.R
+++ b/R/count_fields.R
@@ -8,6 +8,8 @@
 #'   up into fields, e.g., [tokenizer_csv()],
 #'   [tokenizer_fwf()]
 #' @param n_max Optionally, maximum number of rows to count fields for.
+#' @return An integer vector with one element per line, giving the number of
+#'   fields in each line.
 #' @export
 #' @examples
 #' count_fields(readr_example("mtcars.csv"), tokenizer_csv())

--- a/R/tokenizer.R
+++ b/R/tokenizer.R
@@ -9,13 +9,14 @@
 #' @param tokenizer A tokenizer specification.
 #' @param skip Number of lines to skip before reading data.
 #' @param n_max Optionally, maximum number of rows to tokenize.
+#' @return A list of character vectors, one per line, containing the tokens.
 #' @keywords internal
 #' @export
 #' @examples
 #' tokenize("1,2\n3,4,5\n\n6")
 #'
 #' # Only tokenize first two lines
-#' tokenize("1,2\n3,4,5\n\n6", n = 2)
+#' tokenize("1,2\n3,4,5\n\n6", n_max = 2)
 tokenize <- function(file, tokenizer = tokenizer_csv(), skip = 0, n_max = -1L) {
   ds <- datasource(file, skip = skip, skip_empty_rows = FALSE)
   tokenize_(ds, tokenizer, n_max)

--- a/man/count_fields.Rd
+++ b/man/count_fields.Rd
@@ -29,6 +29,10 @@ up into fields, e.g., \code{\link[=tokenizer_csv]{tokenizer_csv()}},
 
 \item{n_max}{Optionally, maximum number of rows to count fields for.}
 }
+\value{
+An integer vector with one element per line, giving the number of
+fields in each line.
+}
 \description{
 This is useful for diagnosing problems with functions that fail
 to parse correctly.

--- a/man/tokenize.Rd
+++ b/man/tokenize.Rd
@@ -27,6 +27,9 @@ Using a value of \code{\link[=clipboard]{clipboard()}} will read from the system
 
 \item{n_max}{Optionally, maximum number of rows to tokenize.}
 }
+\value{
+A list of character vectors, one per line, containing the tokens.
+}
 \description{
 Turns input into a character vector. Usually the tokenization is done purely
 in C++, and never exposed to R (because that requires a copy). This function
@@ -37,6 +40,6 @@ to see the underlying tokens.
 tokenize("1,2\n3,4,5\n\n6")
 
 # Only tokenize first two lines
-tokenize("1,2\n3,4,5\n\n6", n = 2)
+tokenize("1,2\n3,4,5\n\n6", n_max = 2)
 }
 \keyword{internal}


### PR DESCRIPTION
## Changes

- **Fix `tokenize()` example**: Change `n = 2` to `n_max = 2` in the example. The old code worked via R's partial argument matching, but used the wrong parameter name in documentation.

- **Add `@return` to `tokenize()`**: Documents that it returns a list of character vectors, one per line.

- **Add `@return` to `count_fields()`**: Documents that it returns an integer vector with one element per line.

## Validation

- Tests pass: `devtools::test(filter = "parsing-character|tokenize|count-fields")` — 40 pass, 0 fail
- Full test suite: 615 pass, 30 pre-existing failures (related to vroom `problems` attribute propagation, unrelated to this change)