### PR TITLE
docs: add col_big_integer() [I] to vignette column spec list

### DIFF
--- a/vignettes/readr.Rmd
+++ b/vignettes/readr.Rmd
@@ -222,6 +222,7 @@ The available specifications are: (with string abbreviations in brackets)
 
 * `col_logical()` [l], containing only `T`, `F`, `TRUE` or `FALSE`.
 * `col_integer()` [i], integers.
+* `col_big_integer()` [I], 64-bit integers (requires the bit64 package).
 * `col_double()` [d], doubles.
 * `col_character()` [c], everything else.
 * `col_factor(levels, ordered)` [f], a fixed set of values.


### PR DESCRIPTION
## Summary

The "Available column specifications" section in `vignette("readr")` lists all `col_*()` types but omits `col_big_integer()` [I]. This PR adds it in the correct position (after `col_integer()`).

This complements:
- PR #1629 (document `col_big_integer()` [I] in `cols()` help)
- PR #1634 (add 'I = big integer' to `col_types` compact string list in `read_delim()`)

## Changes

- `vignettes/readr.Rmd`: Add `col_big_integer()` [I] entry to the Available column specifications list

## Validation

- Verified `col_big_integer()` works: `read_csv(I("x\n1\n2\n3"), col_types = "I")` produces `integer64` class (requires bit64)
- Vignette renders correctly

## Related issues

- #1564: Support for 64 Bit Integers Should be Added to Documentation for read_csv