### PR TITLE
docs: fix @return typo in read_file() - read_lines_raw -> read_file_raw

### DIFF
--- a/R/count_fields.R
+++ b/R/count_fields.R
@@ -8,6 +8,8 @@
 #'   up into fields, e.g., [tokenizer_csv()],
 #'   [tokenizer_fwf()]
 #' @param n_max Optionally, maximum number of rows to count fields for.
+#' @return An integer vector with one element per line, giving the number of
+#'   fields in each line.
 #' @export
 #' @examples
 #' count_fields(readr_example("mtcars.csv"), tokenizer_csv())

--- a/R/file.R
+++ b/R/file.R
@@ -10,7 +10,7 @@
 #' @inheritParams read_delim
 #' @return
 #'   `read_file`: A length 1 character vector.
-#'   `read_lines_raw`: A raw vector.
+#'   `read_file_raw`: A raw vector.
 #' @param x A single string, or a raw vector to write to disk.
 #' @export
 #' @examples

--- a/R/tokenizer.R
+++ b/R/tokenizer.R
@@ -9,13 +9,14 @@
 #' @param tokenizer A tokenizer specification.
 #' @param skip Number of lines to skip before reading data.
 #' @param n_max Optionally, maximum number of rows to tokenize.
+#' @return A list of character vectors, one per line, containing the tokens.
 #' @keywords internal
 #' @export
 #' @examples
 #' tokenize("1,2\n3,4,5\n\n6")
 #'
 #' # Only tokenize first two lines
-#' tokenize("1,2\n3,4,5\n\n6", n = 2)
+#' tokenize("1,2\n3,4,5\n\n6", n_max = 2)
 tokenize <- function(file, tokenizer = tokenizer_csv(), skip = 0, n_max = -1L) {
   ds <- datasource(file, skip = skip, skip_empty_rows = FALSE)
   tokenize_(ds, tokenizer, n_max)

--- a/man/count_fields.Rd
+++ b/man/count_fields.Rd
@@ -29,6 +29,10 @@ up into fields, e.g., \code{\link[=tokenizer_csv]{tokenizer_csv()}},
 
 \item{n_max}{Optionally, maximum number of rows to count fields for.}
 }
+\value{
+An integer vector with one element per line, giving the number of
+fields in each line.
+}
 \description{
 This is useful for diagnosing problems with functions that fail
 to parse correctly.

--- a/man/read_file.Rd
+++ b/man/read_file.Rd
@@ -41,7 +41,7 @@ file is created.}
 }
 \value{
 \code{read_file}: A length 1 character vector.
-\code{read_lines_raw}: A raw vector.
+\code{read_file_raw}: A raw vector.
 }
 \description{
 \code{read_file()} reads a complete file into a single object: either a

--- a/man/tokenize.Rd
+++ b/man/tokenize.Rd
@@ -27,6 +27,9 @@ Using a value of \code{\link[=clipboard]{clipboard()}} will read from the system
 
 \item{n_max}{Optionally, maximum number of rows to tokenize.}
 }
+\value{
+A list of character vectors, one per line, containing the tokens.
+}
 \description{
 Turns input into a character vector. Usually the tokenization is done purely
 in C++, and never exposed to R (because that requires a copy). This function
@@ -37,6 +40,6 @@ to see the underlying tokens.
 tokenize("1,2\n3,4,5\n\n6")
 
 # Only tokenize first two lines
-tokenize("1,2\n3,4,5\n\n6", n = 2)
+tokenize("1,2\n3,4,5\n\n6", n_max = 2)
 }
 \keyword{internal}


### PR DESCRIPTION
## What

The `@return` tag for `read_file()` referenced `read_lines_raw` instead of `read_file_raw`. This was a copy-paste error from the `read_lines()` documentation.

## Changes

- `R/file.R`: Fix `@return` tag: `read_lines_raw` → `read_file_raw`
- `man/read_file.Rd`: Regenerated

## Validation

- `tools::checkRd("man/read_file.Rd")` — clean
- `devtools::test(filter = "read-file")` — 18 pass, 0 fail
- `R CMD check --no-manual --ignore-vignettes --no-build-vignettes --no-tests` — Status: OK